### PR TITLE
Travis CI: Add Python 3.7 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ python:
   # PyPy versions
   - "pypy3.5"
 # command to install dependencies
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+      sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
+
 install:
   - pip install codecov
   - pip install pytest pytest-cov


### PR DESCRIPTION
Python 3.7 added in alignment with travis-ci/travis-ci#9069