### PR TITLE
1.1.0 rc1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ install:
   # install sphinx_gallery and matplotlib if available (may not work on pypy)
   - pip install sphinx_gallery || true
   # download and install pandoc 2.7.2
-  - pandoc -v
   - wget https://github.com/jgm/pandoc/releases/download/2.7.2/pandoc-2.7.2-linux.tar.gz
   - tar xvzf pandoc-2.7.2-linux.tar.gz
   - export PATH=pandoc-2.7.2/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,12 @@ install:
   - pip install autopep8 || true
   # install sphinx_gallery and matplotlib if available (may not work on pypy)
   - pip install sphinx_gallery || true
+  # download and install pandoc 2.7.2
+  - pandoc -v
+  - wget https://github.com/jgm/pandoc/releases/download/2.7.2/pandoc-2.7.2-linux.tar.gz
+  - tar xvzf pandoc-2.7.2-linux.tar.gz
+  - export PATH=pandoc-2.7.2/bin:$PATH
+  - pandoc -v
 before_script:
   # stop the build if there are Python syntax errors or undefined names
   - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "3.6"
   - "pypy"
+  - "2.6"
   - "2.7"
   - "3.4"
   - "3.5"
@@ -12,9 +13,27 @@ matrix:
       sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
 
 install:
-  # command to install dependencies
-  - pip install -r requirements-dev.txt
-  - pip install -r requirements.txt
+  # We use conda in order to install pandoc
+  # Actually, 2.6 here just means conda, with Python 3!
+  # https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/use-conda-with-travis-ci.html
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.6" ]]; then
+      sudo apt-get update;
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+      bash miniconda.sh -b -p $HOME/miniconda;
+      export PATH="$HOME/miniconda/bin:$PATH";
+      hash -r;
+      conda config --set always_yes yes --set changeps1 no;
+      conda update -q conda;
+      conda config --append channels conda-forge;
+      conda info -a;
+      conda create -q -n jupytext-env python=3 --file requirements-dev.txt --file requirements.txt;
+      source activate jupytext-env;
+      conda install pandoc codecov -c conda-forge;
+      pandoc -v;
+    else
+      pip install -r requirements-dev.txt;
+      pip install -r requirements.txt;
+    fi
   # install is required for testing the pre-commit mode
   - pip install .
   # install black if available (Python 3.6 and above), and autopep8 for testing the pipe mode
@@ -22,17 +41,13 @@ install:
   - pip install autopep8 || true
   # install sphinx_gallery and matplotlib if available (may not work on pypy)
   - pip install sphinx_gallery || true
-  # download and install pandoc 2.7.2
-  - wget https://github.com/jgm/pandoc/releases/download/2.7.2/pandoc-2.7.2-linux.tar.gz
-  - tar xvzf pandoc-2.7.2-linux.tar.gz
-  - PATH=pandoc-2.7.2/bin:$PATH pandoc -v
 before_script:
   # stop the build if there are Python syntax errors or undefined names
   - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   - flake8 . --count --exit-zero --max-complexity=10 --statistics
 script:
-  - PATH=pandoc-2.7.2/bin:$PATH coverage run --source=. -m py.test
+  - coverage run --source=. -m py.test
 after_success:
   - coverage report -m
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,15 +25,14 @@ install:
   # download and install pandoc 2.7.2
   - wget https://github.com/jgm/pandoc/releases/download/2.7.2/pandoc-2.7.2-linux.tar.gz
   - tar xvzf pandoc-2.7.2-linux.tar.gz
-  - export PATH=pandoc-2.7.2/bin:$PATH
-  - pandoc -v
+  - PATH=pandoc-2.7.2/bin:$PATH pandoc -v
 before_script:
   # stop the build if there are Python syntax errors or undefined names
   - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   - flake8 . --count --exit-zero --max-complexity=10 --statistics
 script:
-  - coverage run --source=. -m py.test
+  - PATH=pandoc-2.7.2/bin:$PATH coverage run --source=. -m py.test
 after_success:
   - coverage report -m
   - codecov

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,7 @@ Release History
 
 - Markdown and R Markdown formats now support metadata (#66, #111, #188)
 - The ``light`` format for Scripts can use custom cell markers, e.g. Vim or VScode/PyCharm folding markers (#199)
+- Pandoc's Markdown format for Jupyter notebooks is available in Jupytext as ``md:pandoc`` (#208)
 
 **BugFixes**
 

--- a/README.md
+++ b/README.md
@@ -347,6 +347,14 @@ When you open a plain Markdown file in Jupytext, the Markdown text is rendered i
 c.ContentsManager.split_at_heading = True
 ```
 
+### Pandoc's Markdown
+
+Pandoc, the _Universal document converter_, now has the ability to read Jupyter notebooks. Have a look at how notebooks are [represented](https://pandoc.org/MANUAL.html#creating-jupyter-notebooks-with-pandoc) in that format. This format is also available in Jupytext under the name `md:pandoc` when `jupytext` finds `pandoc` in version 2.7.2 or above.
+
+Please pay attention to the fact that `pandoc`, while preserving the HTML rendering, may reformat the text in some of your Markdown cells. If that is an issue for you, please wait for [jgm/pandoc#5408](https://github.com/jgm/pandoc/issues/5408).
+
+As for the other formats, the `md:pandoc` format in Jupytext can be paired to an `.ipynb` file. For this reason, `jupytext` discards the output cells before calling `pandoc`. If you would like to see the outputs cells in the Markdown file, please use `pandoc` directly.
+
 ### The `light` format for notebooks as scripts
 
 The `light` format was created for this project. It is the default format for scripts. That format can read any script as a Jupyter notebook, even scripts which were never prepared to become a notebook. When a notebook is written as a script using this format, only a few cells markers are introduced—none if possible.

--- a/README.md
+++ b/README.md
@@ -349,9 +349,9 @@ c.ContentsManager.split_at_heading = True
 
 ### Pandoc's Markdown
 
-Pandoc, the _Universal document converter_, now has the ability to read Jupyter notebooks. Have a look at how notebooks are [represented](https://pandoc.org/MANUAL.html#creating-jupyter-notebooks-with-pandoc) in that format. This format is also available in Jupytext under the name `md:pandoc` when `jupytext` finds `pandoc` in version 2.7.2 or above.
+Pandoc, the _Universal document converter_,  can now read and write Jupyter notebooks - see [Pandoc's documentation](https://pandoc.org/MANUAL.html#creating-jupyter-notebooks-with-pandoc). The format name for Pandoc's Markdown in Jupytext is `md:pandoc` (requires `pandoc` in version 2.7.2 or above).
 
-Please pay attention to the fact that `pandoc`, while preserving the HTML rendering, may reformat the text in some of your Markdown cells. If that is an issue for you, please wait for [jgm/pandoc#5408](https://github.com/jgm/pandoc/issues/5408).
+Pandoc's format has explicit cell markers. See for instance how our `World population.ipynb` notebook is [represented](https://github.com/mwouts/jupytext/blob/master/demo/World%20population.pandoc.md) in that format. Please also note that `pandoc`, while preserving the HTML rendering, may reformat the text in some of the Markdown cells. If that is an issue for you, please wait until [jgm/pandoc#5408](https://github.com/jgm/pandoc/issues/5408) gets implemented.
 
 As for the other formats, the `md:pandoc` format in Jupytext can be paired to an `.ipynb` file. For this reason, `jupytext` discards the output cells before calling `pandoc`. If you would like to see the outputs cells in the Markdown file, please use `pandoc` directly.
 

--- a/demo/World population.Rmd
+++ b/demo/World population.Rmd
@@ -1,12 +1,12 @@
 ---
 jupyter:
   jupytext:
-    formats: ipynb,.pct.py:percent,.lgt.py:light,.spx.py:sphinx,md,Rmd
+    formats: ipynb,.pct.py:percent,.lgt.py:light,.spx.py:sphinx,md,Rmd,.pandoc.md:pandoc
     text_representation:
       extension: .Rmd
       format_name: rmarkdown
-      format_version: '1.0'
-      jupytext_version: 1.0.0-dev
+      format_version: '1.1'
+      jupytext_version: 1.1.0-rc1
   kernelspec:
     display_name: Python 3
     language: python

--- a/demo/World population.lgt.py
+++ b/demo/World population.lgt.py
@@ -1,12 +1,12 @@
 # ---
 # jupyter:
 #   jupytext:
-#     formats: ipynb,.pct.py:percent,.lgt.py:light,.spx.py:sphinx,md,Rmd
+#     formats: ipynb,.pct.py:percent,.lgt.py:light,.spx.py:sphinx,md,Rmd,.pandoc.md:pandoc
 #     text_representation:
 #       extension: .py
 #       format_name: light
-#       format_version: '1.3'
-#       jupytext_version: 1.0.0-dev
+#       format_version: '1.4'
+#       jupytext_version: 1.1.0-rc1
 #   kernelspec:
 #     display_name: Python 3
 #     language: python

--- a/demo/World population.pandoc.md
+++ b/demo/World population.pandoc.md
@@ -1,18 +1,21 @@
 ---
 jupyter:
   jupytext:
-    formats: ipynb,.pct.py:percent,.lgt.py:light,.spx.py:sphinx,md,Rmd,.pandoc.md:pandoc
+    formats: 'ipynb,.pct.py:percent,.lgt.py:light,.spx.py:sphinx,md,Rmd,.pandoc.md:pandoc'
     text_representation:
-      extension: .md
-      format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.0-rc1
+      extension: '.md'
+      format_name: pandoc
+      format_version: '2.7.2'
+      jupytext_version: '1.1.0-rc1'
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
+  nbformat: 4
+  nbformat_minor: 2
 ---
 
+::: {.cell .markdown}
 # A quick insight at world population
 
 ## Collecting population data
@@ -20,27 +23,37 @@ jupyter:
 In the below we retrieve population data from the
 [World Bank](http://www.worldbank.org/)
 using the [wbdata](https://github.com/OliverSherouse/wbdata) python package
+:::
 
-```python
+::: {.cell .code}
+``` {.python}
 import pandas as pd
 import wbdata as wb
 
 pd.options.display.max_rows = 6
 pd.options.display.max_columns = 20
 ```
+:::
 
+::: {.cell .markdown}
 Corresponding indicator is found using search method - or, directly,
 the World Bank site.
+:::
 
-```python
+::: {.cell .code}
+``` {.python}
 wb.search_indicators('Population, total')  # SP.POP.TOTL
 # wb.search_indicators('area')
 # => https://data.worldbank.org/indicator is easier to use
 ```
+:::
 
+::: {.cell .markdown}
 Now we download the population data
+:::
 
-```python
+::: {.cell .code}
+``` {.python}
 indicators = {'SP.POP.TOTL': 'Population, total',
               'AG.SRF.TOTL.K2': 'Surface area (sq. km)',
               'AG.LND.TOTL.K2': 'Land area (sq. km)',
@@ -48,44 +61,66 @@ indicators = {'SP.POP.TOTL': 'Population, total',
 data = wb.get_dataframe(indicators, convert_date=True).sort_index()
 data
 ```
+:::
 
+::: {.cell .markdown}
 World is one of the countries
+:::
 
-```python
+::: {.cell .code}
+``` {.python}
 data.loc['World']
 ```
+:::
 
+::: {.cell .markdown}
 Can we classify over continents?
+:::
 
-```python
+::: {.cell .code}
+``` {.python}
 data.loc[(slice(None), '2017-01-01'), :]['Population, total'].dropna(
 ).sort_values().tail(60).index.get_level_values('country')
 ```
+:::
 
+::: {.cell .markdown}
 Extract zones manually (in order of increasing population)
+:::
 
-```python
+::: {.cell .code}
+``` {.python}
 zones = ['North America', 'Middle East & North Africa',
          'Latin America & Caribbean', 'Europe & Central Asia',
          'Sub-Saharan Africa', 'South Asia',
          'East Asia & Pacific'][::-1]
 ```
+:::
 
+::: {.cell .markdown}
 And extract population information (and check total is right)
+:::
 
-```python
+::: {.cell .code}
+``` {.python}
 population = data.loc[zones]['Population, total'].swaplevel().unstack()
 population = population[zones]
 assert all(data.loc['World']['Population, total'] == population.sum(axis=1))
 ```
+:::
 
+::: {.cell .markdown}
 ## Stacked area plot with matplotlib
+:::
 
-```python
+::: {.cell .code}
+``` {.python}
 import matplotlib.pyplot as plt
 ```
+:::
 
-```python
+::: {.cell .code}
+``` {.python}
 plt.clf()
 plt.figure(figsize=(10, 5), dpi=100)
 plt.stackplot(population.index, population.values.T / 1e9)
@@ -93,20 +128,27 @@ plt.legend(population.columns, loc='upper left')
 plt.ylabel('Population count (B)')
 plt.show()
 ```
+:::
 
+::: {.cell .markdown}
 ## Stacked bar plot with plotly
+:::
 
-```python
+::: {.cell .code}
+``` {.python}
 import plotly.offline as offline
 import plotly.graph_objs as go
 
 offline.init_notebook_mode()
 ```
+:::
 
-```python
+::: {.cell .code}
+``` {.python}
 data = [go.Scatter(x=population.index, y=population[zone], name=zone, stackgroup='World')
         for zone in zones]
 fig = go.Figure(data=data,
                 layout=go.Layout(title='World population'))
 offline.iplot(fig)
 ```
+:::

--- a/demo/World population.pct.py
+++ b/demo/World population.pct.py
@@ -1,12 +1,12 @@
 # ---
 # jupyter:
 #   jupytext:
-#     formats: ipynb,.pct.py:percent,.lgt.py:light,.spx.py:sphinx,md,Rmd
+#     formats: ipynb,.pct.py:percent,.lgt.py:light,.spx.py:sphinx,md,Rmd,.pandoc.md:pandoc
 #     text_representation:
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.2'
-#       jupytext_version: 1.0.0-dev
+#       jupytext_version: 1.1.0-rc1
 #   kernelspec:
 #     display_name: Python 3
 #     language: python

--- a/demo/World population.spx.py
+++ b/demo/World population.spx.py
@@ -1,12 +1,12 @@
 # ---
 # jupyter:
 #   jupytext:
-#     formats: ipynb,.pct.py:percent,.lgt.py:light,.spx.py:sphinx,md,Rmd
+#     formats: ipynb,.pct.py:percent,.lgt.py:light,.spx.py:sphinx,md,Rmd,.pandoc.md:pandoc
 #     text_representation:
 #       extension: .py
 #       format_name: sphinx
 #       format_version: '1.1'
-#       jupytext_version: 1.0.0-dev
+#       jupytext_version: 1.1.0-rc1
 #   kernelspec:
 #     display_name: Python 3
 #     language: python

--- a/jupytext/cell_reader.py
+++ b/jupytext/cell_reader.py
@@ -440,7 +440,7 @@ class LightScriptCellReader(ScriptCellReader):
         script = _SCRIPT_EXTENSIONS[self.ext]
         self.default_language = default_language or script['language']
         self.comment = script['comment']
-        if fmt and 'cell_markers' in fmt:
+        if fmt and 'cell_markers' in fmt and fmt['cell_markers'] != '+,-':
             self.cell_marker_start, self.cell_marker_end = fmt['cell_markers'].split(',', 1)
             self.start_code_re = re.compile('^' + self.comment + r'\s*' + self.cell_marker_start + r'\s*(.*)$')
         else:

--- a/jupytext/cell_to_text.py
+++ b/jupytext/cell_to_text.py
@@ -201,7 +201,8 @@ class LightScriptCellExporter(BaseCellExporter):
     def __init__(self, *args, **kwargs):
         BaseCellExporter.__init__(self, *args, **kwargs)
         if 'cell_markers' in self.fmt:
-            self.cell_marker_start, self.cell_marker_end = self.fmt['cell_markers'].split(',', 1)
+            if self.fmt['cell_markers'] != '+,-':
+                self.cell_marker_start, self.cell_marker_end = self.fmt['cell_markers'].split(',', 1)
         for key in ['endofcell']:
             if key in self.unfiltered_metadata:
                 self.metadata[key] = self.unfiltered_metadata[key]

--- a/jupytext/cell_to_text.py
+++ b/jupytext/cell_to_text.py
@@ -261,6 +261,12 @@ class LightScriptCellExporter(BaseCellExporter):
             return False
         if self.metadata:
             return True
+        if self.cell_marker_start:
+            start_code_re = re.compile('^' + self.comment + r'\s*' + self.cell_marker_start + r'\s*(.*)$')
+            end_code_re = re.compile('^' + self.comment + r'\s*' + self.cell_marker_end + r'\s*$')
+            if start_code_re.match(source[0]) or end_code_re.match(source[0]):
+                return False
+
         if all([line.startswith(self.comment) for line in self.source]):
             return True
         if LightScriptCellReader(self.fmt).read(source)[1] < len(source):

--- a/jupytext/cli.py
+++ b/jupytext/cli.py
@@ -248,7 +248,8 @@ def jupytext(args=None):
         if args.update_metadata:
             log('[jupytext] Updating notebook metadata with {}'.format(args.update_metadata))
             # Are we updating a text file that has a metadata filter? #212
-            if ext != '.ipynb' and notebook.metadata.get('jupytext', {}).get('notebook_metadata_filter') == '-all':
+            if fmt['extension'] != '.ipynb' and \
+                    notebook.metadata.get('jupytext', {}).get('notebook_metadata_filter') == '-all':
                 notebook.metadata.get('jupytext', {}).pop('notebook_metadata_filter')
             recursive_update(notebook.metadata, args.update_metadata)
 

--- a/jupytext/cli.py
+++ b/jupytext/cli.py
@@ -247,6 +247,9 @@ def jupytext(args=None):
         # Update the metadata
         if args.update_metadata:
             log('[jupytext] Updating notebook metadata with {}'.format(args.update_metadata))
+            # Are we updating a text file that has a metadata filter? #212
+            if ext != '.ipynb' and notebook.metadata.get('jupytext', {}).get('notebook_metadata_filter') == '-all':
+                notebook.metadata.get('jupytext', {}).pop('notebook_metadata_filter')
             recursive_update(notebook.metadata, args.update_metadata)
 
         # Read paired notebooks

--- a/jupytext/combine.py
+++ b/jupytext/combine.py
@@ -13,7 +13,7 @@ _BLANK_LINE = re.compile(r'^\s*$')
 def black_invariant(text, chars=None):
     """Remove characters that may be changed when reformatting the text with black"""
     if chars is None:
-        chars = [' ', '\n', ',', "'", '"', '(', ')', '\\']
+        chars = [' ', '\t', '\n', ',', "'", '"', '(', ')', '\\']
 
     for char in chars:
         text = text.replace(char, '')

--- a/jupytext/compare.py
+++ b/jupytext/compare.py
@@ -82,7 +82,6 @@ def compare_notebooks(notebook_expected,
     allow_missing_code_cell_metadata = allow_expected_differences and format_name == 'sphinx'
     allow_missing_markdown_cell_metadata = allow_expected_differences and format_name in ['sphinx', 'spin']
     allow_removed_final_blank_line = allow_expected_differences
-    replace_tabs_with_spaces = format_name == 'pandoc'
 
     cell_metadata_filter = notebook_actual.get('jupytext', {}).get('cell_metadata_filter')
 
@@ -94,9 +93,6 @@ def compare_notebooks(notebook_expected,
     modified_cells = set()
     modified_cell_metadata = set()
     for i, ref_cell in enumerate(notebook_expected.cells, 1):
-        if replace_tabs_with_spaces and '\t' in ref_cell.source:
-            ref_cell = copy(ref_cell)
-            ref_cell.source = ref_cell.source.replace('\t', '    ')
         try:
             test_cell = next(test_cell_iter)
         except StopIteration:

--- a/jupytext/compare.py
+++ b/jupytext/compare.py
@@ -82,6 +82,7 @@ def compare_notebooks(notebook_expected,
     allow_missing_code_cell_metadata = allow_expected_differences and format_name == 'sphinx'
     allow_missing_markdown_cell_metadata = allow_expected_differences and format_name in ['sphinx', 'spin']
     allow_removed_final_blank_line = allow_expected_differences
+    replace_tabs_with_spaces = format_name == 'pandoc'
 
     cell_metadata_filter = notebook_actual.get('jupytext', {}).get('cell_metadata_filter')
 
@@ -93,6 +94,9 @@ def compare_notebooks(notebook_expected,
     modified_cells = set()
     modified_cell_metadata = set()
     for i, ref_cell in enumerate(notebook_expected.cells, 1):
+        if replace_tabs_with_spaces and '\t' in ref_cell.source:
+            ref_cell = copy(ref_cell)
+            ref_cell.source = ref_cell.source.replace('\t', '    ')
         try:
             test_cell = next(test_cell_iter)
         except StopIteration:

--- a/jupytext/contentsmanager.py
+++ b/jupytext/contentsmanager.py
@@ -193,7 +193,7 @@ class TextFileContentsManager(LargeFileManager, Configurable):
             format_options.setdefault('comment_magics', self.comment_magics)
         if self.split_at_heading:
             format_options.setdefault('split_at_heading', self.split_at_heading)
-        if self.default_cell_markers:
+        if not read and self.default_cell_markers:
             format_options.setdefault('cell_markers', self.default_cell_markers)
         if read and self.sphinx_convert_rst2md:
             format_options.setdefault('rst2md', self.sphinx_convert_rst2md)

--- a/jupytext/formats.py
+++ b/jupytext/formats.py
@@ -162,7 +162,7 @@ def get_format_implementation(ext, format_name=None):
 
     if formats_for_extension:
         if ext == '.md' and format_name == 'pandoc':
-            raise JupytextFormatError('Please install pandoc>=2.7.1')
+            raise JupytextFormatError('Please install pandoc>=2.7.2')
 
         raise JupytextFormatError("Format '{}' is not associated to extension '{}'. "
                                   "Please choose one of: {}.".format(format_name, ext,
@@ -270,7 +270,7 @@ def guess_format(text, ext):
     if ext == '.md':
         for line in lines:
             if line.startswith(':::'):  # Pandoc div
-                return 'pandoc'
+                return 'pandoc', {}
 
     # Default format
     return get_format_implementation(ext).format_name, {}

--- a/jupytext/formats.py
+++ b/jupytext/formats.py
@@ -493,8 +493,9 @@ def short_form_one_format(jupytext_format):
     if 'prefix' in jupytext_format:
         fmt = jupytext_format['prefix'] + '/' + fmt
 
-    if jupytext_format.get('format_name') and jupytext_format['extension'] not in ['.md', '.Rmd']:
-        fmt = fmt + ':' + jupytext_format['format_name']
+    if jupytext_format.get('format_name'):
+        if jupytext_format['extension'] not in ['.md', '.Rmd'] or jupytext_format['format_name'] == 'pandoc':
+            fmt = fmt + ':' + jupytext_format['format_name']
 
     return fmt
 

--- a/jupytext/formats.py
+++ b/jupytext/formats.py
@@ -16,6 +16,7 @@ from .cell_to_text import MarkdownCellExporter, RMarkdownCellExporter, \
 from .metadata_filter import metadata_filter_as_string
 from .stringparser import StringParser
 from .languages import _SCRIPT_EXTENSIONS, _COMMENT_CHARS
+from .pandoc import pandoc_version, is_pandoc_available
 
 
 class JupytextFormatError(ValueError):
@@ -134,6 +135,15 @@ JUPYTEXT_FORMATS = \
             current_version_number='1.1')
     ]
 
+if is_pandoc_available():
+    JUPYTEXT_FORMATS.append(NotebookFormatDescription(
+        format_name='pandoc',
+        extension='.md',
+        header_prefix='',
+        cell_reader_class=None,
+        cell_exporter_class=None,
+        current_version_number=pandoc_version()))
+
 NOTEBOOK_EXTENSIONS = list(dict.fromkeys(['.ipynb'] + [fmt.extension for fmt in JUPYTEXT_FORMATS]))
 EXTENSION_PREFIXES = ['.lgt', '.spx', '.pct', '.hyd', '.nb']
 
@@ -151,6 +161,9 @@ def get_format_implementation(ext, format_name=None):
             formats_for_extension.append(fmt.format_name)
 
     if formats_for_extension:
+        if ext == '.md' and format_name == 'pandoc':
+            raise JupytextFormatError('Please install pandoc>=2.7.1')
+
         raise JupytextFormatError("Format '{}' is not associated to extension '{}'. "
                                   "Please choose one of: {}.".format(format_name, ext,
                                                                      ', '.join(formats_for_extension)))
@@ -253,6 +266,11 @@ def guess_format(text, ext):
 
         if rspin_comment_count >= 1:
             return 'spin', {}
+
+    if ext == '.md':
+        for line in lines:
+            if line.startswith(':::'):  # Pandoc div
+                return 'pandoc'
 
     # Default format
     return get_format_implementation(ext).format_name, {}

--- a/jupytext/pandoc.py
+++ b/jupytext/pandoc.py
@@ -33,7 +33,7 @@ def pandoc(args, filein=None, fileout=None):
 
 
 def is_pandoc_available():
-    """Is Pandoc>=2.7.1 available?"""
+    """Is Pandoc>=2.7.2 available?"""
     try:
         pandoc_version()
         return True
@@ -44,8 +44,8 @@ def is_pandoc_available():
 def pandoc_version():
     """Pandoc's version number"""
     version = pandoc(u'--version').splitlines()[0].split()[1]
-    if parse_version(version) < parse_version('2.7.1'):
-        raise PandocError('Please install pandoc>=2.7.1 (found version {})'.format(version))
+    if parse_version(version) < parse_version('2.7.2'):
+        raise PandocError('Please install pandoc>=2.7.2 (found version {})'.format(version))
 
     return version
 
@@ -56,7 +56,7 @@ def md_to_notebook(text):
     tmp_file.write(text.encode('utf-8'))
     tmp_file.close()
 
-    pandoc(u'--from markdown --to ipynb -s --atx-headers --wrap=preserve', tmp_file.name, tmp_file.name)
+    pandoc(u'--from markdown --to ipynb -s --atx-headers --wrap=preserve --preserve-tabs', tmp_file.name, tmp_file.name)
 
     with open(tmp_file.name, encoding='utf-8') as opened_file:
         notebook = nbformat.read(opened_file, as_version=4)
@@ -71,7 +71,7 @@ def notebook_to_md(notebook):
     tmp_file.write(nbformat.writes(notebook).encode('utf-8'))
     tmp_file.close()
 
-    pandoc(u'--from ipynb --to markdown -s --atx-headers --wrap=preserve', tmp_file.name, tmp_file.name)
+    pandoc(u'--from ipynb --to markdown -s --atx-headers --wrap=preserve --preserve-tabs', tmp_file.name, tmp_file.name)
 
     with open(tmp_file.name, encoding='utf-8') as opened_file:
         text = opened_file.read()

--- a/jupytext/pandoc.py
+++ b/jupytext/pandoc.py
@@ -1,0 +1,80 @@
+"""Jupyter notebook to Markdown and back, using Pandoc"""
+
+import os
+import subprocess
+import tempfile
+import nbformat
+from pkg_resources import parse_version
+
+
+class PandocError(OSError):
+    """An error related to Pandoc"""
+    pass
+
+
+def pandoc(args, filein=None, fileout=None):
+    """Execute pandoc with the given arguments"""
+    cmd = [u'pandoc']
+
+    if filein:
+        cmd.append(filein)
+
+    if fileout:
+        cmd.append('-o')
+        cmd.append(fileout)
+
+    cmd.extend(args.split())
+
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+    out, err = proc.communicate()
+    if proc.returncode:
+        raise PandocError('pandoc exited with return code {}\n{}'.format(proc.returncode, str(err)))
+    return out.decode('utf-8')
+
+
+def is_pandoc_available():
+    """Is Pandoc>=2.7.1 available?"""
+    try:
+        pandoc_version()
+        return True
+    except (IOError, OSError, PandocError):
+        return False
+
+
+def pandoc_version():
+    """Pandoc's version number"""
+    version = pandoc(u'--version').splitlines()[0].split()[1]
+    if parse_version(version) < parse_version('2.7.1'):
+        raise PandocError('Please install pandoc>=2.7.1 (found version {})'.format(version))
+
+    return version
+
+
+def md_to_notebook(text):
+    """Convert a Markdown text to a Jupyter notebook, using Pandoc"""
+    tmp_file = tempfile.NamedTemporaryFile(delete=False)
+    tmp_file.write(text.encode('utf-8'))
+    tmp_file.close()
+
+    pandoc(u'--from markdown --to ipynb -s --atx-headers --wrap=preserve', tmp_file.name, tmp_file.name)
+
+    with open(tmp_file.name, encoding='utf-8') as opened_file:
+        notebook = nbformat.read(opened_file, as_version=4)
+    os.unlink(tmp_file.name)
+
+    return notebook
+
+
+def notebook_to_md(notebook):
+    """Convert a notebook to its Markdown representation, using Pandoc"""
+    tmp_file = tempfile.NamedTemporaryFile(delete=False)
+    tmp_file.write(nbformat.writes(notebook).encode('utf-8'))
+    tmp_file.close()
+
+    pandoc(u'--from ipynb --to markdown -s --atx-headers --wrap=preserve', tmp_file.name, tmp_file.name)
+
+    with open(tmp_file.name, encoding='utf-8') as opened_file:
+        text = opened_file.read()
+
+    os.unlink(tmp_file.name)
+    return '\n'.join(text.splitlines())

--- a/jupytext/pandoc.py
+++ b/jupytext/pandoc.py
@@ -9,7 +9,6 @@ from pkg_resources import parse_version
 
 class PandocError(OSError):
     """An error related to Pandoc"""
-    pass
 
 
 def pandoc(args, filein=None, fileout=None):

--- a/jupytext/version.py
+++ b/jupytext/version.py
@@ -1,3 +1,3 @@
 """Jupytext's version number"""
 
-__version__ = '1.1.0-rc0'
+__version__ = '1.1.0-rc1'

--- a/tests/notebooks/ipynb_py/The flavors of raw cells.ipynb
+++ b/tests/notebooks/ipynb_py/The flavors of raw cells.ipynb
@@ -1,0 +1,78 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/latex"
+   },
+   "source": [
+    "$1+1$"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    ":math:`1+1`"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/html"
+   },
+   "source": [
+    "<b>Bold text<b>"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/markdown"
+   },
+   "source": [
+    "**Bold text**"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/x-python"
+   },
+   "source": [
+    "1 + 1"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Not formatted"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Format de la Cellule Texte Brut",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/notebooks/mirror/ipynb_to_Rmd/The flavors of raw cells.Rmd
+++ b/tests/notebooks/mirror/ipynb_to_Rmd/The flavors of raw cells.Rmd
@@ -1,0 +1,31 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+---
+
+```{python raw_mimetype=text/latex, active="", eval=FALSE}
+$1+1$
+```
+
+```{python raw_mimetype=text/restructuredtext, active="", eval=FALSE}
+:math:`1+1`
+```
+
+```{python raw_mimetype=text/html, active="", eval=FALSE}
+<b>Bold text<b>
+```
+
+```{python raw_mimetype=text/markdown, active="", eval=FALSE}
+**Bold text**
+```
+
+```{python raw_mimetype=text/x-python, active="", eval=FALSE}
+1 + 1
+```
+
+```{python active="", eval=FALSE}
+Not formatted
+```

--- a/tests/notebooks/mirror/ipynb_to_hydrogen/The flavors of raw cells.py
+++ b/tests/notebooks/mirror/ipynb_to_hydrogen/The flavors of raw cells.py
@@ -1,0 +1,25 @@
+# ---
+# jupyter:
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# %% [raw] {"raw_mimetype": "text/latex"}
+# $1+1$
+
+# %% [raw] {"raw_mimetype": "text/restructuredtext"}
+# :math:`1+1`
+
+# %% [raw] {"raw_mimetype": "text/html"}
+# <b>Bold text<b>
+
+# %% [raw] {"raw_mimetype": "text/markdown"}
+# **Bold text**
+
+# %% [raw] {"raw_mimetype": "text/x-python"}
+# 1 + 1
+
+# %% [raw]
+# Not formatted

--- a/tests/notebooks/mirror/ipynb_to_md/The flavors of raw cells.md
+++ b/tests/notebooks/mirror/ipynb_to_md/The flavors of raw cells.md
@@ -1,0 +1,31 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+---
+
+```raw_mimetype="text/latex"
+$1+1$
+```
+
+```raw_mimetype="text/restructuredtext"
+:math:`1+1`
+```
+
+```raw_mimetype="text/html"
+<b>Bold text<b>
+```
+
+```raw_mimetype="text/markdown"
+**Bold text**
+```
+
+```raw_mimetype="text/x-python"
+1 + 1
+```
+
+```
+Not formatted
+```

--- a/tests/notebooks/mirror/ipynb_to_pandoc/Notebook with function and cell metadata 164.md
+++ b/tests/notebooks/mirror/ipynb_to_pandoc/Notebook with function and cell metadata 164.md
@@ -1,0 +1,43 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+  nbformat: 4
+  nbformat_minor: 2
+---
+
+::: {.cell .code}
+``` {.python}
+1 + 1
+```
+:::
+
+::: {.cell .markdown}
+A markdown cell
+And below, the cell for function f has non trivial cell metadata. And the next cell as well.
+:::
+
+::: {.cell .code attributes="{\"n\":\"10\",\"id\":\"\",\"classes\":[]}"}
+``` {.python}
+def f(x):
+    return x
+```
+:::
+
+::: {.cell .code attributes="{\"n\":\"10\",\"id\":\"\",\"classes\":[]}"}
+``` {.python}
+f(5)
+```
+:::
+
+::: {.cell .markdown}
+More text
+:::
+
+::: {.cell .code}
+``` {.python}
+2 + 2
+```
+:::

--- a/tests/notebooks/mirror/ipynb_to_pandoc/Notebook with html and latex cells.md
+++ b/tests/notebooks/mirror/ipynb_to_pandoc/Notebook with html and latex cells.md
@@ -1,0 +1,45 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+  nbformat: 4
+  nbformat_minor: 2
+---
+
+::: {.cell .code}
+``` {.python}
+%%html
+<p><a href="https://github.com/mwouts/jupytext", style="color: rgb(0,0,255)">Jupytext</a> on GitHub</p>
+```
+:::
+
+::: {.cell .code}
+``` {.python}
+%%latex
+$\frac{\pi}{2}$
+```
+:::
+
+::: {.cell .code}
+``` {.python}
+%load_ext rpy2.ipython
+```
+:::
+
+::: {.cell .code}
+``` {.python}
+%%R
+library(ggplot2)
+ggplot(data=data.frame(x=c('A', 'B'), y=c(5, 2)), aes(x,weight=y)) + geom_bar()
+```
+:::
+
+::: {.cell .code}
+``` {.python}
+%matplotlib inline
+import pandas as pd
+pd.Series({'A':5, 'B':2}).plot(figsize=(3,2), kind='bar')
+```
+:::

--- a/tests/notebooks/mirror/ipynb_to_pandoc/Notebook with many hash signs.md
+++ b/tests/notebooks/mirror/ipynb_to_pandoc/Notebook with many hash signs.md
@@ -1,0 +1,40 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+  nbformat: 4
+  nbformat_minor: 2
+---
+
+::: {.cell .markdown}
+################################################################## 
+
+This is a notebook that contains many hash signs.
+Hopefully its python representation is not recognized as a Sphinx Gallery script\...
+
+################################################################## 
+:::
+
+::: {.cell .code}
+``` {.python}
+some = 1
+code = 2
+some+code
+
+##################################################################
+# A comment
+##################################################################
+# Another comment
+```
+:::
+
+::: {.cell .markdown}
+##################################################################  {#section}
+
+This is a notebook that contains many hash signs.
+Hopefully its python representation is not recognized as a Sphinx Gallery script\...
+
+##################################################################  {#section-1}
+:::

--- a/tests/notebooks/mirror/ipynb_to_pandoc/Notebook with metadata and long cells.md
+++ b/tests/notebooks/mirror/ipynb_to_pandoc/Notebook with metadata and long cells.md
@@ -1,0 +1,71 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+  nbformat: 4
+  nbformat_minor: 2
+---
+
+::: {.cell .markdown}
+# Part one - various cells
+:::
+
+::: {.cell .markdown}
+Here we have a markdown cell
+
+with two blank lines
+:::
+
+::: {.cell .markdown}
+Now we have a markdown cell
+with a code block inside it
+
+``` {.python}
+1 + 1
+```
+
+After that cell we\'ll have a code cell
+:::
+
+::: {.cell .code}
+``` {.python}
+2 + 2
+
+
+3 + 3
+```
+:::
+
+::: {.cell .markdown}
+Followed by a raw cell
+:::
+
+::: {.cell .raw}
+```{=ipynb}
+This is 
+the content
+of the raw cell
+```
+:::
+
+::: {.cell .markdown}
+# Part two - cell metadata
+:::
+
+::: {.cell .markdown key="value"}
+This is a markdown cell with cell metadata `{"key": "value"}`
+:::
+
+::: {.cell .code .class="null" tags="[\"parameters\"]"}
+``` {.python}
+"""This is a code cell with metadata `{"tags":["parameters"], ".class":null}`"""
+```
+:::
+
+::: {.cell .raw key="value"}
+```{=ipynb}
+This is a raw cell with cell metadata `{"key": "value"}`
+```
+:::

--- a/tests/notebooks/mirror/ipynb_to_pandoc/Notebook_with_R_magic.md
+++ b/tests/notebooks/mirror/ipynb_to_pandoc/Notebook_with_R_magic.md
@@ -1,0 +1,46 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Python 2
+    language: python
+    name: python2
+  nbformat: 4
+  nbformat_minor: 2
+---
+
+::: {.cell .markdown}
+# A notebook with R cells
+
+This notebook shows the use of R cells to generate plots
+:::
+
+::: {.cell .code}
+``` {.python}
+%load_ext rpy2.ipython
+```
+:::
+
+::: {.cell .code}
+``` {.python}
+%%R
+suppressMessages(require(tidyverse))
+```
+:::
+
+::: {.cell .code}
+``` {.python}
+%%R
+ggplot(iris, aes(x = Sepal.Length, y = Petal.Length, color=Species)) + geom_point()
+```
+:::
+
+::: {.cell .markdown}
+The default plot dimensions are not good for us, so we use the -w and -h parameters in %%R magic to set the plot size
+:::
+
+::: {.cell .code}
+``` {.python}
+%%R -w 400 -h 240
+ggplot(iris, aes(x = Sepal.Length, y = Petal.Length, color=Species)) + geom_point()
+```
+:::

--- a/tests/notebooks/mirror/ipynb_to_pandoc/Notebook_with_more_R_magic_111.md
+++ b/tests/notebooks/mirror/ipynb_to_pandoc/Notebook_with_more_R_magic_111.md
@@ -1,0 +1,33 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+  nbformat: 4
+  nbformat_minor: 2
+---
+
+::: {.cell .code}
+``` {.python}
+%load_ext rpy2.ipython
+import pandas as pd
+
+df = pd.DataFrame(
+    {
+        "Letter": ["a", "a", "a", "b", "b", "b", "c", "c", "c"],
+        "X": [4, 3, 5, 2, 1, 7, 7, 5, 9],
+        "Y": [0, 4, 3, 6, 7, 10, 11, 9, 13],
+        "Z": [1, 2, 3, 1, 2, 3, 1, 2, 3],
+    }
+)
+```
+:::
+
+::: {.cell .code}
+``` {.python}
+%%R -i df
+library("ggplot2")
+ggplot(data = df) + geom_point(aes(x = X, y = Y, color = Letter, size = Z))
+```
+:::

--- a/tests/notebooks/mirror/ipynb_to_pandoc/World population.md
+++ b/tests/notebooks/mirror/ipynb_to_pandoc/World population.md
@@ -1,0 +1,155 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+  nbformat: 4
+  nbformat_minor: 2
+---
+
+::: {.cell .markdown}
+# A quick insight at world population
+
+## Collecting population data
+
+In the below we retrieve population data from the
+[World Bank](http://www.worldbank.org/)
+using the [wbdata](https://github.com/OliverSherouse/wbdata) python package
+:::
+
+::: {.cell .code}
+``` {.python}
+import pandas as pd
+import wbdata as wb
+
+pd.options.display.max_rows = 6
+pd.options.display.max_columns = 20
+```
+:::
+
+::: {.cell .markdown}
+Corresponding indicator is found using search method - or, directly,
+the World Bank site.
+:::
+
+::: {.cell .code}
+``` {.python}
+wb.search_indicators('Population, total')  # SP.POP.TOTL
+# wb.search_indicators('area')
+# => https://data.worldbank.org/indicator is easier to use
+```
+:::
+
+::: {.cell .markdown}
+Now we download the population data
+:::
+
+::: {.cell .code}
+``` {.python}
+indicators = {'SP.POP.TOTL': 'Population, total',
+              'AG.SRF.TOTL.K2': 'Surface area (sq. km)',
+              'AG.LND.TOTL.K2': 'Land area (sq. km)',
+              'AG.LND.ARBL.ZS': 'Arable land (% of land area)'}
+data = wb.get_dataframe(indicators, convert_date=True).sort_index()
+data
+```
+:::
+
+::: {.cell .markdown}
+World is one of the countries
+:::
+
+::: {.cell .code}
+``` {.python}
+data.loc['World']
+```
+:::
+
+::: {.cell .markdown}
+Can we classify over continents?
+:::
+
+::: {.cell .code}
+``` {.python}
+data.loc[(slice(None), '2017-01-01'), :]['Population, total'].dropna(
+).sort_values().tail(60).index.get_level_values('country')
+```
+:::
+
+::: {.cell .markdown}
+Extract zones manually (in order of increasing population)
+:::
+
+::: {.cell .code}
+``` {.python}
+zones = ['North America', 'Middle East & North Africa',
+         'Latin America & Caribbean', 'Europe & Central Asia',
+         'Sub-Saharan Africa', 'South Asia',
+         'East Asia & Pacific'][::-1]
+```
+:::
+
+::: {.cell .markdown}
+And extract population information (and check total is right)
+:::
+
+::: {.cell .code}
+``` {.python}
+population = data.loc[zones]['Population, total'].swaplevel().unstack()
+population = population[zones]
+assert all(data.loc['World']['Population, total'] == population.sum(axis=1))
+```
+:::
+
+::: {.cell .markdown}
+## Stacked area plot with matplotlib
+:::
+
+::: {.cell .code}
+``` {.python}
+import matplotlib.pyplot as plt
+```
+:::
+
+::: {.cell .code}
+``` {.python}
+plt.clf()
+plt.figure(figsize=(10, 5), dpi=100)
+plt.stackplot(population.index, population.values.T / 1e9)
+plt.legend(population.columns, loc='upper left')
+plt.ylabel('Population count (B)')
+plt.show()
+```
+:::
+
+::: {.cell .markdown}
+## Stacked bar plot with plotly
+:::
+
+::: {.cell .markdown}
+Stacked area plots (with cumulated values computed depending on
+selected legends) are
+[on their way](https://github.com/plotly/plotly.js/pull/2960) at Plotly. For
+now we just do a stacked bar plot.
+:::
+
+::: {.cell .code}
+``` {.python}
+import plotly.offline as offline
+import plotly.graph_objs as go
+
+offline.init_notebook_mode()
+```
+:::
+
+::: {.cell .code}
+``` {.python}
+bars = [go.Bar(x=population.index, y=population[zone], name=zone)
+        for zone in zones]
+fig = go.Figure(data=bars,
+                layout=go.Layout(title='World population',
+                                 barmode='stack'))
+offline.iplot(fig)
+```
+:::

--- a/tests/notebooks/mirror/ipynb_to_pandoc/convert_to_py_then_test_with_update83.md
+++ b/tests/notebooks/mirror/ipynb_to_pandoc/convert_to_py_then_test_with_update83.md
@@ -1,0 +1,26 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+  nbformat: 4
+  nbformat_minor: 2
+---
+
+::: {.cell .code}
+``` {.python}
+%%time
+
+print('asdf')
+```
+:::
+
+::: {.cell .markdown}
+Thanks for jupytext!
+:::
+
+::: {.cell .code}
+``` {.python}
+```
+:::

--- a/tests/notebooks/mirror/ipynb_to_pandoc/frozen_cell.md
+++ b/tests/notebooks/mirror/ipynb_to_pandoc/frozen_cell.md
@@ -1,0 +1,23 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+  nbformat: 4
+  nbformat_minor: 2
+---
+
+::: {.cell .code}
+``` {.python}
+# This is an unfrozen cell. Works as usual.
+print("I'm a regular cell so I run and print!")
+```
+:::
+
+::: {.cell .code deletable="false" editable="false" run_control="{\"frozen\":true}"}
+``` {.python}
+# This is an frozen cell
+print("I'm frozen so Im not executed :(")
+```
+:::

--- a/tests/notebooks/mirror/ipynb_to_pandoc/ir_notebook.md
+++ b/tests/notebooks/mirror/ipynb_to_pandoc/ir_notebook.md
@@ -1,0 +1,30 @@
+---
+jupyter:
+  kernelspec:
+    display_name: R
+    language: R
+    name: ir
+  nbformat: 4
+  nbformat_minor: 2
+---
+
+::: {.cell .markdown}
+This is a jupyter notebook that uses the IR kernel.
+:::
+
+::: {.cell .code}
+``` {.R}
+sum(1:10)
+```
+:::
+
+::: {.cell .code}
+``` {.R}
+plot(cars)
+```
+:::
+
+::: {.cell .code}
+``` {.R}
+```
+:::

--- a/tests/notebooks/mirror/ipynb_to_pandoc/julia_benchmark_plotly_barchart.md
+++ b/tests/notebooks/mirror/ipynb_to_pandoc/julia_benchmark_plotly_barchart.md
@@ -1,0 +1,113 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+  nbformat: 4
+  nbformat_minor: 2
+---
+
+::: {.cell .code}
+``` {.python}
+# IJulia rocks! So does Plotly. Check it out
+
+using Plotly
+api_key = "" # visit https://plot.ly/api to generate an API username and password
+username = ""
+
+Plotly.signin(username, api_key)
+```
+:::
+
+::: {.cell .code}
+``` {.python}
+# Following data taken from http://julialang.org/ frontpage 
+benchmarks = ["fib", "parse_int", "quicksort3", "mandel", "pi_sum", "rand_mat_stat", "rand_mat_mul"]
+platforms = ["Fortran", "Julia", "Python", "R", "Matlab", "Mathematica", "Javascript", "Go"]
+
+data = {
+        platforms[1] => [0.26, 5.03, 1.11, 0.86, 0.80, 0.64, 0.96],
+        platforms[2] => [0.91, 1.60, 1.14, 0.85, 1.00, 1.66, 1.01],
+        platforms[3] => [30.37, 13.95, 31.98, 14.19, 16.33, 13.52, 3.41 ],
+        platforms[4] => [411.36, 59.40, 524.29, 106.97, 15.42, 10.84, 3.98  ],
+        platforms[5] => [1992.00, 1463.16, 101.84, 64.58, 1.29, 6.61, 1.10   ],
+        platforms[6] => [64.46, 29.54, 35.74, 6.07, 1.32, 4.52, 1.16 ],
+        platforms[7] => [2.18, 2.43, 3.51, 3.49, 0.84, 3.28, 14.60],
+        platforms[8] => [1.03, 4.79, 1.25, 2.36, 1.41, 8.12, 8.51]
+        }
+
+pdata = [ {"x"=>benchmarks,"y"=>data[k],"bardir"=>"h","type"=>"bar","name"=>k} for k = platforms ]
+
+layout = {
+          "title"=> "Julia benchmark comparison (smaller is better, C performance = 1.0)",
+          "barmode"=> "group",
+          "autosize"=> false,
+          "width"=> 900,
+          "height"=> 900,
+          "titlefont"=>
+          {
+           "family"=> "Open Sans",
+           "size"=> 18,
+           "color"=> "rgb(84, 39, 143)"
+           },
+          "margin"=> {"l"=>160, "pad"=>0},
+          "xaxis"=> {
+                     "title"=> "Benchmark log-time",
+                     "type"=> "log"
+                     },
+          "yaxis"=> {"title"=> "Benchmark Name"}
+          }
+
+response = Plotly.plot(pdata,["layout"=>layout])
+
+# Embed in an iframe within IJulia
+s = string("<iframe height='750' id='igraph' scrolling='no' seamless='seamless' src='",
+            response["url"],
+            "/700/700' width='750'></iframe>")
+display("text/html", s)
+```
+:::
+
+::: {.cell .code}
+``` {.python}
+# checkout https://plot.ly/api/ for more Julia examples!
+# But to show off some other Plotly features:
+x = 1:1500
+y1 = sin(2*pi*x/1500.) + rand(1500)-0.5
+y2 = sin(2*pi*x/1500.)
+
+fish = {"x"=>x,"y"=> y1,
+	"type"=>"scatter","mode"=>"markers",
+	"marker"=>{"color"=>"rgb(0, 0, 255)","opacity"=>0.5 } }
+
+fit = {"x"=> x,"y"=> y2,
+	"type"=>"scatter", "mode"=>"markers", "opacity"=>0.8,
+	"marker"=>{"color"=>"rgb(255, 0, 0)"} }
+
+layout = {"autosize"=> false,
+    "width"=> 650, "height"=> 550,
+    "title"=>"Fish School",
+	"xaxis"=>{ "ticks"=> "",
+        "gridcolor"=> "white",
+        "zerolinecolor"=> "white",    
+        "linecolor"=> "white",
+        "autorange"=> false,
+        "range"=>[0,1500] },
+	"yaxis"=>{ "ticks"=> "",
+        "gridcolor"=> "white",
+        "zerolinecolor"=> "white",
+		"linecolor"=> "white",
+        "autorange"=> false,
+        "range"=>[-2.2,2.2] },
+	"plot_bgcolor"=> "rgb(245,245,247)",
+    "showlegend"=> false,
+    "hovermode"=> "closest"}
+
+response = Plotly.plot([fish, fit],["layout"=>layout])
+s = string("<iframe height='750' id='igraph' scrolling='no' seamless='seamless' src='",
+            response["url"],
+            "/700/700' width='750'></iframe>")
+display("text/html", s)
+```
+:::

--- a/tests/notebooks/mirror/ipynb_to_pandoc/julia_functional_geometry.md
+++ b/tests/notebooks/mirror/ipynb_to_pandoc/julia_functional_geometry.md
@@ -1,0 +1,139 @@
+---
+jupyter:
+  jupytext:
+    main_language: julia
+  nbformat: 4
+  nbformat_minor: 2
+---
+
+::: {.cell .code}
+``` {.python}
+# This notebook is a semi top-down explanation. This cell needs to be
+# executed first so that the operators and helper functions are defined
+# All of this is explained in the later half of the notebook
+
+using Compose, Interact
+Compose.set_default_graphic_size(2inch, 2inch)
+
+points_f = [
+    (.1, .1),
+    (.9, .1),
+    (.9, .2),
+    (.2, .2),
+    (.2, .4),
+    (.6, .4),
+    (.6, .5),
+    (.2, .5),
+    (.2, .9),
+    (.1, .9),
+    (.1, .1)
+]
+
+f = compose(context(), stroke("black"), line(points_f))
+
+rot(pic) = compose(context(rotation=Rotation(-deg2rad(90))), pic)
+flip(pic) = compose(context(mirror=Mirror(deg2rad(90), 0.5w, 0.5h)), pic)
+above(m, n, p, q) =
+    compose(context(),
+            (context(0, 0, 1, m/(m+n)), p),
+            (context(0, m/(m+n), 1, n/(m+n)), q))
+
+above(p, q) = above(1, 1, p, q)
+
+beside(m, n, p, q) =
+    compose(context(),
+            (context(0, 0, m/(m+n), 1), p),
+            (context(m/(m+n), 0, n/(m+n), 1), q))
+
+beside(p, q) = beside(1, 1, p, q)
+
+over(p, q) = compose(context(),
+                (context(), p), (context(), q))
+
+rot45(pic) =
+    compose(context(0, 0, 1/sqrt(2), 1/sqrt(2),
+        rotation=Rotation(-deg2rad(45), 0w, 0h)), pic)
+
+# Utility function to zoom out and look at the context
+zoomout(pic) = compose(context(),
+                (context(0.2, 0.2, 0.6, 0.6), pic),
+                (context(0.2, 0.2, 0.6, 0.6), fill(nothing), stroke("black"), strokedash([0.5mm, 0.5mm]),
+                    polygon([(0, 0), (1, 0), (1, 1), (0, 1)])))
+
+function read_path(p_str)
+    tokens = [try parsefloat(x) catch symbol(x) end for x in split(p_str, r"[\s,]+")]
+    path(tokens)
+end
+
+fish = compose(context(units=UnitBox(260, 260)), stroke("black"),
+            read_path(strip(readall("fish.path"))))
+
+rotatable(pic) = @manipulate for θ=0:0.001:2π
+    compose(context(rotation=Rotation(θ)), pic)
+end
+
+blank = compose(context())
+
+fliprot45(pic) = rot45(compose(context(mirror=Mirror(deg2rad(-45))),pic))
+
+# Hide this cell.
+display(MIME("text/html"), """<script>
+var cell = \$(".container .cell").eq(0), ia = cell.find(".input_area")
+if (cell.find(".toggle-button").length == 0) {
+ia.after(
+    \$('<button class="toggle-button">Toggle hidden code</button>').click(
+        function (){ ia.toggle() }
+        )
+    )
+ia.hide()
+}
+</script>""")
+```
+:::
+
+::: {.cell .markdown}
+# Functional Geometry
+
+*Functional Geometry* is a paper by Peter Henderson ([original (1982)](users.ecs.soton.ac.uk/peter/funcgeo.pdf), [revisited (2002)](https://cs.au.dk/~hosc/local/HOSC-15-4-pp349-365.pdf)) which deconstructs the MC Escher woodcut *Square Limit*
+
+![Square Limit](http://i.imgur.com/LjRzmNM.png)
+:::
+
+::: {.cell .markdown}
+> A picture is an example of a complex object that can be described in terms of its parts.
+> Yet a picture needs to be rendered on a printer or a screen by a device that expects to
+> be given a sequence of commands. Programming that sequence of commands directly is
+> much harder than having an application generate the commands automatically from the
+> simpler, denotational description.
+:::
+
+::: {.cell .markdown}
+A `picture` is a *denotation* of something to draw.
+
+e.g. The value of f here denotes the picture of the letter F
+:::
+
+::: {.cell .markdown}
+Original at <http://nbviewer.jupyter.org/github/shashi/ijulia-notebooks/blob/master/funcgeo/Functional%20Geometry.ipynb>
+:::
+
+::: {.cell .markdown}
+## In conclusion
+
+We described Escher\'s *Square Limit* from the description of its smaller parts, which in turn were described in terms of their smaller parts.
+
+This seemed simple because we chose to talk in terms of an *algebra* to describe pictures. The primitives `rot`, `flip`, `fliprot45`, `above`, `beside` and `over` fit the job perfectly.
+
+We were able to describe these primitves in terms of `compose` `contexts`, which the Compose library knows how to render.
+
+Denotation can be an easy way to describe a system as well as a practical implementation method.
+
+[Abstraction barriers](https://mitpress.mit.edu/sicp/full-text/sicp/book/node29.html) are useful tools that can reduce the cognitive overhead on the programmer. It entails creating layers consisting of functions which only use functions in the same layer or layers below in their own implementation. The layers in our language were:
+
+    ------------------[ squarelimit ]------------------
+    -------------[ quartet, cycle, nonet ]-------------
+    ---[ rot, flip, fliprot45, above, beside, over ]---
+    -------[ compose, context, line, path,... ]--------
+
+Drawing this diagram out is a useful way to begin building any library.
+:::

--- a/tests/notebooks/mirror/ipynb_to_pandoc/jupyter.md
+++ b/tests/notebooks/mirror/ipynb_to_pandoc/jupyter.md
@@ -1,0 +1,43 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+  nbformat: 4
+  nbformat_minor: 2
+---
+
+::: {.cell .markdown}
+# Jupyter notebook
+
+This notebook is a simple jupyter notebook. It only has markdown and code cells. And it does not contain consecutive markdown cells. We start with an addition:
+:::
+
+::: {.cell .code}
+``` {.python}
+a = 1
+b = 2
+a + b
+```
+:::
+
+::: {.cell .markdown}
+Now we return a few tuples
+:::
+
+::: {.cell .code}
+``` {.python}
+a, b
+```
+:::
+
+::: {.cell .code}
+``` {.python}
+a, b, a+b
+```
+:::
+
+::: {.cell .markdown}
+And this is already the end of the notebook
+:::

--- a/tests/notebooks/mirror/ipynb_to_pandoc/jupyter_again.md
+++ b/tests/notebooks/mirror/ipynb_to_pandoc/jupyter_again.md
@@ -1,0 +1,36 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+  nbformat: 4
+  nbformat_minor: 2
+---
+
+::: {.cell .code}
+``` {.python}
+c = '''
+title: "Quick test"
+output:
+  ioslides_presentation:
+    widescreen: true
+    smaller: true
+editor_options:
+     chunk_output_type console
+'''
+```
+:::
+
+::: {.cell .code}
+``` {.python}
+import yaml
+print(yaml.dump(yaml.load(c)))
+```
+:::
+
+::: {.cell .code}
+``` {.python}
+?next
+```
+:::

--- a/tests/notebooks/mirror/ipynb_to_pandoc/jupyter_with_raw_cell_in_body.md
+++ b/tests/notebooks/mirror/ipynb_to_pandoc/jupyter_with_raw_cell_in_body.md
@@ -1,0 +1,25 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+  nbformat: 4
+  nbformat_minor: 2
+---
+
+::: {.cell .code}
+``` {.python}
+1+2+3
+```
+:::
+
+::: {.cell .raw}
+```{=ipynb}
+This is a raw cell
+```
+:::
+
+::: {.cell .markdown}
+This is a markdown cell
+:::

--- a/tests/notebooks/mirror/ipynb_to_pandoc/jupyter_with_raw_cell_on_top.md
+++ b/tests/notebooks/mirror/ipynb_to_pandoc/jupyter_with_raw_cell_on_top.md
@@ -1,0 +1,34 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+  nbformat: 4
+  nbformat_minor: 2
+---
+
+::: {.cell .raw}
+```{=ipynb}
+---
+title: "Quick test"
+output:
+  ioslides_presentation:
+    widescreen: true
+    smaller: true
+editor_options:
+     chunk_output_type console
+---
+```
+:::
+
+::: {.cell .code}
+``` {.python}
+1+2+3
+```
+:::
+
+::: {.cell .code}
+``` {.python}
+```
+:::

--- a/tests/notebooks/mirror/ipynb_to_pandoc/notebook_with_complex_metadata.md
+++ b/tests/notebooks/mirror/ipynb_to_pandoc/notebook_with_complex_metadata.md
@@ -1,0 +1,14 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+  nbformat: 4
+  nbformat_minor: 2
+---
+
+::: {.cell .code}
+``` {.python}
+```
+:::

--- a/tests/notebooks/mirror/ipynb_to_pandoc/nteract_with_parameter.md
+++ b/tests/notebooks/mirror/ipynb_to_pandoc/nteract_with_parameter.md
@@ -1,0 +1,38 @@
+---
+jupyter:
+  kernel_info:
+    name: python3
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+  nbformat: 4
+  nbformat_minor: 2
+---
+
+::: {.cell .code inputHidden="false" outputHidden="false" tags="[\"parameters\"]"}
+``` {.python}
+param = 4
+```
+:::
+
+::: {.cell .code inputHidden="false" outputHidden="false"}
+``` {.python}
+import pandas as pd
+```
+:::
+
+::: {.cell .code inputHidden="false" outputHidden="false"}
+``` {.python}
+df = pd.DataFrame({'A': [1, 2], 'B': [3 + param, 4]},
+                  index=pd.Index(['x0', 'x1'], name='x'))
+df
+```
+:::
+
+::: {.cell .code inputHidden="false" outputHidden="false"}
+``` {.python}
+%matplotlib inline
+df.plot(kind='bar')
+```
+:::

--- a/tests/notebooks/mirror/ipynb_to_pandoc/sample_rise_notebook_66.md
+++ b/tests/notebooks/mirror/ipynb_to_pandoc/sample_rise_notebook_66.md
@@ -1,0 +1,23 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+  nbformat: 4
+  nbformat_minor: 2
+---
+
+::: {.cell .markdown slideshow="{\"slide_type\":\"slide\"}"}
+A markdown cell
+:::
+
+::: {.cell .code slideshow="{\"slide_type\":\"\"}"}
+``` {.python}
+1+1
+```
+:::
+
+::: {.cell .markdown cell_style="center" slideshow="{\"slide_type\":\"fragment\"}"}
+Markdown cell two
+:::

--- a/tests/notebooks/mirror/ipynb_to_percent/The flavors of raw cells.py
+++ b/tests/notebooks/mirror/ipynb_to_percent/The flavors of raw cells.py
@@ -1,0 +1,25 @@
+# ---
+# jupyter:
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# %% [raw] {"raw_mimetype": "text/latex"}
+# $1+1$
+
+# %% [raw] {"raw_mimetype": "text/restructuredtext"}
+# :math:`1+1`
+
+# %% [raw] {"raw_mimetype": "text/html"}
+# <b>Bold text<b>
+
+# %% [raw] {"raw_mimetype": "text/markdown"}
+# **Bold text**
+
+# %% [raw] {"raw_mimetype": "text/x-python"}
+# 1 + 1
+
+# %% [raw]
+# Not formatted

--- a/tests/notebooks/mirror/ipynb_to_script/The flavors of raw cells.py
+++ b/tests/notebooks/mirror/ipynb_to_script/The flavors of raw cells.py
@@ -1,0 +1,25 @@
+# ---
+# jupyter:
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# + {"raw_mimetype": "text/latex", "active": ""}
+# $1+1$
+
+# + {"raw_mimetype": "text/restructuredtext", "active": ""}
+# :math:`1+1`
+
+# + {"raw_mimetype": "text/html", "active": ""}
+# <b>Bold text<b>
+
+# + {"raw_mimetype": "text/markdown", "active": ""}
+# **Bold text**
+
+# + {"raw_mimetype": "text/x-python", "active": ""}
+# 1 + 1
+
+# + {"active": ""}
+# Not formatted

--- a/tests/notebooks/mirror/ipynb_to_script_vim_folding_markers/The flavors of raw cells.py
+++ b/tests/notebooks/mirror/ipynb_to_script_vim_folding_markers/The flavors of raw cells.py
@@ -1,0 +1,33 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_markers: '{{{,}}}'
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# {{{ {"raw_mimetype": "text/latex", "active": ""}
+# $1+1$
+# }}}
+
+# {{{ {"raw_mimetype": "text/restructuredtext", "active": ""}
+# :math:`1+1`
+# }}}
+
+# {{{ {"raw_mimetype": "text/html", "active": ""}
+# <b>Bold text<b>
+# }}}
+
+# {{{ {"raw_mimetype": "text/markdown", "active": ""}
+# **Bold text**
+# }}}
+
+# {{{ {"raw_mimetype": "text/x-python", "active": ""}
+# 1 + 1
+# }}}
+
+# {{{ {"active": ""}
+# Not formatted
+# }}}

--- a/tests/notebooks/mirror/ipynb_to_script_vscode_folding_markers/The flavors of raw cells.py
+++ b/tests/notebooks/mirror/ipynb_to_script_vscode_folding_markers/The flavors of raw cells.py
@@ -1,0 +1,33 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_markers: region,endregion
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# region {"raw_mimetype": "text/latex", "active": ""}
+# $1+1$
+# endregion
+
+# region {"raw_mimetype": "text/restructuredtext", "active": ""}
+# :math:`1+1`
+# endregion
+
+# region {"raw_mimetype": "text/html", "active": ""}
+# <b>Bold text<b>
+# endregion
+
+# region {"raw_mimetype": "text/markdown", "active": ""}
+# **Bold text**
+# endregion
+
+# region {"raw_mimetype": "text/x-python", "active": ""}
+# 1 + 1
+# endregion
+
+# region {"active": ""}
+# Not formatted
+# endregion

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -523,6 +523,15 @@ def test_set_formats(py_file, tmpdir):
 
 
 @pytest.mark.parametrize('py_file', list_notebooks('python'))
+def test_set_formats_py_file_only(py_file, tmpdir):
+    tmp_py = str(tmpdir.join('notebook.py'))
+    copyfile(py_file, tmp_py)
+    jupytext([tmp_py, '--set-formats', 'ipynb,py:light'])
+    nb = readf(tmp_py)
+    assert nb.metadata['jupytext']['formats'] == 'ipynb,py:light'
+
+
+@pytest.mark.parametrize('py_file', list_notebooks('python'))
 def test_update_metadata(py_file, tmpdir, capsys):
     tmp_py = str(tmpdir.join('notebook.py'))
     tmp_ipynb = str(tmpdir.join('notebook.ipynb'))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -615,7 +615,7 @@ def test_sync(nb_file, tmpdir):
     compare_notebooks(nb, nb2)
 
     # ipynb must be older than py file, otherwise our Contents Manager will complain
-    assert os.path.getmtime(tmp_ipynb) < os.path.getmtime(tmp_py)
+    assert os.path.getmtime(tmp_ipynb) <= os.path.getmtime(tmp_py)
 
 
 @pytest.mark.parametrize('nb_file,ext',

--- a/tests/test_contentsmanager.py
+++ b/tests/test_contentsmanager.py
@@ -1232,3 +1232,77 @@ a = 1
 b = 1
 # endregion
 """, text)
+
+
+def test_open_file_with_default_cell_markers(tmpdir):
+    tmp_py = str(tmpdir.join('nb.py'))
+
+    cm = jupytext.TextFileContentsManager()
+    cm.root_dir = str(tmpdir)
+
+    # Default VScode/PyCharm folding markers
+    cm.default_cell_markers = 'region,endregion'
+
+    text = """# +
+# this is a unique code cell
+1 + 1
+
+2 + 2
+"""
+
+    with open(tmp_py, 'w') as fp:
+        fp.write(text)
+
+    nb = cm.get('nb.py')['content']
+    assert len(nb.cells) == 1
+
+    cm.save(model=dict(type='notebook', content=nb), path='nb.py')
+
+    with open(tmp_py) as fp:
+        text2 = fp.read()
+
+    expected = """# region
+# this is a unique code cell
+1 + 1
+
+2 + 2
+# endregion
+"""
+
+    compare(expected, text2)
+
+
+def test_save_file_with_default_cell_markers(tmpdir):
+    tmp_py = str(tmpdir.join('nb.py'))
+
+    cm = jupytext.TextFileContentsManager()
+    cm.root_dir = str(tmpdir)
+
+    # Default VScode/PyCharm folding markers
+    cm.default_cell_markers = 'region,endregion'
+
+    text = """# +
+# this is a unique code cell
+1 + 1
+
+2 + 2
+"""
+
+    with open(tmp_py, 'w') as fp:
+        fp.write(text)
+
+    nb = cm.get('nb.py')['content']
+    assert len(nb.cells) == 1
+
+    nb.metadata['jupytext']['cell_markers'] = '+,-'
+    del nb.metadata['jupytext']['notebook_metadata_filter']
+    cm.save(model=dict(type='notebook', content=nb), path='nb.py')
+
+    with open(tmp_py) as fp:
+        text2 = fp.read()
+
+    compare('\n'.join(text.splitlines()), '\n'.join(text2.splitlines()[-len(text.splitlines()):]))
+
+    nb2 = cm.get('nb.py')['content']
+    compare_notebooks(nb, nb2)
+    assert nb2.metadata['jupytext']['cell_markers'] == '+,-'

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -201,3 +201,11 @@ def test_validate_one_format():
 def test_set_auto_ext():
     with pytest.raises(ValueError):
         long_form_multiple_formats('ipynb,auto:percent', {})
+
+
+def test_pandoc_format_is_preserved():
+    formats_org = 'ipynb,md,.pandoc.md:pandoc,py:light'
+    long = long_form_multiple_formats(formats_org)
+    formats_new = short_form_multiple_formats(long)
+
+    compare(formats_org, formats_new)

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -277,6 +277,6 @@ def test_ipynb_to_md(nb_file):
 
 
 @requires_pandoc
-@pytest.mark.parametrize('nb_file', list_notebooks('ipynb', skip='(functional|Notebook with)'))
+@pytest.mark.parametrize('nb_file', list_notebooks('ipynb', skip='(functional|Notebook with|flavors)'))
 def test_ipynb_to_pandoc(nb_file):
     assert_conversion_same_as_mirror(nb_file, 'md:pandoc', 'ipynb_to_pandoc')

--- a/tests/test_pep8.py
+++ b/tests/test_pep8.py
@@ -154,7 +154,7 @@ def f(x):
 
 
 @pytest.mark.parametrize('py_file', [py_file for py_file in list_notebooks('../jupytext') + list_notebooks('.') if
-                                     py_file.endswith('.py')])
+                                     py_file.endswith('.py') and 'folding_markers' not in py_file])
 def test_no_metadata_when_py_is_pep8(py_file):
     nb = readf(py_file)
 

--- a/tests/test_read_all_py.py
+++ b/tests/test_read_all_py.py
@@ -7,7 +7,8 @@ from .utils import list_notebooks
 @pytest.mark.parametrize('py_file',
                          [py_file for py_file in
                           list_notebooks('../jupytext') +
-                          list_notebooks('.') if py_file.endswith('.py')])
+                          list_notebooks('.') if py_file.endswith('.py')
+                          if 'folding_markers' not in py_file])
 def test_identity_source_write_read(py_file):
     with open(py_file) as fp:
         py = fp.read()

--- a/tests/test_read_folding_markers.py
+++ b/tests/test_read_folding_markers.py
@@ -116,3 +116,20 @@ b = 2
 
     script2 = jupytext.writes(nb, 'py')
     compare(script, script2)
+
+
+def test_indented_markers_are_ignored(
+        script="""# region global
+    # region indented
+a = 1
+
+b = 2
+    # endregion
+# endregion
+"""):
+    nb = jupytext.reads(script, 'py')
+    assert len(nb.cells) == 1
+    assert nb.cells[0].cell_type == 'code'
+
+    script2 = jupytext.writes(nb, 'py')
+    compare(script, script2)

--- a/tests/test_read_folding_markers.py
+++ b/tests/test_read_folding_markers.py
@@ -64,16 +64,55 @@ a = 1
 b = 2
 # endregion
 
-c = 3
+def f(x):
+    return x + 1
+
+
 # endregion
+
+
+d = 4
 """):
     nb = jupytext.reads(script, 'py')
-    assert len(nb.cells) == 2
     assert nb.cells[0].cell_type == 'markdown'
     assert nb.cells[0].source == 'This is a markdown cell'
     assert nb.cells[1].cell_type == 'code'
-    assert nb.cells[1].metadata == {'key': 'value'}
+    assert nb.cells[1].source == '# region {"key": "value"}\na = 1'
+    assert nb.cells[2].cell_type == 'code'
+    assert nb.cells[2].metadata['title'] == 'An inner region'
+    assert nb.cells[2].source == 'b = 2'
+    assert nb.cells[3].cell_type == 'code'
+    assert nb.cells[3].source == 'def f(x):\n    return x + 1'
+    assert nb.cells[4].cell_type == 'code'
+    assert nb.cells[4].source == '# endregion'
+    assert nb.cells[5].cell_type == 'code'
+    assert nb.cells[5].source == 'd = 4'
+    assert len(nb.cells) == 6
 
     script2 = jupytext.writes(nb, 'py')
     compare(script, script2)
+
+
 # endregion
+
+
+def test_adjacent_regions(
+        script="""# region global
+# region innermost
+a = 1
+
+b = 2
+# endregion
+# endregion
+"""):
+    nb = jupytext.reads(script, 'py')
+    assert len(nb.cells) == 3
+    assert nb.cells[0].cell_type == 'code'
+    assert nb.cells[0].source == '# region global'
+    assert nb.cells[1].cell_type == 'code'
+    assert nb.cells[1].source == 'a = 1\n\nb = 2'
+    assert nb.cells[2].cell_type == 'code'
+    assert nb.cells[2].source == '# endregion'
+
+    script2 = jupytext.writes(nb, 'py')
+    compare(script, script2)

--- a/tests/test_read_simple_pandoc.py
+++ b/tests/test_read_simple_pandoc.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from testfixtures import compare
 from nbformat.v4.nbbase import new_notebook, new_markdown_cell
 from jupytext.compare import compare_notebooks

--- a/tests/test_read_simple_pandoc.py
+++ b/tests/test_read_simple_pandoc.py
@@ -1,0 +1,60 @@
+from testfixtures import compare
+from nbformat.v4.nbbase import new_notebook, new_markdown_cell
+from jupytext.compare import compare_notebooks
+import jupytext
+from .utils import requires_pandoc
+
+
+@requires_pandoc
+def test_pandoc_implicit(markdown='''# Lorem ipsum
+
+**Lorem ipsum** dolor sit amet, consectetur adipiscing elit. Nunc luctus
+bibendum felis dictum sodales.
+
+``` code
+print("hello")
+```
+'''):
+    nb = jupytext.reads(markdown, 'md:pandoc')
+    markdown2 = jupytext.writes(nb, 'md')
+
+    nb2 = jupytext.reads(markdown2, 'md')
+    compare_notebooks(nb, nb2)
+
+    markdown3 = jupytext.writes(nb2, 'md')
+    compare(markdown2, markdown3)
+
+
+@requires_pandoc
+def test_pandoc_explicit(markdown='''::: {.cell .markdown}
+# Lorem
+
+**Lorem ipsum** dolor sit amet, consectetur adipiscing elit. Nunc luctus
+bibendum felis dictum sodales.
+:::'''):
+    nb = jupytext.reads(markdown, 'md')
+
+    markdown2 = jupytext.writes(nb, 'md')
+    compare(markdown, '\n'.join(markdown2.splitlines()[12:]))
+
+
+@requires_pandoc
+def test_pandoc_utf8_in_md(markdown='''::: {.cell .markdown}
+# Utf-8 support
+
+This is the greek letter $\pi$: π
+:::'''):
+    nb = jupytext.reads(markdown, 'md')
+
+    markdown2 = jupytext.writes(nb, 'md')
+    compare(markdown, '\n'.join(markdown2.splitlines()[12:]))
+
+
+@requires_pandoc
+def test_pandoc_utf8_in_nb(nb=new_notebook(cells=[new_markdown_cell('''# Utf-8 support
+
+This is the greek letter $\pi$: π''')])):
+    markdown = jupytext.writes(nb, 'md:pandoc')
+    nb2 = jupytext.reads(markdown, 'md:pandoc')
+    nb2.metadata.pop('jupytext')
+    compare_notebooks(nb2, nb, 'md:pandoc')

--- a/tests/test_read_simple_pandoc.py
+++ b/tests/test_read_simple_pandoc.py
@@ -43,7 +43,7 @@ bibendum felis dictum sodales.
 def test_pandoc_utf8_in_md(markdown='''::: {.cell .markdown}
 # Utf-8 support
 
-This is the greek letter $\pi$: π
+This is the greek letter $\\pi$: π
 :::'''):
     nb = jupytext.reads(markdown, 'md')
 
@@ -54,7 +54,7 @@ This is the greek letter $\pi$: π
 @requires_pandoc
 def test_pandoc_utf8_in_nb(nb=new_notebook(cells=[new_markdown_cell('''# Utf-8 support
 
-This is the greek letter $\pi$: π''')])):
+This is the greek letter $\\pi$: π''')])):
     markdown = jupytext.writes(nb, 'md:pandoc')
     nb2 = jupytext.reads(markdown, 'md:pandoc')
     nb2.metadata.pop('jupytext')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,6 +4,7 @@ import re
 import pytest
 from jupytext.cli import system
 from jupytext.cell_reader import rst2md
+from jupytext.pandoc import is_pandoc_available
 
 skip_if_dict_is_not_ordered = pytest.mark.skipif(
     sys.version_info < (3, 6),
@@ -22,6 +23,7 @@ requires_black = pytest.mark.skipif(not tool_version('black'), reason='black not
 requires_flake8 = pytest.mark.skipif(not tool_version('flake8'), reason='flake8 not found')
 requires_autopep8 = pytest.mark.skipif(not tool_version('autopep8'), reason='autopep8 not found')
 requires_sphinx_gallery = pytest.mark.skipif(not rst2md, reason='sphinx_gallery not available')
+requires_pandoc = pytest.mark.skipif(not is_pandoc_available(), reason='pandoc>=2.7.1 not available')
 
 
 def list_notebooks(path='ipynb', skip='World'):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -18,12 +18,12 @@ def tool_version(tool):
         return None
 
 
-requires_jupytext_installed = pytest.mark.skipif(not tool_version('jupytext'), reason='jupytext not installed')
+requires_jupytext_installed = pytest.mark.skipif(not tool_version('jupytext'), reason='jupytext is not installed')
 requires_black = pytest.mark.skipif(not tool_version('black'), reason='black not found')
 requires_flake8 = pytest.mark.skipif(not tool_version('flake8'), reason='flake8 not found')
 requires_autopep8 = pytest.mark.skipif(not tool_version('autopep8'), reason='autopep8 not found')
-requires_sphinx_gallery = pytest.mark.skipif(not rst2md, reason='sphinx_gallery not available')
-requires_pandoc = pytest.mark.skipif(not is_pandoc_available(), reason='pandoc>=2.7.1 not available')
+requires_sphinx_gallery = pytest.mark.skipif(not rst2md, reason='sphinx_gallery is not available')
+requires_pandoc = pytest.mark.skipif(not is_pandoc_available(), reason='pandoc>=2.7.2 is not available')
 
 
 def list_notebooks(path='ipynb', skip='World'):


### PR DESCRIPTION
**Improvements**

- Markdown and R Markdown formats now support metadata (#66, #111, #188)
- The `light` format for Scripts can use custom cell markers, e.g. Vim or VScode/PyCharm folding markers (#199)
- Pandoc's Markdown format for Jupyter notebooks is available in Jupytext as `md:pandoc` (#208)

**BugFixes**

- Jupytext's contents manager is now based on `LargeFileManager` to allow large file uploads (#210)
- YAML header parsed with yaml.safe_load rather than yaml.load
- IPython line magic can be split across lines (#209)