### PR TITLE
Travis CI: Update pypy, Add flake8 tests

### DIFF
--- a/.jupyter/jupyter_notebook_config.py
+++ b/.jupyter/jupyter_notebook_config.py
@@ -1,1 +1,1 @@
-c.NotebookApp.contents_manager_class = 'jupytext.TextFileContentsManager'
+c.NotebookApp.contents_manager_class = 'jupytext.TextFileContentsManager'  # noqa

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.5"
   - "3.6"
   # PyPy versions
-  - "pypy3.5"
+  - "pypy"
 # command to install dependencies
 matrix:
   include:
@@ -14,12 +14,13 @@ matrix:
       sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
 
 install:
-  - pip install codecov
-  - pip install pytest pytest-cov
-  - pip install notebook
+  - pip install codecov flake8 notebook pytest pytest-cov
   - pip install -r requirements.txt
-  - pip install .
-# command to run tests
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
   - coverage run --source=. -m py.test -s tests/
 after_success:

--- a/tests/mirror/jupyter_again.py
+++ b/tests/mirror/jupyter_again.py
@@ -29,4 +29,4 @@ editor_options:
 import yaml
 print(yaml.dump(yaml.load(c)))
 
-?next
+# ?next


### PR DESCRIPTION
Add [flake8](http://flake8.pycqa.org) tests to find Python syntax errors and undefined names.

__E901,E999,F821,F822,F823__ are the "_showstopper_" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree