### PR TITLE
Also allow subclasses of TextFileContentsManager

### DIFF
--- a/jupytext/__init__.py
+++ b/jupytext/__init__.py
@@ -17,9 +17,9 @@ except ImportError as err:
 
 def load_jupyter_server_extension(app):  # pragma: no cover
     """Use Jupytext's contents manager"""
-    if app.contents_manager_class == TextFileContentsManager:
+    if isinstance(app.contents_manager_class, TextFileContentsManager):
         app.log.info("[Jupytext Server Extension] NotebookApp.contents_manager_class is "
-                     "jupytext.TextFileContentsManager already - OK")
+                     "(or a subclass of) jupytext.TextFileContentsManager already - OK")
         return
 
     # The server extension call is too late!


### PR DESCRIPTION
Only load the jupytext.TextFileContentsManager as contents manager
if the configured class is not already an instance of it.

We use a subclass of TextFileContentsManager to extend the rename and delete methods. However, our subclass is replaced by the provided TextFileContentsManager since it is not exactly that class.
This allows custom classes if they are a subclass of TextFileContentsManager.