### PR TITLE
Allow more flexible code identification

### DIFF
--- a/jupytext/cell_metadata.py
+++ b/jupytext/cell_metadata.py
@@ -325,7 +325,18 @@ def is_active(ext, metadata):
 
 def double_percent_options_to_metadata(options):
     """Parse double percent options"""
-    matches = _PERCENT_CELL.findall('# %%' + options)[0]
+    matches = _PERCENT_CELL.findall('# %%' + options)
+    if matches == []: ## didn't match with options
+        matches = _PERCENT_CELL.findall('# %%')
+        ## assume a code cell, with extra stuff
+        if matches == []: ## didn't match at all
+            return {}
+        else:
+            ## Put rest of line in title metadata:
+            matches = list(matches[0])
+            matches[1] = options
+    else:
+        matches = matches[0]
     # Fifth match are JSON metadata
     if matches[4]:
         metadata = json_options_to_metadata(matches[4], add_brackets=False)

--- a/jupytext/cell_metadata.py
+++ b/jupytext/cell_metadata.py
@@ -326,17 +326,14 @@ def is_active(ext, metadata):
 def double_percent_options_to_metadata(options):
     """Parse double percent options"""
     matches = _PERCENT_CELL.findall('# %%' + options)
-    if matches == []: ## didn't match with options
-        matches = _PERCENT_CELL.findall('# %%')
-        ## assume a code cell, with extra stuff
-        if matches == []: ## didn't match at all
-            return {}
-        else:
-            ## Put rest of line in title metadata:
-            matches = list(matches[0])
-            matches[1] = options
-    else:
-        matches = matches[0]
+
+    # Fail safe when regexp matching fails #116
+    # (occurs e.g. if square brackets are found in the title)
+    if not matches:
+        return {'title': options.strip()}
+
+    matches = matches[0]
+
     # Fifth match are JSON metadata
     if matches[4]:
         metadata = json_options_to_metadata(matches[4], add_brackets=False)

--- a/tests/test_read_simple_percent.py
+++ b/tests/test_read_simple_percent.py
@@ -144,3 +144,11 @@ def f(x):
 
     script2 = jupytext.writes(nb, ext='.py', format_name='percent')
     compare(script, script2)
+
+
+def test_no_crash_on_square_bracket(script="""# %% In [2]
+print('Hello')
+"""):
+    nb = jupytext.reads(script, ext='.py')
+    script2 = jupytext.writes(nb, ext='.py', format_name='percent')
+    compare(script, script2)


### PR DESCRIPTION
Currently, if you have a comment like this in a program when converting from "py:percent":

```python
# %% In [2]:
path = fastai.untar_data(fastai.URLs.MNIST_TINY)
print("data path:", path)
```
jupytext will crash. This fix keeps it from crashing, and also identifies the cell as code.