### PR TITLE
Version 0.8.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
   - pip install .
 before_script:
   # stop the build if there are Python syntax errors or undefined names
-  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics --exclude=ipynb_to_percent
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@
 Release History
 ---------------
 
+0.8.6 (2018-11-??)
+++++++++++++++++++++++
+
+**Improvements**
+
+- The ``language_info`` section is not part of the default header any more. Language information is now taken from metadata ``kernelspec.language``. (#105).
+
 0.8.5 (2018-11-13)
 ++++++++++++++++++++++
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,8 @@ Release History
 
 - The ``language_info`` section is not part of the default header any more. Language information is now taken from metadata ``kernelspec.language``. (#105).
 - When opening a paired notebook, the active file is now the file that was originally opened (#118). When saving a notebook, timestamps of all the alternative representations are tested to ensure that Jupyter's autosave does not override manual modifications.
+- Jupyter magic commands are now commented per default in the ``percent`` format (#126, #132). Version for the ``percent`` format increases from '1.1' to '1.2'. Set an option ``comment_magics`` to ``false`` either per notebook, or globally on Jupytext's contents manager, or on `jupytext`'s command line, if you prefer not to comment Jupyter magics.
+
 
 0.8.5 (2018-11-13)
 ++++++++++++++++++++++

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,7 @@ Release History
 **Improvements**
 
 - The ``language_info`` section is not part of the default header any more. Language information is now taken from metadata ``kernelspec.language``. (#105).
+- When opening a paired notebook, the active file is now the file that was originally opened (#118). When saving a notebook, timestamps of all the alternative representations are tested to ensure that Jupyter's autosave does not override manual modifications.
 
 0.8.5 (2018-11-13)
 ++++++++++++++++++++++

--- a/README.md
+++ b/README.md
@@ -122,18 +122,19 @@ c.ContentsManager.preferred_jupytext_formats_save = "py:percent"
 ```
 and then, Jupytext will understand `"jupytext": {"formats": "ipynb,py"},` as an instruction to create the paired Python script in the `percent` format.
 
-If you use Jupytext to edit and run scripts and markdown files as Jupyter notebooks, but you don't want Jupyter to add a YAML header to those, use:
-```python
-# Do not add metadata to existing scripts
-c.ContentsManager.freeze_metadata = True
-```
-
-If you want to control the default metadata filter, use for instance:
+If you want that the generated text files have no metadata, you may use the global metadata filters below. Please note that with this setting, the metadata is only preserved in the `.ipynb` file &mdash; be sure to open that file in Jupyter, and not the text file which will miss the pairing information.
 ```python
 # Filter out all metadata in text representations
 c.ContentsManager.default_notebook_metadata_filter = "-all"
 c.ContentsManager.default_cell_metadata_filter = "-all"
 ```
+
+Finally, if you use Jupytext as an interactive editor for scripts and markdown files, but you don't want Jupyter to add a YAML header to those, use:
+```python
+# Do not add metadata to existing scripts
+c.ContentsManager.freeze_metadata = True
+```
+
 
 NB: All these global options (and more) are documented [here](https://github.com/mwouts/jupytext/blob/master/jupytext/contentsmanager.py).
 

--- a/README.md
+++ b/README.md
@@ -78,10 +78,9 @@ Then, configure Jupyter to use Jupytext:
 - generate a Jupyter config, if you don't have one yet, with `jupyter notebook --generate-config`
 - edit `.jupyter/jupyter_notebook_config.py` and append the following:
 ```python
-c.NotebookApp.contents_manager_class = "jupytext.TextFileContentsManager"  # necessary
-# optional but recommended default - always pairs notebooks for example to .py files:
-c.ContentsManager.default_jupytext_formats = "ipynb,py"  # add your favorite formats
+c.NotebookApp.contents_manager_class = "jupytext.TextFileContentsManager"
 ```
+(note that our contents manager accepts a few options: default formats, default metadata filter, etc &mdash; read more on this [below](#global-configuration)).
 - and restart Jupyter, i.e. run
 ```bash
 jupyter notebook

--- a/README.md
+++ b/README.md
@@ -123,19 +123,19 @@ c.ContentsManager.preferred_jupytext_formats_save = "py:percent"
 ```
 and then, Jupytext will understand `"jupytext": {"formats": "ipynb,py"},` as an instruction to create the paired Python script in the `percent` format.
 
-If you want that the generated text files have no metadata, you may use the global metadata filters below. Please note that with this setting, the metadata is only preserved in the `.ipynb` file &mdash; be sure to open that file in Jupyter, and not the text file which will miss the pairing information.
+If you want that the text files created by Jupytext have no metadata, you may use the global metadata filters below. Please note that with this setting, the metadata is only preserved in the `.ipynb` file &mdash; be sure to open that file in Jupyter, and not the text file which will miss the pairing information.
 ```python
 # Filter out all metadata in text representations
+# Alternatively, build your own filter: comma separated values, minus for exclusion
 c.ContentsManager.default_notebook_metadata_filter = "-all"
 c.ContentsManager.default_cell_metadata_filter = "-all"
 ```
 
-Finally, if you use Jupytext as an interactive editor for scripts and markdown files, but you don't want Jupyter to add a YAML header to those, use:
+Finally, if you want metadata in the text representation of your notebooks, but not in the pre-existing scripts or markdown files that you may edit in Jupyter, use:
 ```python
-# Do not add metadata to existing scripts
+# Do not add metadata when editing a markdown document or a script
 c.ContentsManager.freeze_metadata = True
 ```
-
 
 NB: All these global options (and more) are documented [here](https://github.com/mwouts/jupytext/blob/master/jupytext/contentsmanager.py).
 

--- a/README.md
+++ b/README.md
@@ -239,9 +239,9 @@ c.ContentsManager.preferred_jupytext_formats_save = "py:percent" # or "auto:perc
 ```
 Then, Jupytext's content manager will understand `"jupytext": {"formats": "ipynb,py"},` as an instruction to create the paired Python script in the `percent` format.
 
-By default, Jupyter magics are not commented in the `percent` representation. If you are using percent scripts in another editor that Hydrogen, add a metadata `"jupytext": {"comment_magics": true},"` to your notebook, or add 
+By default, Jupyter magics are commented in the `percent` representation. If you are using percent scripts in Hydrogen and you want to preserve Jupyter magics, then add a metadata `"jupytext": {"comment_magics": false},"` to your notebook, or add 
 ```python
-c.ContentsManager.comment_magics = True
+c.ContentsManager.comment_magics = False
 ```
 to Jupyter's configuration file.
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 [![codecov.io](https://codecov.io/github/mwouts/jupytext/coverage.svg?branch=master)](https://codecov.io/github/mwouts/jupytext?branch=master)
 [![Language grade: Python](https://img.shields.io/badge/lgtm-A+-brightgreen.svg)](https://lgtm.com/projects/g/mwouts/jupytext/context:python)
 
-You've always wished Jupyter notebooks were plain text documents? Wished you could edit them in your favorite IDE? And get clear and meaningfull diffs when doing version control? Then... Jupytext may well be the tool you were looking for!
+Have you always wished Jupyter notebooks were plain text documents? Wished you could edit them in your favorite IDE? And get clear and meaningfull diffs when doing version control? Then... Jupytext may well be the tool you're looking for!
 
 Jupytext can save Jupyter notebooks as
 - Markdown and R Markdown documents,
 - Julia, Python, R, Bash, Scheme and C++ scripts.
 
-Jupytext is available as a command line tool and as _contents manager_ for Jupyter. With the later, Jupyter will save your notebook to your favorite format(s), from `.ipynb` to `.py`, `.R`, `.jl`, `.md`, `.Rmd`... The text representation can be edited outside of Jupyter. Simply refresh the notebook in Jupyter to get the latest input cells from the script or Markdown document. When refreshing, kernel variables are unaffected, and output cells are reloaded from the traditionnal `.ipynb` if present.
+Jupytext is available as a command line tool and as a _contents manager_ for Jupyter. With the latter, Jupyter will save your notebook to your favorite format(s), from `.ipynb` to `.py`, `.R`, `.jl`, `.md`, `.Rmd`... The text representation can be edited outside of Jupyter. Simply refresh the notebook in Jupyter to get the latest input cells from the script or Markdown document. When refreshing, kernel variables are unaffected, and output cells are reloaded from the traditionnal `.ipynb` if present. You can also delete your `.ipynb` notebook entirely if you don't need to save output cells.
 
 ## Demo time
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,13 @@ jupytext --to md --output - notebook.ipynb      # display the markdown version o
 jupytext --from ipynb --to py:percent           # read ipynb from stdin and write double percent script on stdout
 ```
 
+Jupytext is also available as a pre-commit hook. Use this if you want Jupytext to create and update the `.py` representation of your `.ipynb` notebooks on every commit. All you need is to create a `.git/hooks/pre-commit` file with the following content:
+```bash
+#!/bin/sh
+jupytext --to py:light --pre-commit
+```
+Jupytext does not offer a merge driver. If a conflict occurs, solve it on the text representation and then update or recreate the `.ipynb` notebook. Or give a try to nbdime and its [merge driver](https://nbdime.readthedocs.io/en/stable/vcs.html#merge-driver).
+
 ## Reading notebooks in Python
 
 Manipulate notebooks in a Python shell or script using `jupytext`'s main functions:

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ The package provides a `jupytext` script for command line conversion between the
 ```bash
 jupytext --to python notebook.ipynb             # create a notebook.py file
 jupytext --to py:percent notebook.ipynb         # create a notebook.py file in the double percent format
+jupytext --to py:percent --comment-magics false notebook.ipynb   # create a notebook.py file in the double percent format, and do not comment magic commands
 jupytext --to markdown notebook.ipynb           # create a notebook.md file
 jupytext --output script.py notebook.ipynb      # create a script.py file
 
@@ -282,7 +283,7 @@ That being said, Jupytext also works well from Jupyter Lab. Please note that:
 
 ## Will my notebook really run in an IDE?
 
-Well, that's what we expect. There's however a big difference in the python environments between Python IDEs and Jupyter: in most IDEs the code is executed with  `python` and not in a Jupyter kernel. For this reason, `jupytext` comments Jupyter magics found in your notebook when exporting to R Markdown, and to scripts in all format but the `percent` one. Magics are not commented in the plain Markdown representation, nor in the `percent` format, as some editors use that format in combination with Jupyter kernels. Change this by adding a `#escape` or `#noescape` flag on the same line as the magic, or a `"comment_magics": true` or `false` entry in the notebook metadata, in the `"jupytext"` section. Or set your preference globally on the contents manager by adding this line to `.jupyter/jupyter_notebook_config.py`:
+Well, that's what we expect. There's however a big difference in the python environments between Python IDEs and Jupyter: in most IDEs the code is executed with  `python` and not in a Jupyter kernel. For this reason, `jupytext` comments Jupyter magics found in your notebook when exporting to all format but the plain Markdown one. Change this by adding a `#escape` or `#noescape` flag on the same line as the magic, or a `"comment_magics": true` or `false` entry in the notebook metadata, in the `"jupytext"` section. Or set your preference globally on the contents manager by adding this line to `.jupyter/jupyter_notebook_config.py`:
 ```python
 c.ContentsManager.comment_magics = True # or False
 ```

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Also, you may want some cells to be active only in the Python, or R Markdown rep
 
 The text representation of the notebook focuses on the part of the notebook that you have written. That is also the part of the notebook that should go under version control. Outputs and metadata that are (re)-constructed automatically when the notebook is executed do not need to enter the text representation.
 
-To that aim, cell metadata `autoscroll`, `collapsed`, `scrolled`, `trusted` and `ExecuteTime` are not included in the text representation. And only the required notebook metadata: `kernelspec`, `language_info` and `jupytext` are saved when a notebook is exported as text.
+To that aim, cell metadata `autoscroll`, `collapsed`, `scrolled`, `trusted` and `ExecuteTime` are not included in the text representation. And only the required notebook metadata: `kernelspec` and `jupytext` are saved when a notebook is exported as text.
 
 When a paired notebook is loaded, Jupytext reconstructs the filtered metadata using the `.ipynb` file. Please keep in mind that the `.ipynb` file is typically not distributed accross contributors, and that the cell metadata may be lost when an input cell changes (cells are matched according to their contents). Thus, if some cell or notebook metadata are important to your notebook, you should preserve it in the text version. Change the default metadata filtering as follows:
 - If you want no YAML header in your script, then set a notebook metadata

--- a/README.md
+++ b/README.md
@@ -1,40 +1,27 @@
 # Jupyter notebooks as Markdown documents, Julia, Python or R scripts
 
-[![Conda Version](https://img.shields.io/conda/vn/conda-forge/jupytext.svg)](https://anaconda.org/conda-forge/jupytext)
-[![Pypi](https://img.shields.io/pypi/v/jupytext.svg)](https://pypi.python.org/pypi/jupytext)
-[![Pypi](https://img.shields.io/pypi/l/jupytext.svg)](https://pypi.python.org/pypi/jupytext)
 [![Build Status](https://travis-ci.com/mwouts/jupytext.svg?branch=master)](https://travis-ci.com/mwouts/jupytext)
 [![codecov.io](https://codecov.io/github/mwouts/jupytext/coverage.svg?branch=master)](https://codecov.io/github/mwouts/jupytext?branch=master)
-[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/mwouts/jupytext.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/mwouts/jupytext/context:python)
-[![pyversions](https://img.shields.io/pypi/pyversions/jupytext.svg)](https://pypi.python.org/pypi/jupytext)
-[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/mwouts/jupytext/master?filepath=demo)
-[![PyParis](https://img.shields.io/badge/PyParis-YouTube-red.svg)](https://www.youtube.com/watch?v=y-VEZenk824)
+[![Language grade: Python](https://img.shields.io/badge/lgtm-A+-brightgreen.svg)](https://lgtm.com/projects/g/mwouts/jupytext/context:python)
 
-You've always wanted to
-* edit Jupyter notebooks as e.g. plain Python scripts in your favorite editor?
-* do version control of Jupyter notebooks with clear and meaningful diffs?
-* *collaborate* on Jupyter notebooks using standard (text oriented) merge tools?
+You've always wished Jupyter notebooks were plain text documents? Wished you could edit them in your favorite IDE? And get clear and meaningfull diffs when doing version control? Then... Jupytext may well be the tool you were looking for!
 
-Jupytext can convert notebooks to and from
-- Markdown and R Markdown documents (extensions `.md` and `.Rmd`)
-- Julia, Python, R, Bash, Scheme and C++ scripts (extensions `.jl`, `.py`, `.R`, etc).
+Jupytext can save Jupyter notebooks as
+- Markdown and R Markdown documents,
+- Julia, Python, R, Bash, Scheme and C++ scripts.
 
-Jupytext is available from within Jupyter. You can work as usual on your notebook in Jupyter, and save and read it in the formats you choose. The text representations can be edited outside of Jupyter (see our [demo](#code-refactoring) below). When the notebook is refreshed in Jupyter, input cells are loaded from the script or Markdown document. Kernel variables are preserved. Outputs are not stored in such text documents, and are therefore lost when the notebook is refreshed. To avoid this, we recommend to [pair](#paired-notebooks) the text notebook with a traditional `.ipynb` notebook (both files are saved and loaded together).
+Jupytext is available as a command line tool and as _contents manager_ for Jupyter. With the later, Jupyter will save your notebook to your favorite format(s), from `.ipynb` to `.py`, `.R`, `.jl`, `.md`, `.Rmd`... The text representation can be edited outside of Jupyter. Simply refresh the notebook in Jupyter to get the latest input cells from the script or Markdown document. When refreshing, kernel variables are unaffected, and output cells are reloaded from the traditionnal `.ipynb` if present.
 
-| Format       | Extension          | Text editor friendly | IDE friendly | Git friendly | Preserve outputs |
-| ------------ | ------------------ | -------------------- | ------------ | ------------ | ---------------- |
-| Jupyter notebook | `.ipynb`       |                      |              |              | ✔                |
-| Markdown or R Markdown | `.md`/`.Rmd` | ✔                |              | ✔            |                  |
-| Julia, Python or R script | `.jl`/`.py`/`.R`/... | ✔         | ✔            | ✔            |                  |
-| [Paired notebook](#paired-notebooks)  | (`.jl`/`.py`/`.R`/.../`.md`/`.Rmd`) + `.ipynb` | ✔ | (✔) | ✔ | ✔      |
+## Demo time
 
-Note that Jupytext implements a few different [formats](#format-specifications) for notebooks as scripts:
-- the [`light`](#the-light-format-for-notebooks-as-scripts) format allows to open arbitrary scripts as notebooks. Reversely, use it to save notebooks as scripts with very few cell markers.
-- the [`percent`](#the-percent-format) format with explicit `# %%` cells is compatible with various Python editors.
-- the [`sphinx`](#sphinx-gallery-scripts) format produces Sphinx gallery scripts (Python only).
-- and the [`spin`](#r-knitrspin-scripts) format is compatible with Knitr's spin function (R only).
+[![Introducing Jupytext](https://img.shields.io/badge/TDS-Introducing%20Jupytext-blue.svg)](https://towardsdatascience.com/introducing-jupytext-9234fdff6c57)
+[![PyParis](https://img.shields.io/badge/YouTube-PyParis-red.svg)](https://www.youtube.com/watch?v=y-VEZenk824)
+[![Binder](https://img.shields.io/badge/Binder-Try%20it!-blue.svg)](https://mybinder.org/v2/gh/mwouts/jupytext_pyparis_2018/master?filepath=demo)
 
-If you want to have a demo of Jupytext, have a look at the original [announcement](https://towardsdatascience.com/introducing-jupytext-9234fdff6c57), or watch the [PyParis presentation](https://github.com/mwouts/jupytext_pyparis_2018/blob/master/README.md).
+Looking for a demo?
+- Read the original [announcement](https://towardsdatascience.com/introducing-jupytext-9234fdff6c57) in Towards Data Science,
+- Watch the [PyParis talk](https://github.com/mwouts/jupytext_pyparis_2018/blob/master/README.md),
+- or, try Jupytext online with [binder](https://mybinder.org/v2/gh/mwouts/jupytext_pyparis_2018/master?filepath=demo)!
 
 ## Example usage
 
@@ -74,7 +61,11 @@ In the animation below we propose a quick demo of Jupytext. While the example re
 
 ## Installation
 
-Install or update Jupytext with either
+[![Conda Version](https://img.shields.io/conda/vn/conda-forge/jupytext.svg)](https://anaconda.org/conda-forge/jupytext)
+[![Pypi](https://img.shields.io/pypi/v/jupytext.svg)](https://pypi.python.org/pypi/jupytext)
+[![pyversions](https://img.shields.io/pypi/pyversions/jupytext.svg)](https://pypi.python.org/pypi/jupytext)
+
+Jupytext is available on pypi and on conda-forge. Run either of
 ```bash
 pip install jupytext --upgrade
 ```
@@ -94,17 +85,9 @@ c.NotebookApp.contents_manager_class = "jupytext.TextFileContentsManager"
 jupyter notebook
 ```
 
-## Paired notebooks
+### <a name="paired-notebooks"></a> Per-notebook configuration
 
-The idea of paired notebooks is to store an `.ipynb` file alongside other formats. This lets us get the best of both worlds: an easily sharable notebook that stores the outputs, and one or more text-only files that can for instance be put under version control.
-
-You can edit text-only files outside of Jupyter (first deactivate Jupyter's autosave by running `%autosave 0` in a cell), and then get the updated version in Jupyter by refreshing your browser.
-
-When loading or refreshing an `.ipynb` file, the input cells of the notebook are read from the first non-`.ipynb` file among the associated formats.
-
-When loading or refreshing a non-`.ipynb` file, the outputs are read from the `.ipynb` file (if `ipynb` is listed in the formats).
-
-To enable paired notebooks, one option is to set the output formats by adding a `"jupytext": {"formats": "ipynb,py"},` entry to the notebook metadata with *Edit/Edit Notebook Metadata* in Jupyter's menu:
+Configure the multiple export formats for your notebook by adding a `"jupytext": {"formats": "ipynb,py"},` entry to the notebook metadata with *Edit/Edit Notebook Metadata* in Jupyter's menu:
 ```
 {
   "jupytext": {"formats": "ipynb,py"},
@@ -116,20 +99,43 @@ To enable paired notebooks, one option is to set the output formats by adding a 
   }
 }
 ```
-Accepted formats are composed of an extension, like `ipynb`, `md`, `Rmd`, `jl`, `py`, `R`, and an optional format name among `light` (default for Julia, Python), `percent`, `sphinx`, `spin` (default for R). Use `ipynb,py:percent` if you want to pair the `.ipynb` notebook with a `.py` script in the `percent` format. To have the script extension chosen according to the Jupyter kernel, use the `auto` extension.
+Accepted formats are composed of an extension, like `ipynb`, `md`, `Rmd`, `jl`, `py`, `R`, `sh`, `cpp`... and an optional format name among `light` (default for Julia, Python), `percent`, `sphinx`, `spin` (default for R) &mdash; see below for the [format specifications](#Format-specifications). Use `ipynb,py:percent` if you want to pair the `.ipynb` notebook with a `.py` script in the `percent` format. To have the script extension chosen according to the Jupyter kernel, use the `auto` extension.
 
-Alternatively, it is also possible to set a default format pairing. Say you want to always associate `.ipynb` notebooks with an `.md` file  (and reciprocally). This is simply done by adding the following to your Jupyter configuration file:
+Jupytext accepts a few additional options:
+- `comment_magics`: By default, Jupyter magics are commented when notebooks are exported to any other format than markdown. If you prefer otherwise, use this boolean option, or is global counterpart (see below).
+- `metadata_filter.notebook`: By default, Jupytext only exports the `kernelspec` and `jupytext` metadata to the text files. Set `"jupytext": {"metadata_filter": {"notebook": "-all"}}` if you want that the script has no notebook metadata at all. The value for `metadata_filter.notebook` is a comma separated list of additional/excluded (negated) entries, with `all` a keyword that allows to exclude all entries.
+- `metadata_filter.cells`: By default, cell metadata `autoscroll`, `collapsed`, `scrolled`, `trusted` and `ExecuteTime` are not included in the text representation. Add or exclude more cell metadata with this option.
+
+### Global configuration
+
+Jupytext's contents manager also accepts global options. We start with the default format pairing. Say you want to always associate every `.ipynb` notebook with a `.md` file  (and reciprocally). This is simply done by adding the following to your Jupyter configuration file:
 ```python
-c.NotebookApp.contents_manager_class = "jupytext.TextFileContentsManager"
+# Always pair ipynb notebooks to md files
 c.ContentsManager.default_jupytext_formats = "ipynb,md"
 ```
 (and similarly for the other formats).
 
 In case the [`percent`](#the-percent-format) format is your favorite, add the following to your `.jupyter/jupyter_notebook_config.py` file:
 ```python
+# Use the percent format when saving as py
 c.ContentsManager.preferred_jupytext_formats_save = "py:percent"
 ```
 and then, Jupytext will understand `"jupytext": {"formats": "ipynb,py"},` as an instruction to create the paired Python script in the `percent` format.
+
+If you use Jupytext to edit and run scripts and markdown files as Jupyter notebooks, but you don't want Jupyter to add a YAML header to those, use:
+```python
+# Do not add metadata to existing scripts
+c.ContentsManager.freeze_metadata = True
+```
+
+If you want to control the default metadata filter, use for instance:
+```python
+# Filter out all metadata in text representations
+c.ContentsManager.default_notebook_metadata_filter = "-all"
+c.ContentsManager.default_cell_metadata_filter = "-all"
+```
+
+NB: All these global options (and more) are documented [here](https://github.com/mwouts/jupytext/blob/master/jupytext/contentsmanager.py).
 
 ## Command line conversion
 
@@ -239,7 +245,7 @@ c.ContentsManager.preferred_jupytext_formats_save = "py:percent" # or "auto:perc
 ```
 Then, Jupytext's content manager will understand `"jupytext": {"formats": "ipynb,py"},` as an instruction to create the paired Python script in the `percent` format.
 
-By default, Jupyter magics are commented in the `percent` representation. If you are using percent scripts in Hydrogen and you want to preserve Jupyter magics, then add a metadata `"jupytext": {"comment_magics": false},"` to your notebook, or add 
+By default, Jupyter magics are commented in the `percent` representation. If you are using percent scripts in Hydrogen and you want to preserve Jupyter magics, then add a metadata `"jupytext": {"comment_magics": false},"` to your notebook, or add
 ```python
 c.ContentsManager.comment_magics = False
 ```
@@ -289,35 +295,6 @@ c.ContentsManager.comment_magics = True # or False
 ```
 
 Also, you may want some cells to be active only in the Python, or R Markdown representation. For this, use the `active` cell metadata. Set `"active": "ipynb"` if you want that cell to be active only in the Jupyter notebook. And `"active": "py"` if you want it to be active only in the Python script. And `"active": "ipynb,py"` if you want it to be active in both, but not in the R Markdown representation...
-
-## Cell and notebook metadata filtering
-
-The text representation of the notebook focuses on the part of the notebook that you have written. That is also the part of the notebook that should go under version control. Outputs and metadata that are (re)-constructed automatically when the notebook is executed do not need to enter the text representation.
-
-To that aim, cell metadata `autoscroll`, `collapsed`, `scrolled`, `trusted` and `ExecuteTime` are not included in the text representation. And only the required notebook metadata: `kernelspec` and `jupytext` are saved when a notebook is exported as text.
-
-When a paired notebook is loaded, Jupytext reconstructs the filtered metadata using the `.ipynb` file. Please keep in mind that the `.ipynb` file is typically not distributed accross contributors, and that the cell metadata may be lost when an input cell changes (cells are matched according to their contents). Thus, if some cell or notebook metadata are important to your notebook, you should preserve it in the text version. Change the default metadata filtering as follows:
-- If you want no YAML header in your script, then set a notebook metadata
-`"jupytext": {"metadata_filter": {"notebook": "-all"}}`, or append the below to Jupyter's configuration file:
-```
-c.ContentsManager.default_notebook_metadata_filter = "-all"
-```
-Note that when the Jupytext metadata is not included in the text representation, paired notebooks have to be opened by selecting the `ipynb` file.
-- If you want to preserve all the notebook metadata but `widgets` and `varInspector` in the YAML header, set a notebook metadata `"jupytext": {"metadata_filter": {"notebook": "all,-widgets,-varInspector"}}`
-- If you want to preserve the `toc` section (in addition to the default YAML header), use `"jupytext": {"metadata_filter": {"notebook": "toc"}}`
-- At last, if you want to modify the default cell filter and allow `ExecuteTime` and `autoscroll`, but not `hide_ouput`, use `"jupytext": {"metadata_filter": {"cells": "ExecuteTime,autoscroll,-hide_ouput"}}`
-
-A default value for these filters can be set on Jupytext's content manager using, for instance
-```
-c.ContentsManager.default_notebook_metadata_filter = "all,-widgets,-varInspector"
-c.ContentsManager.default_cell_metadata_filter = "ExecuteTime,autoscroll,-hide_ouput"
-```
-Help us improving the default configuration: if you are aware of a notebook metadata that should not be filtered, or of a cell metadata that should always be filtered, please open an issue and let us know.
-
-Finally, if you prefer that scripts and markdown files with no YAML header do not get one (nor additional cell metadata) when opened and saved in Jupyter, use the `freeze_metadata` option on the command line `jupytext`, or set the following option on Jupytext's content manager:
-```python
-c.ContentsManager.freeze_metadata = True
-```
 
 ## Extending the `light` and `percent` formats to more languages
 

--- a/jupytext/cell_reader.py
+++ b/jupytext/cell_reader.py
@@ -408,7 +408,7 @@ class LightScriptCellReader(ScriptCellReader):
 
 class DoublePercentScriptCellReader(ScriptCellReader):
     """Read notebook cells from Hydrogen/Spyder/VScode scripts (#59)"""
-    default_comment_magics = False
+    default_comment_magics = True
 
     def __init__(self, ext, comment_magics=None):
         ScriptCellReader.__init__(self, ext, comment_magics)
@@ -443,9 +443,10 @@ class DoublePercentScriptCellReader(ScriptCellReader):
         # Cell content
         source = lines[cell_start:cell_end_marker]
 
-        if self.cell_type != 'code' or (self.metadata and not is_active('py', self.metadata)):
+        if self.cell_type != 'code' or (self.metadata and not is_active('py', self.metadata)) \
+                or (self.language is not None and self.language != self.default_language):
             source = uncomment(source, self.comment)
-        if self.comment_magics:
+        elif self.metadata is not None and self.comment_magics:
             source = self.uncomment_code_and_magics(source)
 
         self.content = source

--- a/jupytext/cell_to_text.py
+++ b/jupytext/cell_to_text.py
@@ -60,8 +60,7 @@ class BaseCellExporter(object):
 
         # how many blank lines before next cell
         self.lines_to_next_cell = cell.metadata.get('lines_to_next_cell', 1)
-        self.lines_to_end_of_cell_marker = \
-            cell.metadata.get('lines_to_end_of_cell_marker', 0)
+        self.lines_to_end_of_cell_marker = cell.metadata.get('lines_to_end_of_cell_marker', 0)
 
         # for compatibility with v0.5.4 and lower (to be removed)
         if 'skipline' in cell.metadata:
@@ -286,8 +285,8 @@ class RScriptCellExporter(BaseCellExporter):
 class DoublePercentCellExporter(BaseCellExporter):
     """A class that can represent a notebook cell as an
     Hydrogen/Spyder/VScode script (#59)"""
-    default_comment_magics = False
-    parse_cell_language = False
+    default_comment_magics = True
+    parse_cell_language = True
 
     def code_to_text(self):
         """Not used"""
@@ -299,6 +298,8 @@ class DoublePercentCellExporter(BaseCellExporter):
             self.metadata['cell_type'] = self.cell_type
 
         active = is_active('py', self.metadata)
+        if self.language != self.default_language and 'active' not in self.metadata:
+            active = False
         if self.cell_type == 'raw' and 'active' in self.metadata and self.metadata['active'] == '':
             del self.metadata['active']
 
@@ -308,11 +309,10 @@ class DoublePercentCellExporter(BaseCellExporter):
         else:
             lines = [self.comment + ' %% ' + options]
 
-        if self.cell_type == 'code':
+        if self.cell_type == 'code' and active:
             source = copy(self.source)
             comment_magic(source, self.language, self.comment_magics)
-            if active:
-                return lines + source
+            return lines + source
 
         return lines + comment_lines(self.source, self.comment)
 

--- a/jupytext/cli.py
+++ b/jupytext/cli.py
@@ -201,8 +201,8 @@ def str2bool(input):
 def cli_jupytext(args=None):
     """Command line parser for jupytext"""
     parser = argparse.ArgumentParser(
-        description='Jupyter notebooks as markdown documents, '
-                    'Julia, Python or R scripts')
+        description='Jupyter notebooks as markdown documents, Julia, Python or R scripts',
+        formatter_class=argparse.RawTextHelpFormatter)
 
     notebook_formats = (['notebook', 'rmarkdown', 'markdown'] +
                         [_SCRIPT_EXTENSIONS[ext]['language'] for ext in _SCRIPT_EXTENSIONS] +
@@ -218,15 +218,16 @@ def cli_jupytext(args=None):
                         choices=notebook_formats,
                         help="Input format")
     parser.add_argument('notebooks',
-                        help='One or more notebook(s) to be converted. Input '
-                             'is read from stdin when no notebook is '
-                             'provided , but then the --from field is '
-                             'mandatory',
+                        help='One or more notebook(s). Input is read from stdin when no notebook '
+                             'is provided , but then the --from field is mandatory',
                         nargs='*')
     parser.add_argument('--pre-commit', action='store_true',
-                        help="""Run Jupytext on the ipynb files in the git index. Use Jupytext 
-                        as a pre-commit hook with: echo '#!/bin/sh
-                        jupytext --to py:light --pre-commit' > .git/hooks/pre-commit""")
+                        help="""Run Jupytext on the ipynb files in the git index. 
+Create a pre-commit hook with:                        
+
+echo '#!/bin/sh
+jupytext --to py:light --pre-commit' > .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit""")
     parser.add_argument('-o', '--output',
                         help='Destination file. Defaults to original file, '
                              'with extension changed to destination format. '

--- a/jupytext/contentsmanager.py
+++ b/jupytext/contentsmanager.py
@@ -29,7 +29,7 @@ def kernelspec_from_language(language):
     try:
         for name in find_kernel_specs():
             ks = get_kernel_spec(name)
-            if ks.language == language:
+            if ks.language == language or (language == 'c++' and ks.language.startswith('C++')):
                 return {'name': name, 'language': language, 'display_name': ks.display_name}
     except (KeyError, ValueError):
         pass

--- a/jupytext/contentsmanager.py
+++ b/jupytext/contentsmanager.py
@@ -329,7 +329,7 @@ class TextFileContentsManager(FileContentsManager, Configurable):
                 # Modification time of a paired notebook, in this context - Jupyter is checking timestamp
                 # before saving - is the most recent among all representations #118
                 for alt_path in self.paired_notebooks.get(path, []):
-                    if alt_path != path:
+                    if alt_path != path and self.exists(alt_path):
                         alt_model = self._notebook_model(alt_path, content=False)
                         if alt_model['last_modified'] > model['last_modified']:
                             model['last_modified'] = alt_model['last_modified']

--- a/jupytext/formats.py
+++ b/jupytext/formats.py
@@ -87,10 +87,12 @@ JUPYTEXT_FORMATS = \
             header_prefix=_SCRIPT_EXTENSIONS[ext]['comment'],
             cell_reader_class=DoublePercentScriptCellReader,
             cell_exporter_class=DoublePercentCellExporter,
+            # Version 1.2 on 2018-11-18 - jupytext v0.8.6: Jupyter magics are commented by default #126, #132
             # Version 1.1 on 2018-09-23 - jupytext v0.7.0rc1 : [markdown] and
             # [raw] for markdown and raw cells.
             # Version 1.0 on 2018-09-22 - jupytext v0.7.0rc0 : Initial version
-            current_version_number='1.1') for ext in _SCRIPT_EXTENSIONS] + \
+            current_version_number='1.2',
+            min_readable_version_number='1.1') for ext in _SCRIPT_EXTENSIONS] + \
     [
         NotebookFormatDescription(
             format_name='sphinx',

--- a/jupytext/header.py
+++ b/jupytext/header.py
@@ -22,8 +22,8 @@ _UTF8_HEADER = ' -*- coding: utf-8 -*-'
 _DEFAULT_NOTEBOOK_METADATA = ','.join([
     # Preserve Jupytext section
     'jupytext',
-    # Preserve kernel specs and language_info
-    'kernelspec', 'language_info',
+    # Preserve kernel specs
+    'kernelspec',
     # Kernel_info found in Nteract notebooks
     'kernel_info'])
 

--- a/jupytext/languages.py
+++ b/jupytext/languages.py
@@ -19,15 +19,21 @@ def default_language_from_metadata_and_ext(notebook, ext):
     from the given file extension"""
     default_from_ext = _SCRIPT_EXTENSIONS.get(ext, {}).get('language', 'python')
 
-    return (notebook.metadata.get('language_info', {}).get('name')
-            or notebook.metadata.get('jupytext', {}).get('main_language') or default_from_ext)
+    language = (notebook.metadata.get('kernelspec', {}).get('language')
+                or notebook.metadata.get('jupytext', {}).get('main_language')
+                or default_from_ext)
+
+    if language.startswith('C++'):
+        language = 'c++'
+
+    return language
 
 
 def set_main_and_cell_language(metadata, cells, ext):
     """Set main language for the given collection of cells, and
     use magics for cells that use other languages"""
     default_from_ext = _SCRIPT_EXTENSIONS.get(ext, {}).get('language', 'python')
-    main_language = (metadata.get('language_info', {}).get('name') or
+    main_language = (metadata.get('kernelspec', {}).get('language') or
                      metadata.get('jupytext', {}).get('main_language'))
     if main_language is None:
         languages = {default_from_ext: 0.5}
@@ -38,8 +44,8 @@ def set_main_and_cell_language(metadata, cells, ext):
 
         main_language = max(languages, key=languages.get)
 
-        # save main language when not kernel is set
-        if 'name' not in metadata.get('language_info', {}):
+        # save main language when no kernel is set
+        if 'language' not in metadata.get('kernelspec', {}):
             metadata.setdefault('jupytext', {})['main_language'] = main_language
 
     # Remove 'language' meta data and add a magic if not main language

--- a/jupytext/version.py
+++ b/jupytext/version.py
@@ -1,3 +1,3 @@
 """Jupytext's version number"""
 
-__version__ = '0.8.5'
+__version__ = '0.8.6'

--- a/tests/notebooks/Rmd/chunk_options.Rmd
+++ b/tests/notebooks/Rmd/chunk_options.Rmd
@@ -3,8 +3,10 @@ title: "Test chunk options in Rmd/Jupyter conversion"
 author: "Marc Wouts"
 date: "June 16, 2018"
 jupyter:
-  language_info:
-    name: python
+  kernelspec:
+    display_name: Python
+    language: python
+    name: python3
 ---
 
 ```{r knitr_setup, include=FALSE}

--- a/tests/notebooks/mirror/Rmd_to_ipynb/R_sample.ipynb
+++ b/tests/notebooks/mirror/Rmd_to_ipynb/R_sample.ipynb
@@ -41,7 +41,9 @@
   }
  ],
  "metadata": {
-  "main_language": "R"
+  "jupytext": {
+   "main_language": "R"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/tests/notebooks/mirror/Rmd_to_ipynb/chunk_options.ipynb
+++ b/tests/notebooks/mirror/Rmd_to_ipynb/chunk_options.ipynb
@@ -59,8 +59,10 @@
   }
  ],
  "metadata": {
-  "language_info": {
-   "name": "python"
+  "kernelspec": {
+   "display_name": "Python",
+   "language": "python",
+   "name": "python3"
   }
  },
  "nbformat": 4,

--- a/tests/notebooks/mirror/Rmd_to_ipynb/ioslides.ipynb
+++ b/tests/notebooks/mirror/Rmd_to_ipynb/ioslides.ipynb
@@ -87,7 +87,9 @@
   }
  ],
  "metadata": {
-  "main_language": "python"
+  "jupytext": {
+   "main_language": "python"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/tests/notebooks/mirror/Rmd_to_ipynb/knitr-spin.ipynb
+++ b/tests/notebooks/mirror/Rmd_to_ipynb/knitr-spin.ipynb
@@ -172,7 +172,9 @@
   }
  ],
  "metadata": {
-  "main_language": "R"
+  "jupytext": {
+   "main_language": "R"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/tests/notebooks/mirror/Rmd_to_ipynb/markdown.ipynb
+++ b/tests/notebooks/mirror/Rmd_to_ipynb/markdown.ipynb
@@ -34,7 +34,9 @@
   }
  ],
  "metadata": {
-  "main_language": "python"
+  "jupytext": {
+   "main_language": "python"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/tests/notebooks/mirror/ipynb_to_Rmd/Notebook with many hash signs.Rmd
+++ b/tests/notebooks/mirror/ipynb_to_Rmd/Notebook with many hash signs.Rmd
@@ -4,16 +4,6 @@ jupyter:
     display_name: Python 3
     language: python
     name: python3
-  language_info:
-    codemirror_mode:
-      name: ipython
-      version: 3
-    file_extension: .py
-    mimetype: text/x-python
-    name: python
-    nbconvert_exporter: python
-    pygments_lexer: ipython3
-    version: 3.6.6
 ---
 
 ##################################################################

--- a/tests/notebooks/mirror/ipynb_to_Rmd/Notebook_with_R_magic.Rmd
+++ b/tests/notebooks/mirror/ipynb_to_Rmd/Notebook_with_R_magic.Rmd
@@ -4,16 +4,6 @@ jupyter:
     display_name: Python 2
     language: python
     name: python2
-  language_info:
-    codemirror_mode:
-      name: ipython
-      version: 2
-    file_extension: .py
-    mimetype: text/x-python
-    name: python
-    nbconvert_exporter: python
-    pygments_lexer: ipython2
-    version: 2.7.11
 ---
 
 # A notebook with R cells

--- a/tests/notebooks/mirror/ipynb_to_Rmd/World population.Rmd
+++ b/tests/notebooks/mirror/ipynb_to_Rmd/World population.Rmd
@@ -4,16 +4,6 @@ jupyter:
     display_name: Python 3
     language: python
     name: python3
-  language_info:
-    codemirror_mode:
-      name: ipython
-      version: 3
-    file_extension: .py
-    mimetype: text/x-python
-    name: python
-    nbconvert_exporter: python
-    pygments_lexer: ipython3
-    version: 3.6.6
 ---
 
 # A quick insight at world population

--- a/tests/notebooks/mirror/ipynb_to_Rmd/convert_to_py_then_test_with_update83.Rmd
+++ b/tests/notebooks/mirror/ipynb_to_Rmd/convert_to_py_then_test_with_update83.Rmd
@@ -7,16 +7,6 @@ jupyter:
     display_name: Python 3
     language: python
     name: python3
-  language_info:
-    codemirror_mode:
-      name: ipython
-      version: 3
-    file_extension: .py
-    mimetype: text/x-python
-    name: python
-    nbconvert_exporter: python
-    pygments_lexer: ipython3
-    version: 3.5.3
 ---
 
 ```{python}

--- a/tests/notebooks/mirror/ipynb_to_Rmd/frozen_cell.Rmd
+++ b/tests/notebooks/mirror/ipynb_to_Rmd/frozen_cell.Rmd
@@ -4,16 +4,6 @@ jupyter:
     display_name: Python 3
     language: python
     name: python3
-  language_info:
-    codemirror_mode:
-      name: ipython
-      version: 3
-    file_extension: .py
-    mimetype: text/x-python
-    name: python
-    nbconvert_exporter: python
-    pygments_lexer: ipython3
-    version: 3.7.0
 ---
 
 ```{python}

--- a/tests/notebooks/mirror/ipynb_to_Rmd/ir_notebook.Rmd
+++ b/tests/notebooks/mirror/ipynb_to_Rmd/ir_notebook.Rmd
@@ -4,13 +4,6 @@ jupyter:
     display_name: R
     language: R
     name: ir
-  language_info:
-    codemirror_mode: r
-    file_extension: .r
-    mimetype: text/x-r-source
-    name: R
-    pygments_lexer: r
-    version: 3.5.0
 ---
 
 This is a jupyter notebook that uses the IR kernel.

--- a/tests/notebooks/mirror/ipynb_to_Rmd/julia_benchmark_plotly_barchart.Rmd
+++ b/tests/notebooks/mirror/ipynb_to_Rmd/julia_benchmark_plotly_barchart.Rmd
@@ -4,16 +4,6 @@ jupyter:
     display_name: Python 3
     language: python
     name: python3
-  language_info:
-    codemirror_mode:
-      name: ipython
-      version: 3
-    file_extension: .py
-    mimetype: text/x-python
-    name: python
-    nbconvert_exporter: python
-    pygments_lexer: ipython3
-    version: 3.6.6
 ---
 
 ```{python}

--- a/tests/notebooks/mirror/ipynb_to_Rmd/jupyter.Rmd
+++ b/tests/notebooks/mirror/ipynb_to_Rmd/jupyter.Rmd
@@ -4,16 +4,6 @@ jupyter:
     display_name: Python 3
     language: python
     name: python3
-  language_info:
-    codemirror_mode:
-      name: ipython
-      version: 3
-    file_extension: .py
-    mimetype: text/x-python
-    name: python
-    nbconvert_exporter: python
-    pygments_lexer: ipython3
-    version: 3.6.4
 ---
 
 # Jupyter notebook

--- a/tests/notebooks/mirror/ipynb_to_Rmd/jupyter_again.Rmd
+++ b/tests/notebooks/mirror/ipynb_to_Rmd/jupyter_again.Rmd
@@ -4,16 +4,6 @@ jupyter:
     display_name: Python 3
     language: python
     name: python3
-  language_info:
-    codemirror_mode:
-      name: ipython
-      version: 3
-    file_extension: .py
-    mimetype: text/x-python
-    name: python
-    nbconvert_exporter: python
-    pygments_lexer: ipython3
-    version: 3.6.5
 ---
 
 ```{python}

--- a/tests/notebooks/mirror/ipynb_to_Rmd/jupyter_with_raw_cell_in_body.Rmd
+++ b/tests/notebooks/mirror/ipynb_to_Rmd/jupyter_with_raw_cell_in_body.Rmd
@@ -4,16 +4,6 @@ jupyter:
     display_name: Python 3
     language: python
     name: python3
-  language_info:
-    codemirror_mode:
-      name: ipython
-      version: 3
-    file_extension: .py
-    mimetype: text/x-python
-    name: python
-    nbconvert_exporter: python
-    pygments_lexer: ipython3
-    version: 3.6.6
 ---
 
 ```{python}

--- a/tests/notebooks/mirror/ipynb_to_Rmd/jupyter_with_raw_cell_on_top.Rmd
+++ b/tests/notebooks/mirror/ipynb_to_Rmd/jupyter_with_raw_cell_on_top.Rmd
@@ -11,16 +11,6 @@ jupyter:
     display_name: Python 3
     language: python
     name: python3
-  language_info:
-    codemirror_mode:
-      name: ipython
-      version: 3
-    file_extension: .py
-    mimetype: text/x-python
-    name: python
-    nbconvert_exporter: python
-    pygments_lexer: ipython3
-    version: 3.6.5
 ---
 
 ```{python}

--- a/tests/notebooks/mirror/ipynb_to_Rmd/notebook_with_complex_metadata.Rmd
+++ b/tests/notebooks/mirror/ipynb_to_Rmd/notebook_with_complex_metadata.Rmd
@@ -4,16 +4,6 @@ jupyter:
     display_name: Python 3
     language: python
     name: python3
-  language_info:
-    codemirror_mode:
-      name: ipython
-      version: 3
-    file_extension: .py
-    mimetype: text/x-python
-    name: python
-    nbconvert_exporter: python
-    pygments_lexer: ipython3
-    version: 3.5.1
 ---
 
 ```{python}

--- a/tests/notebooks/mirror/ipynb_to_Rmd/nteract_with_parameter.Rmd
+++ b/tests/notebooks/mirror/ipynb_to_Rmd/nteract_with_parameter.Rmd
@@ -6,16 +6,6 @@ jupyter:
     display_name: Python 3
     language: python
     name: python3
-  language_info:
-    codemirror_mode:
-      name: ipython
-      version: 3
-    file_extension: .py
-    mimetype: text/x-python
-    name: python
-    nbconvert_exporter: python
-    pygments_lexer: ipython3
-    version: 3.6.6
 ---
 
 ```{python outputHidden=FALSE, inputHidden=FALSE, tags=c("parameters")}

--- a/tests/notebooks/mirror/ipynb_to_md/Notebook with many hash signs.md
+++ b/tests/notebooks/mirror/ipynb_to_md/Notebook with many hash signs.md
@@ -4,16 +4,6 @@ jupyter:
     display_name: Python 3
     language: python
     name: python3
-  language_info:
-    codemirror_mode:
-      name: ipython
-      version: 3
-    file_extension: .py
-    mimetype: text/x-python
-    name: python
-    nbconvert_exporter: python
-    pygments_lexer: ipython3
-    version: 3.6.6
 ---
 
 ##################################################################

--- a/tests/notebooks/mirror/ipynb_to_md/World population.md
+++ b/tests/notebooks/mirror/ipynb_to_md/World population.md
@@ -4,16 +4,6 @@ jupyter:
     display_name: Python 3
     language: python
     name: python3
-  language_info:
-    codemirror_mode:
-      name: ipython
-      version: 3
-    file_extension: .py
-    mimetype: text/x-python
-    name: python
-    nbconvert_exporter: python
-    pygments_lexer: ipython3
-    version: 3.6.6
 ---
 
 # A quick insight at world population

--- a/tests/notebooks/mirror/ipynb_to_md/convert_to_py_then_test_with_update83.md
+++ b/tests/notebooks/mirror/ipynb_to_md/convert_to_py_then_test_with_update83.md
@@ -7,16 +7,6 @@ jupyter:
     display_name: Python 3
     language: python
     name: python3
-  language_info:
-    codemirror_mode:
-      name: ipython
-      version: 3
-    file_extension: .py
-    mimetype: text/x-python
-    name: python
-    nbconvert_exporter: python
-    pygments_lexer: ipython3
-    version: 3.5.3
 ---
 
 ```python

--- a/tests/notebooks/mirror/ipynb_to_md/ir_notebook.md
+++ b/tests/notebooks/mirror/ipynb_to_md/ir_notebook.md
@@ -4,13 +4,6 @@ jupyter:
     display_name: R
     language: R
     name: ir
-  language_info:
-    codemirror_mode: r
-    file_extension: .r
-    mimetype: text/x-r-source
-    name: R
-    pygments_lexer: r
-    version: 3.5.0
 ---
 
 This is a jupyter notebook that uses the IR kernel.

--- a/tests/notebooks/mirror/ipynb_to_md/julia_benchmark_plotly_barchart.md
+++ b/tests/notebooks/mirror/ipynb_to_md/julia_benchmark_plotly_barchart.md
@@ -4,16 +4,6 @@ jupyter:
     display_name: Python 3
     language: python
     name: python3
-  language_info:
-    codemirror_mode:
-      name: ipython
-      version: 3
-    file_extension: .py
-    mimetype: text/x-python
-    name: python
-    nbconvert_exporter: python
-    pygments_lexer: ipython3
-    version: 3.6.6
 ---
 
 ```python

--- a/tests/notebooks/mirror/ipynb_to_md/jupyter.md
+++ b/tests/notebooks/mirror/ipynb_to_md/jupyter.md
@@ -4,16 +4,6 @@ jupyter:
     display_name: Python 3
     language: python
     name: python3
-  language_info:
-    codemirror_mode:
-      name: ipython
-      version: 3
-    file_extension: .py
-    mimetype: text/x-python
-    name: python
-    nbconvert_exporter: python
-    pygments_lexer: ipython3
-    version: 3.6.4
 ---
 
 # Jupyter notebook

--- a/tests/notebooks/mirror/ipynb_to_md/jupyter_again.md
+++ b/tests/notebooks/mirror/ipynb_to_md/jupyter_again.md
@@ -4,16 +4,6 @@ jupyter:
     display_name: Python 3
     language: python
     name: python3
-  language_info:
-    codemirror_mode:
-      name: ipython
-      version: 3
-    file_extension: .py
-    mimetype: text/x-python
-    name: python
-    nbconvert_exporter: python
-    pygments_lexer: ipython3
-    version: 3.6.5
 ---
 
 ```python

--- a/tests/notebooks/mirror/ipynb_to_md/jupyter_with_raw_cell_in_body.md
+++ b/tests/notebooks/mirror/ipynb_to_md/jupyter_with_raw_cell_in_body.md
@@ -4,16 +4,6 @@ jupyter:
     display_name: Python 3
     language: python
     name: python3
-  language_info:
-    codemirror_mode:
-      name: ipython
-      version: 3
-    file_extension: .py
-    mimetype: text/x-python
-    name: python
-    nbconvert_exporter: python
-    pygments_lexer: ipython3
-    version: 3.6.6
 ---
 
 ```python

--- a/tests/notebooks/mirror/ipynb_to_md/jupyter_with_raw_cell_on_top.md
+++ b/tests/notebooks/mirror/ipynb_to_md/jupyter_with_raw_cell_on_top.md
@@ -11,16 +11,6 @@ jupyter:
     display_name: Python 3
     language: python
     name: python3
-  language_info:
-    codemirror_mode:
-      name: ipython
-      version: 3
-    file_extension: .py
-    mimetype: text/x-python
-    name: python
-    nbconvert_exporter: python
-    pygments_lexer: ipython3
-    version: 3.6.5
 ---
 
 ```python

--- a/tests/notebooks/mirror/ipynb_to_md/notebook_with_complex_metadata.md
+++ b/tests/notebooks/mirror/ipynb_to_md/notebook_with_complex_metadata.md
@@ -4,16 +4,6 @@ jupyter:
     display_name: Python 3
     language: python
     name: python3
-  language_info:
-    codemirror_mode:
-      name: ipython
-      version: 3
-    file_extension: .py
-    mimetype: text/x-python
-    name: python
-    nbconvert_exporter: python
-    pygments_lexer: ipython3
-    version: 3.5.1
 ---
 
 ```python

--- a/tests/notebooks/mirror/ipynb_to_md/nteract_with_parameter.md
+++ b/tests/notebooks/mirror/ipynb_to_md/nteract_with_parameter.md
@@ -6,16 +6,6 @@ jupyter:
     display_name: Python 3
     language: python
     name: python3
-  language_info:
-    codemirror_mode:
-      name: ipython
-      version: 3
-    file_extension: .py
-    mimetype: text/x-python
-    name: python
-    nbconvert_exporter: python
-    pygments_lexer: ipython3
-    version: 3.6.6
 ---
 
 ```python

--- a/tests/notebooks/mirror/ipynb_to_percent/Notebook with many hash signs.py
+++ b/tests/notebooks/mirror/ipynb_to_percent/Notebook with many hash signs.py
@@ -4,16 +4,6 @@
 #     display_name: Python 3
 #     language: python
 #     name: python3
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 3
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython3
-#     version: 3.6.6
 # ---
 
 # %% [markdown]

--- a/tests/notebooks/mirror/ipynb_to_percent/Notebook_with_R_magic.py
+++ b/tests/notebooks/mirror/ipynb_to_percent/Notebook_with_R_magic.py
@@ -4,16 +4,6 @@
 #     display_name: Python 2
 #     language: python
 #     name: python2
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 2
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython2
-#     version: 2.7.11
 # ---
 
 # %% [markdown]

--- a/tests/notebooks/mirror/ipynb_to_percent/Notebook_with_R_magic.py
+++ b/tests/notebooks/mirror/ipynb_to_percent/Notebook_with_R_magic.py
@@ -12,19 +12,16 @@
 # This notebook shows the use of R cells to generate plots
 
 # %%
-%load_ext rpy2.ipython
+# %load_ext rpy2.ipython
 
-# %%
-%%R
-suppressMessages(require(tidyverse))
+# %% {"language": "R"}
+# suppressMessages(require(tidyverse))
 
-# %%
-%%R
-ggplot(iris, aes(x = Sepal.Length, y = Petal.Length, color=Species)) + geom_point()
+# %% {"language": "R"}
+# ggplot(iris, aes(x = Sepal.Length, y = Petal.Length, color=Species)) + geom_point()
 
 # %% [markdown]
 # The default plot dimensions are not good for us, so we use the -w and -h parameters in %%R magic to set the plot size
 
-# %%
-%%R -w 400 -h 240
-ggplot(iris, aes(x = Sepal.Length, y = Petal.Length, color=Species)) + geom_point()
+# %% {"magic_args": "-w 400 -h 240", "language": "R"}
+# ggplot(iris, aes(x = Sepal.Length, y = Petal.Length, color=Species)) + geom_point()

--- a/tests/notebooks/mirror/ipynb_to_percent/Reference Guide for Calysto Scheme.ss
+++ b/tests/notebooks/mirror/ipynb_to_percent/Reference Guide for Calysto Scheme.ss
@@ -5,12 +5,6 @@
 ;;     display_name: Calysto Scheme (Python)
 ;;     language: scheme
 ;;     name: calysto_scheme
-;;   language_info:
-;;     codemirror_mode:
-;;       name: scheme
-;;     mimetype: text/x-scheme
-;;     name: scheme
-;;     pygments_lexer: scheme
 ;; ---
 
 ;; %% [markdown]

--- a/tests/notebooks/mirror/ipynb_to_percent/World population.py
+++ b/tests/notebooks/mirror/ipynb_to_percent/World population.py
@@ -4,16 +4,6 @@
 #     display_name: Python 3
 #     language: python
 #     name: python3
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 3
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython3
-#     version: 3.6.6
 # ---
 
 # %% [markdown]

--- a/tests/notebooks/mirror/ipynb_to_percent/convert_to_py_then_test_with_update83.py
+++ b/tests/notebooks/mirror/ipynb_to_percent/convert_to_py_then_test_with_update83.py
@@ -10,7 +10,7 @@
 # ---
 
 # %%
-%%time
+# %%time
 
 print('asdf')
 

--- a/tests/notebooks/mirror/ipynb_to_percent/convert_to_py_then_test_with_update83.py
+++ b/tests/notebooks/mirror/ipynb_to_percent/convert_to_py_then_test_with_update83.py
@@ -7,16 +7,6 @@
 #     display_name: Python 3
 #     language: python
 #     name: python3
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 3
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython3
-#     version: 3.5.3
 # ---
 
 # %%

--- a/tests/notebooks/mirror/ipynb_to_percent/frozen_cell.py
+++ b/tests/notebooks/mirror/ipynb_to_percent/frozen_cell.py
@@ -4,16 +4,6 @@
 #     display_name: Python 3
 #     language: python
 #     name: python3
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 3
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython3
-#     version: 3.7.0
 # ---
 
 # %%

--- a/tests/notebooks/mirror/ipynb_to_percent/ir_notebook.R
+++ b/tests/notebooks/mirror/ipynb_to_percent/ir_notebook.R
@@ -4,13 +4,6 @@
 #     display_name: R
 #     language: R
 #     name: ir
-#   language_info:
-#     codemirror_mode: r
-#     file_extension: .r
-#     mimetype: text/x-r-source
-#     name: R
-#     pygments_lexer: r
-#     version: 3.5.0
 # ---
 
 # %% [markdown]

--- a/tests/notebooks/mirror/ipynb_to_percent/ir_notebook.low.r
+++ b/tests/notebooks/mirror/ipynb_to_percent/ir_notebook.low.r
@@ -4,13 +4,6 @@
 #     display_name: R
 #     language: R
 #     name: ir
-#   language_info:
-#     codemirror_mode: r
-#     file_extension: .r
-#     mimetype: text/x-r-source
-#     name: R
-#     pygments_lexer: r
-#     version: 3.5.0
 # ---
 
 # %% [markdown]

--- a/tests/notebooks/mirror/ipynb_to_percent/julia_benchmark_plotly_barchart.jl
+++ b/tests/notebooks/mirror/ipynb_to_percent/julia_benchmark_plotly_barchart.jl
@@ -4,16 +4,6 @@
 #     display_name: Python 3
 #     language: python
 #     name: python3
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 3
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython3
-#     version: 3.6.6
 # ---
 
 # %%

--- a/tests/notebooks/mirror/ipynb_to_percent/jupyter.py
+++ b/tests/notebooks/mirror/ipynb_to_percent/jupyter.py
@@ -4,16 +4,6 @@
 #     display_name: Python 3
 #     language: python
 #     name: python3
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 3
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython3
-#     version: 3.6.4
 # ---
 
 # %% [markdown]

--- a/tests/notebooks/mirror/ipynb_to_percent/jupyter_again.py
+++ b/tests/notebooks/mirror/ipynb_to_percent/jupyter_again.py
@@ -22,4 +22,4 @@ import yaml
 print(yaml.dump(yaml.load(c)))
 
 # %%
-?next
+# ?next

--- a/tests/notebooks/mirror/ipynb_to_percent/jupyter_again.py
+++ b/tests/notebooks/mirror/ipynb_to_percent/jupyter_again.py
@@ -4,16 +4,6 @@
 #     display_name: Python 3
 #     language: python
 #     name: python3
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 3
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython3
-#     version: 3.6.5
 # ---
 
 # %%

--- a/tests/notebooks/mirror/ipynb_to_percent/jupyter_with_raw_cell_in_body.py
+++ b/tests/notebooks/mirror/ipynb_to_percent/jupyter_with_raw_cell_in_body.py
@@ -4,16 +4,6 @@
 #     display_name: Python 3
 #     language: python
 #     name: python3
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 3
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython3
-#     version: 3.6.6
 # ---
 
 # %%

--- a/tests/notebooks/mirror/ipynb_to_percent/jupyter_with_raw_cell_on_top.py
+++ b/tests/notebooks/mirror/ipynb_to_percent/jupyter_with_raw_cell_on_top.py
@@ -11,16 +11,6 @@
 #     display_name: Python 3
 #     language: python
 #     name: python3
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 3
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython3
-#     version: 3.6.5
 # ---
 
 # %%

--- a/tests/notebooks/mirror/ipynb_to_percent/notebook_with_complex_metadata.py
+++ b/tests/notebooks/mirror/ipynb_to_percent/notebook_with_complex_metadata.py
@@ -4,16 +4,6 @@
 #     display_name: Python 3
 #     language: python
 #     name: python3
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 3
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython3
-#     version: 3.5.1
 # ---
 
 # %%

--- a/tests/notebooks/mirror/ipynb_to_percent/nteract_with_parameter.py
+++ b/tests/notebooks/mirror/ipynb_to_percent/nteract_with_parameter.py
@@ -20,5 +20,5 @@ df = pd.DataFrame({'A': [1, 2], 'B': [3 + param, 4]},
 df
 
 # %% {"outputHidden": false, "inputHidden": false}
-%matplotlib inline
+# %matplotlib inline
 df.plot(kind='bar')

--- a/tests/notebooks/mirror/ipynb_to_percent/nteract_with_parameter.py
+++ b/tests/notebooks/mirror/ipynb_to_percent/nteract_with_parameter.py
@@ -6,16 +6,6 @@
 #     display_name: Python 3
 #     language: python
 #     name: python3
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 3
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython3
-#     version: 3.6.6
 # ---
 
 # %% {"outputHidden": false, "inputHidden": false, "tags": ["parameters"]}

--- a/tests/notebooks/mirror/ipynb_to_percent/sample_bash_notebook.sh
+++ b/tests/notebooks/mirror/ipynb_to_percent/sample_bash_notebook.sh
@@ -4,11 +4,6 @@
 #     display_name: Bash
 #     language: bash
 #     name: bash
-#   language_info:
-#     codemirror_mode: shell
-#     file_extension: .sh
-#     mimetype: text/x-sh
-#     name: bash
 # ---
 
 # %%

--- a/tests/notebooks/mirror/ipynb_to_percent/sample_rise_notebook_66.py
+++ b/tests/notebooks/mirror/ipynb_to_percent/sample_rise_notebook_66.py
@@ -4,16 +4,6 @@
 #     display_name: Python 3
 #     language: python
 #     name: python3
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 3
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython3
-#     version: 3.6.6
 # ---
 
 # %% [markdown] {"slideshow": {"slide_type": "slide"}}

--- a/tests/notebooks/mirror/ipynb_to_percent/xcpp_by_quantstack.cpp
+++ b/tests/notebooks/mirror/ipynb_to_percent/xcpp_by_quantstack.cpp
@@ -373,7 +373,7 @@ xcpp::display(rect, "some_display_id", true);
 std::vector<double> to_shuffle = {1, 2, 3, 4};
 
 // %%
-%timeit std::random_shuffle(to_shuffle.begin(), to_shuffle.end());
+// %timeit std::random_shuffle(to_shuffle.begin(), to_shuffle.end());
 
 // %% [markdown]
 // [![xtensor](images/xtensor.png)](https://github.com/QuantStack/xtensor/)

--- a/tests/notebooks/mirror/ipynb_to_percent/xcpp_by_quantstack.cpp
+++ b/tests/notebooks/mirror/ipynb_to_percent/xcpp_by_quantstack.cpp
@@ -4,12 +4,6 @@
 //     display_name: C++14
 //     language: C++14
 //     name: xeus-cling-cpp14
-//   language_info:
-//     codemirror_mode: text/x-c++src
-//     file_extension: .cpp
-//     mimetype: text/x-c++src
-//     name: c++
-//     version: -std=c++14
 // ---
 
 // %% [markdown]

--- a/tests/notebooks/mirror/ipynb_to_script/Notebook with many hash signs.py
+++ b/tests/notebooks/mirror/ipynb_to_script/Notebook with many hash signs.py
@@ -4,16 +4,6 @@
 #     display_name: Python 3
 #     language: python
 #     name: python3
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 3
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython3
-#     version: 3.6.6
 # ---
 
 # ##################################################################

--- a/tests/notebooks/mirror/ipynb_to_script/Notebook_with_R_magic.py
+++ b/tests/notebooks/mirror/ipynb_to_script/Notebook_with_R_magic.py
@@ -4,16 +4,6 @@
 #     display_name: Python 2
 #     language: python
 #     name: python2
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 2
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython2
-#     version: 2.7.11
 # ---
 
 # # A notebook with R cells

--- a/tests/notebooks/mirror/ipynb_to_script/Reference Guide for Calysto Scheme.ss
+++ b/tests/notebooks/mirror/ipynb_to_script/Reference Guide for Calysto Scheme.ss
@@ -5,12 +5,6 @@
 ;;     display_name: Calysto Scheme (Python)
 ;;     language: scheme
 ;;     name: calysto_scheme
-;;   language_info:
-;;     codemirror_mode:
-;;       name: scheme
-;;     mimetype: text/x-scheme
-;;     name: scheme
-;;     pygments_lexer: scheme
 ;; ---
 
 ;; <img src="images/logo-64x64.png"/>

--- a/tests/notebooks/mirror/ipynb_to_script/World population.py
+++ b/tests/notebooks/mirror/ipynb_to_script/World population.py
@@ -4,16 +4,6 @@
 #     display_name: Python 3
 #     language: python
 #     name: python3
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 3
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython3
-#     version: 3.6.6
 # ---
 
 # # A quick insight at world population

--- a/tests/notebooks/mirror/ipynb_to_script/convert_to_py_then_test_with_update83.py
+++ b/tests/notebooks/mirror/ipynb_to_script/convert_to_py_then_test_with_update83.py
@@ -7,16 +7,6 @@
 #     display_name: Python 3
 #     language: python
 #     name: python3
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 3
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython3
-#     version: 3.5.3
 # ---
 
 # +

--- a/tests/notebooks/mirror/ipynb_to_script/frozen_cell.py
+++ b/tests/notebooks/mirror/ipynb_to_script/frozen_cell.py
@@ -4,16 +4,6 @@
 #     display_name: Python 3
 #     language: python
 #     name: python3
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 3
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython3
-#     version: 3.7.0
 # ---
 
 # This is an unfrozen cell. Works as usual.

--- a/tests/notebooks/mirror/ipynb_to_script/ir_notebook.R
+++ b/tests/notebooks/mirror/ipynb_to_script/ir_notebook.R
@@ -4,13 +4,6 @@
 #'     display_name: R
 #'     language: R
 #'     name: ir
-#'   language_info:
-#'     codemirror_mode: r
-#'     file_extension: .r
-#'     mimetype: text/x-r-source
-#'     name: R
-#'     pygments_lexer: r
-#'     version: 3.5.0
 #' ---
 
 #' This is a jupyter notebook that uses the IR kernel.

--- a/tests/notebooks/mirror/ipynb_to_script/ir_notebook.low.r
+++ b/tests/notebooks/mirror/ipynb_to_script/ir_notebook.low.r
@@ -4,13 +4,6 @@
 #'     display_name: R
 #'     language: R
 #'     name: ir
-#'   language_info:
-#'     codemirror_mode: r
-#'     file_extension: .r
-#'     mimetype: text/x-r-source
-#'     name: R
-#'     pygments_lexer: r
-#'     version: 3.5.0
 #' ---
 
 #' This is a jupyter notebook that uses the IR kernel.

--- a/tests/notebooks/mirror/ipynb_to_script/julia_benchmark_plotly_barchart.jl
+++ b/tests/notebooks/mirror/ipynb_to_script/julia_benchmark_plotly_barchart.jl
@@ -4,16 +4,6 @@
 #     display_name: Python 3
 #     language: python
 #     name: python3
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 3
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython3
-#     version: 3.6.6
 # ---
 
 # +

--- a/tests/notebooks/mirror/ipynb_to_script/jupyter.py
+++ b/tests/notebooks/mirror/ipynb_to_script/jupyter.py
@@ -4,16 +4,6 @@
 #     display_name: Python 3
 #     language: python
 #     name: python3
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 3
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython3
-#     version: 3.6.4
 # ---
 
 # # Jupyter notebook

--- a/tests/notebooks/mirror/ipynb_to_script/jupyter_again.py
+++ b/tests/notebooks/mirror/ipynb_to_script/jupyter_again.py
@@ -4,16 +4,6 @@
 #     display_name: Python 3
 #     language: python
 #     name: python3
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 3
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython3
-#     version: 3.6.5
 # ---
 
 c = '''

--- a/tests/notebooks/mirror/ipynb_to_script/jupyter_with_raw_cell_in_body.py
+++ b/tests/notebooks/mirror/ipynb_to_script/jupyter_with_raw_cell_in_body.py
@@ -4,16 +4,6 @@
 #     display_name: Python 3
 #     language: python
 #     name: python3
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 3
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython3
-#     version: 3.6.6
 # ---
 
 1+2+3

--- a/tests/notebooks/mirror/ipynb_to_script/jupyter_with_raw_cell_on_top.py
+++ b/tests/notebooks/mirror/ipynb_to_script/jupyter_with_raw_cell_on_top.py
@@ -11,16 +11,6 @@
 #     display_name: Python 3
 #     language: python
 #     name: python3
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 3
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython3
-#     version: 3.6.5
 # ---
 
 1+2+3

--- a/tests/notebooks/mirror/ipynb_to_script/notebook_with_complex_metadata.py
+++ b/tests/notebooks/mirror/ipynb_to_script/notebook_with_complex_metadata.py
@@ -4,16 +4,6 @@
 #     display_name: Python 3
 #     language: python
 #     name: python3
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 3
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython3
-#     version: 3.5.1
 # ---
 
 

--- a/tests/notebooks/mirror/ipynb_to_script/nteract_with_parameter.py
+++ b/tests/notebooks/mirror/ipynb_to_script/nteract_with_parameter.py
@@ -6,16 +6,6 @@
 #     display_name: Python 3
 #     language: python
 #     name: python3
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 3
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython3
-#     version: 3.6.6
 # ---
 
 # + {"outputHidden": false, "inputHidden": false, "tags": ["parameters"]}

--- a/tests/notebooks/mirror/ipynb_to_script/sample_bash_notebook.sh
+++ b/tests/notebooks/mirror/ipynb_to_script/sample_bash_notebook.sh
@@ -4,11 +4,6 @@
 #     display_name: Bash
 #     language: bash
 #     name: bash
-#   language_info:
-#     codemirror_mode: shell
-#     file_extension: .sh
-#     mimetype: text/x-sh
-#     name: bash
 # ---
 
 ls

--- a/tests/notebooks/mirror/ipynb_to_script/sample_rise_notebook_66.py
+++ b/tests/notebooks/mirror/ipynb_to_script/sample_rise_notebook_66.py
@@ -4,16 +4,6 @@
 #     display_name: Python 3
 #     language: python
 #     name: python3
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 3
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython3
-#     version: 3.6.6
 # ---
 
 # + {"slideshow": {"slide_type": "slide"}, "cell_type": "markdown"}

--- a/tests/notebooks/mirror/ipynb_to_script/xcpp_by_quantstack.cpp
+++ b/tests/notebooks/mirror/ipynb_to_script/xcpp_by_quantstack.cpp
@@ -4,12 +4,6 @@
 //     display_name: C++14
 //     language: C++14
 //     name: xeus-cling-cpp14
-//   language_info:
-//     codemirror_mode: text/x-c++src
-//     file_extension: .cpp
-//     mimetype: text/x-c++src
-//     name: c++
-//     version: -std=c++14
 // ---
 
 // [![xeus-cling](images/xeus-cling.png)](https://github.com/QuantStack/xeus-cling/)

--- a/tests/notebooks/mirror/ipynb_to_sphinx/World population.py
+++ b/tests/notebooks/mirror/ipynb_to_sphinx/World population.py
@@ -4,16 +4,6 @@
 #     display_name: Python 3
 #     language: python
 #     name: python3
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 3
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython3
-#     version: 3.6.6
 # ---
 
 """

--- a/tests/notebooks/mirror/ipynb_to_sphinx/convert_to_py_then_test_with_update83.py
+++ b/tests/notebooks/mirror/ipynb_to_sphinx/convert_to_py_then_test_with_update83.py
@@ -7,16 +7,6 @@
 #     display_name: Python 3
 #     language: python
 #     name: python3
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 3
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython3
-#     version: 3.5.3
 # ---
 
 # %%time

--- a/tests/notebooks/mirror/ipynb_to_sphinx/jupyter.py
+++ b/tests/notebooks/mirror/ipynb_to_sphinx/jupyter.py
@@ -4,16 +4,6 @@
 #     display_name: Python 3
 #     language: python
 #     name: python3
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 3
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython3
-#     version: 3.6.4
 # ---
 
 """

--- a/tests/notebooks/mirror/ipynb_to_sphinx/jupyter_again.py
+++ b/tests/notebooks/mirror/ipynb_to_sphinx/jupyter_again.py
@@ -4,16 +4,6 @@
 #     display_name: Python 3
 #     language: python
 #     name: python3
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 3
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython3
-#     version: 3.6.5
 # ---
 
 c = '''

--- a/tests/notebooks/mirror/ipynb_to_sphinx/notebook_with_complex_metadata.py
+++ b/tests/notebooks/mirror/ipynb_to_sphinx/notebook_with_complex_metadata.py
@@ -4,16 +4,6 @@
 #     display_name: Python 3
 #     language: python
 #     name: python3
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 3
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython3
-#     version: 3.5.1
 # ---
 
 

--- a/tests/notebooks/mirror/ipynb_to_sphinx/nteract_with_parameter.py
+++ b/tests/notebooks/mirror/ipynb_to_sphinx/nteract_with_parameter.py
@@ -6,16 +6,6 @@
 #     display_name: Python 3
 #     language: python
 #     name: python3
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 3
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython3
-#     version: 3.6.6
 # ---
 
 param = 4

--- a/tests/notebooks/mirror/ipynb_to_sphinx/sample_rise_notebook_66.py
+++ b/tests/notebooks/mirror/ipynb_to_sphinx/sample_rise_notebook_66.py
@@ -4,16 +4,6 @@
 #     display_name: Python 3
 #     language: python
 #     name: python3
-#   language_info:
-#     codemirror_mode:
-#       name: ipython
-#       version: 3
-#     file_extension: .py
-#     mimetype: text/x-python
-#     name: python
-#     nbconvert_exporter: python
-#     pygments_lexer: ipython3
-#     version: 3.6.6
 # ---
 
 """

--- a/tests/notebooks/mirror/ipynb_to_spin/ir_notebook.R
+++ b/tests/notebooks/mirror/ipynb_to_spin/ir_notebook.R
@@ -4,13 +4,6 @@
 #'     display_name: R
 #'     language: R
 #'     name: ir
-#'   language_info:
-#'     codemirror_mode: r
-#'     file_extension: .r
-#'     mimetype: text/x-r-source
-#'     name: R
-#'     pygments_lexer: r
-#'     version: 3.5.0
 #' ---
 
 #' This is a jupyter notebook that uses the IR kernel.

--- a/tests/notebooks/mirror/ipynb_to_spin/ir_notebook.low.r
+++ b/tests/notebooks/mirror/ipynb_to_spin/ir_notebook.low.r
@@ -4,13 +4,6 @@
 #'     display_name: R
 #'     language: R
 #'     name: ir
-#'   language_info:
-#'     codemirror_mode: r
-#'     file_extension: .r
-#'     mimetype: text/x-r-source
-#'     name: R
-#'     pygments_lexer: r
-#'     version: 3.5.0
 #' ---
 
 #' This is a jupyter notebook that uses the IR kernel.

--- a/tests/notebooks/mirror/script_to_ipynb/hydrogen.ipynb
+++ b/tests/notebooks/mirror/script_to_ipynb/hydrogen.ipynb
@@ -38,7 +38,9 @@
   }
  ],
  "metadata": {
-  "main_language": "python"
+  "jupytext": {
+   "main_language": "python"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/tests/notebooks/mirror/script_to_ipynb/julia_sample_script.ipynb
+++ b/tests/notebooks/mirror/script_to_ipynb/julia_sample_script.ipynb
@@ -78,9 +78,9 @@
  ],
  "metadata": {
   "jupytext": {
-   "encoding": "# -*- coding: utf-8 -*-"
-  },
-  "main_language": "julia"
+   "encoding": "# -*- coding: utf-8 -*-",
+   "main_language": "julia"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/tests/notebooks/mirror/script_to_ipynb/knitr-spin.ipynb
+++ b/tests/notebooks/mirror/script_to_ipynb/knitr-spin.ipynb
@@ -172,7 +172,9 @@
   }
  ],
  "metadata": {
-  "main_language": "R"
+  "jupytext": {
+   "main_language": "R"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/tests/notebooks/mirror/script_to_ipynb/light_sample.ipynb
+++ b/tests/notebooks/mirror/script_to_ipynb/light_sample.ipynb
@@ -22,12 +22,12 @@
  "metadata": {
   "jupytext": {
    "formats": "ipynb,py",
+   "main_language": "python",
    "text_representation": {
     "format_name": "light",
     "format_version": "1.2"
    }
-  },
-  "main_language": "python"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/tests/notebooks/mirror/script_to_ipynb/python_notebook_sample.ipynb
+++ b/tests/notebooks/mirror/script_to_ipynb/python_notebook_sample.ipynb
@@ -168,7 +168,9 @@
   }
  ],
  "metadata": {
-  "main_language": "python"
+  "jupytext": {
+   "main_language": "python"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/tests/notebooks/mirror/sphinx_to_ipynb/plot_notebook.ipynb
+++ b/tests/notebooks/mirror/sphinx_to_ipynb/plot_notebook.ipynb
@@ -123,8 +123,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "cell_marker": "##########################################################################",
-    "lines_to_next_cell": 2
+    "cell_marker": "##########################################################################"
    },
    "source": [
     "There's some subtle differences between rendered html rendered comment\n",
@@ -141,6 +140,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "\n",
     "def dummy():\n",
     "    \"\"\"Dummy function to make sure docstrings don't get rendered as text\"\"\"\n",
     "    pass\n",
@@ -210,9 +210,9 @@
  ],
  "metadata": {
   "jupytext": {
-   "encoding": "# -*- coding: utf-8 -*-"
-  },
-  "main_language": "python"
+   "encoding": "# -*- coding: utf-8 -*-",
+   "main_language": "python"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -223,3 +223,24 @@ def test_convert_to_percent_format(nb_file, tmpdir):
     nb2 = readf(tmp_nbpy)
 
     compare_notebooks(nb1, nb2)
+
+
+@pytest.mark.parametrize('nb_file', list_notebooks('ipynb_py'))
+def test_convert_to_percent_format_and_keep_magics(nb_file, tmpdir):
+    tmp_ipynb = str(tmpdir.join('notebook.ipynb'))
+    tmp_nbpy = str(tmpdir.join('notebook.py'))
+
+    copyfile(nb_file, tmp_ipynb)
+
+    with mock.patch('jupytext.header.INSERT_AND_CHECK_VERSION_NUMBER', True):
+        jupytext(['--to', 'py:percent', '--comment-magics', 'no', tmp_ipynb])
+
+    with open(tmp_nbpy) as stream:
+        py_script = stream.read()
+        assert 'format_name: percent' in py_script
+        assert '# %%time' not in py_script
+
+    nb1 = readf(tmp_ipynb)
+    nb2 = readf(tmp_nbpy)
+
+    compare_notebooks(nb1, nb2)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import os
+import stat
 from shutil import copyfile
 import pytest
 from testfixtures import compare
@@ -256,9 +257,13 @@ def test_pre_commit_hook(tmpdir):
 
     git('init')
     git('status')
-    with open(str(tmpdir.join('.git/hooks/pre-commit')), 'w') as fp:
+    hook = str(tmpdir.join('.git/hooks/pre-commit'))
+    with open(hook, 'w') as fp:
         fp.write('#!/bin/sh\n'
                  'jupytext --to py:light --pre-commit\n')
+
+    st = os.stat(hook)
+    os.chmod(hook, st.st_mode | stat.S_IEXEC)
 
     writef(nb, tmp_ipynb)
     assert os.path.isfile(tmp_ipynb)
@@ -291,10 +296,14 @@ def test_pre_commit_hook_py_to_ipynb_and_md(tmpdir):
 
     git('init')
     git('status')
-    with open(str(tmpdir.join('.git/hooks/pre-commit')), 'w') as fp:
+    hook = str(tmpdir.join('.git/hooks/pre-commit'))
+    with open(hook, 'w') as fp:
         fp.write('#!/bin/sh\n'
                  'jupytext --from py:light --to ipynb --pre-commit\n'
                  'jupytext --from py:light --to md --pre-commit\n')
+
+    st = os.stat(hook)
+    os.chmod(hook, st.st_mode | stat.S_IEXEC)
 
     writef(nb, tmp_py)
     assert os.path.isfile(tmp_py)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ import mock
 from nbformat.v4.nbbase import new_notebook
 from jupytext import header, __version__
 from jupytext import readf, writef, writes
-from jupytext.cli import convert_notebook_files, cli_jupytext, jupytext
+from jupytext.cli import convert_notebook_files, cli_jupytext, jupytext, system
 from jupytext.compare import compare_notebooks
 from .utils import list_notebooks
 
@@ -244,3 +244,76 @@ def test_convert_to_percent_format_and_keep_magics(nb_file, tmpdir):
     nb2 = readf(tmp_nbpy)
 
     compare_notebooks(nb1, nb2)
+
+
+def test_pre_commit_hook(tmpdir):
+    tmp_ipynb = str(tmpdir.join('notebook.ipynb'))
+    tmp_py = str(tmpdir.join('notebook.py'))
+    nb = new_notebook(cells=[])
+
+    def git(*args):
+        print(system('git', *args, cwd=str(tmpdir)))
+
+    git('init')
+    git('status')
+    with open(str(tmpdir.join('.git/hooks/pre-commit')), 'w') as fp:
+        fp.write('#!/bin/sh\n'
+                 'jupytext --to py:light --pre-commit\n')
+
+    writef(nb, tmp_ipynb)
+    assert os.path.isfile(tmp_ipynb)
+    assert not os.path.isfile(tmp_py)
+
+    git('add', 'notebook.ipynb')
+    git('status')
+    git('commit', '-m', 'created')
+    git('status')
+
+    assert os.path.isfile(tmp_py)
+
+    git('rm', 'notebook.ipynb')
+    git('status')
+    git('commit', '-m', 'deleted')
+    git('status')
+
+    assert not os.path.isfile(tmp_ipynb)
+    assert not os.path.isfile(tmp_py)
+
+
+def test_pre_commit_hook_py_to_ipynb_and_md(tmpdir):
+    tmp_ipynb = str(tmpdir.join('notebook.ipynb'))
+    tmp_py = str(tmpdir.join('notebook.py'))
+    tmp_md = str(tmpdir.join('notebook.md'))
+    nb = new_notebook(cells=[])
+
+    def git(*args):
+        print(system('git', *args, cwd=str(tmpdir)))
+
+    git('init')
+    git('status')
+    with open(str(tmpdir.join('.git/hooks/pre-commit')), 'w') as fp:
+        fp.write('#!/bin/sh\n'
+                 'jupytext --from py:light --to ipynb --pre-commit\n'
+                 'jupytext --from py:light --to md --pre-commit\n')
+
+    writef(nb, tmp_py)
+    assert os.path.isfile(tmp_py)
+    assert not os.path.isfile(tmp_ipynb)
+    assert not os.path.isfile(tmp_md)
+
+    git('add', 'notebook.py')
+    git('status')
+    git('commit', '-m', 'created')
+    git('status')
+
+    assert os.path.isfile(tmp_ipynb)
+    assert os.path.isfile(tmp_md)
+
+    git('rm', 'notebook.py')
+    git('status')
+    git('commit', '-m', 'deleted')
+    git('status')
+
+    assert not os.path.isfile(tmp_ipynb)
+    assert not os.path.isfile(tmp_py)
+    assert not os.path.isfile(tmp_md)

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -7,8 +7,10 @@ jupytext.header.INSERT_AND_CHECK_VERSION_NUMBER = False
 
 
 def test_raise_on_different_metadata():
-    ref = new_notebook(metadata={'language_info': {'name': 'python'}}, cells=[new_markdown_cell('Cell one')])
-    test = new_notebook(metadata={'language_info': {'name': 'R'}}, cells=[new_markdown_cell('Cell one')])
+    ref = new_notebook(metadata={'kernelspec': {'language': 'python', 'name': 'python', 'display_name': 'Python'}},
+                       cells=[new_markdown_cell('Cell one')])
+    test = new_notebook(metadata={'kernelspec': {'language': 'R', 'name': 'R', 'display_name': 'R'}},
+                        cells=[new_markdown_cell('Cell one')])
     with pytest.raises(NotebookDifference):
         compare_notebooks(ref, test, ext='.md')
 

--- a/tests/test_contentsmanager.py
+++ b/tests/test_contentsmanager.py
@@ -534,7 +534,7 @@ def test_save_in_pct_and_lgt_auto_extensions(nb_file, tmpdir):
         assert read_format_from_metadata(stream.read(), '.lgt' + auto_ext) == 'light'
 
 
-@pytest.mark.parametrize('nb_file', list_notebooks('ipynb'))
+@pytest.mark.parametrize('nb_file', list_notebooks('ipynb', skip='magic'))
 def test_metadata_filter_is_effective(nb_file, tmpdir):
     nb = jupytext.readf(nb_file)
     tmp_ipynb = 'notebook.ipynb'
@@ -550,7 +550,7 @@ def test_metadata_filter_is_effective(nb_file, tmpdir):
 
     # set config
     cm.default_jupytext_formats = 'ipynb, py'
-    cm.default_notebook_metadata_filter = 'language_info,jupytext,-all'
+    cm.default_notebook_metadata_filter = 'jupytext,-all'
     cm.default_cell_metadata_filter = '-all'
 
     # load notebook
@@ -558,7 +558,7 @@ def test_metadata_filter_is_effective(nb_file, tmpdir):
         nb = cm.get(tmp_ipynb)['content']
 
     assert nb.metadata['jupytext']['metadata_filter']['cells'] == {'excluded': 'all'}
-    assert nb.metadata['jupytext']['metadata_filter']['notebook'] == {'additional': ['language_info', 'jupytext'],
+    assert nb.metadata['jupytext']['metadata_filter']['notebook'] == {'additional': ['jupytext'],
                                                                       'excluded': 'all'}
 
     # save notebook again
@@ -570,7 +570,7 @@ def test_metadata_filter_is_effective(nb_file, tmpdir):
         nb2 = jupytext.readf(str(tmpdir.join(tmp_script)))
 
     # test no metadata
-    assert set(nb2.metadata.keys()) <= {'language_info', 'jupytext'}
+    assert set(nb2.metadata.keys()) <= {'jupytext'}
     for cell in nb2.cells:
         assert not cell.metadata
 

--- a/tests/test_contentsmanager.py
+++ b/tests/test_contentsmanager.py
@@ -47,6 +47,22 @@ def test_load_save_rename(nb_file, tmpdir):
     assert os.path.isfile(str(tmpdir.join('new.ipynb')))
     assert os.path.isfile(str(tmpdir.join('new.Rmd')))
 
+    # delete one file, test that we can still read and rename it
+    cm.delete('new.Rmd')
+    assert not os.path.isfile(str(tmpdir.join('new.Rmd')))
+    model = cm.get('new.ipynb', content=False)
+    assert 'last_modified' in model
+    cm.save(model=dict(type='notebook', content=nb), path='new.ipynb')
+    assert os.path.isfile(str(tmpdir.join('new.Rmd')))
+
+    cm.delete('new.Rmd')
+    cm.rename('new.ipynb', tmp_ipynb)
+
+    assert os.path.isfile(str(tmpdir.join(tmp_ipynb)))
+    assert not os.path.isfile(str(tmpdir.join(tmp_rmd)))
+    assert not os.path.isfile(str(tmpdir.join('new.ipynb')))
+    assert not os.path.isfile(str(tmpdir.join('new.Rmd')))
+
 
 @skip_if_dict_is_not_ordered
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_py'))

--- a/tests/test_contentsmanager.py
+++ b/tests/test_contentsmanager.py
@@ -328,7 +328,7 @@ def test_save_to_light_percent_sphinx_format(nb_file, tmpdir):
     # (notebooks not equal as we insert %matplotlib inline in sphinx)
 
     model = cm.get(path=tmp_ipynb)
-    assert model['name'] == 'notebook.pct'
+    assert model['name'] == 'notebook.ipynb'
     compare_notebooks(nb, model['content'])
 
 

--- a/tests/test_escape_magics.py
+++ b/tests/test_escape_magics.py
@@ -36,7 +36,7 @@ def test_force_noescape_with_gbl_esc_flag(line):
 
 @pytest.mark.parametrize('ext_and_format_name,commented',
                          zip(['md', 'Rmd', 'py:light', 'py:percent', 'py:sphinx', 'R', 'ss:light', 'ss:percent'],
-                             [False, True, True, False, True, True, True, False]))
+                             [False, True, True, True, True, True, True, True]))
 def test_magics_commented_default(ext_and_format_name, commented):
     ext, format_name = parse_one_format(ext_and_format_name)
     nb = new_notebook(cells=[new_code_cell('%pylab inline')])
@@ -99,9 +99,9 @@ def test_force_comment_using_contents_manager(tmpdir):
 
     cm.save(model=dict(type='notebook', content=nb), path=tmp_py)
     with open(str(tmpdir.join(tmp_py))) as stream:
-        assert '%pylab inline' in stream.read().splitlines()
+        assert '# %pylab inline' in stream.read().splitlines()
 
-    cm.comment_magics = True
+    cm.comment_magics = False
     cm.save(model=dict(type='notebook', content=nb), path=tmp_py)
     with open(str(tmpdir.join(tmp_py))) as stream:
-        assert '# %pylab inline' in stream.read().splitlines()
+        assert '%pylab inline' in stream.read().splitlines()

--- a/tests/test_read_simple_percent.py
+++ b/tests/test_read_simple_percent.py
@@ -48,7 +48,7 @@ def test_read_simple_file(script="""# ---
     compare(nb.cells[5].source, '''1 + 2 + 3 + 4
 5
 6
-# %%magic # this is a commented magic, not a cell
+%%magic # this is a commented magic, not a cell
 
 7''')
     assert nb.cells[5].metadata == {'title': 'And now a code cell'}


### PR DESCRIPTION
**Improvements**

- The `language_info` section is not part of the default header any more. Language information is now taken from metadata `kernelspec.language`. (#105).
- When opening a paired notebook, the active file is now the file that was originally opened (#118). When saving a notebook, timestamps of all the alternative representations are tested to ensure that Jupyter's autosave does not override manual modifications.
- Jupyter magic commands are now commented per default in the `percent` format (#126, #132). Version for the `percent` format increases from '1.1' to '1.2'. Set an option `comment_magics` to `false` either per notebook, or globally on Jupytext's contents manager, or on `jupytext`'s command line, if you prefer not to comment Jupyter magics.
- Jupytext command line has a pre-commit mode (#121).