### PR TITLE
Define unicode in Python 3

### DIFF
--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -16,10 +16,7 @@ def test_notebook_contents_is_unicode(nb_file):
     nb = jupytext.readf(nb_file)
 
     for cell in nb.cells:
-        if sys.version_info < (3, 0):
-            assert cell.source == '' or isinstance(cell.source, unicode)
-        else:
-            assert isinstance(cell.source, str)
+        assert cell.source == '' or isinstance(cell.source, unicode)
 
 
 def test_write_non_ascii(tmpdir):

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -4,6 +4,11 @@ import pytest
 import jupytext
 from .utils import list_all_notebooks
 
+try:
+  unicode        # Python 2
+except NameError:
+  unicode = str  # Python 3
+
 
 @pytest.mark.parametrize('nb_file', list_all_notebooks('.ipynb') +
                          list_all_notebooks('.Rmd'))


### PR DESCRIPTION
Follows Python porting best practice, [use feature detection instead of version detection](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection).

__unicode__ was removed in Python 3 because all __str__ are Unicode.

[flake8](http://flake8.pycqa.org) testing of https://github.com/mwouts/jupytext on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./.jupyter/jupyter_notebook_config.py:1:1: F821 undefined name 'c'
c.NotebookApp.contents_manager_class = 'jupytext.TextFileContentsManager'
^
./tests/test_unicode.py:15:65: F821 undefined name 'unicode'
            assert cell.source == '' or isinstance(cell.source, unicode)
                                                                ^
./tests/mirror/jupyter_again.py:32:1: E999 SyntaxError: invalid syntax
?next
^
1     E999 SyntaxError: invalid syntax
2     F821 undefined name 'c'
3
```