### PR TITLE
Require pytest-cov==2.5.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 flake8
 pytest
-pytest-cov
+pytest-cov==2.5.1
 codecov
 notebook
 sphinx_gallery


### PR DESCRIPTION
Travis CI is currently failing with error message
```
Plugin 'pytest_cov' could not be loaded: (pytest 3.3.0 (/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages), Requirement.parse('pytest>=3.6'))!
```
As in the pytest-cov release notes I find the mention _Dropped support for Python < 3.4, Pytest < 3.5 and Coverage < 4.4_ for version 2.6, we'll try with the previous release.