### PR TITLE
changing isinstance to issubclass

### DIFF
--- a/jupytext/__init__.py
+++ b/jupytext/__init__.py
@@ -17,7 +17,7 @@ except ImportError as err:
 
 def load_jupyter_server_extension(app):  # pragma: no cover
     """Use Jupytext's contents manager"""
-    if isinstance(app.contents_manager_class, TextFileContentsManager):
+    if issubclass(app.contents_manager_class, TextFileContentsManager):
         app.log.info("[Jupytext Server Extension] NotebookApp.contents_manager_class is "
                      "(a subclass of) jupytext.TextFileContentsManager already - OK")
         return

--- a/tests/test_contentsmanager.py
+++ b/tests/test_contentsmanager.py
@@ -1351,3 +1351,11 @@ def test_notebook_extensions(tmpdir):
 
     model = cm.get('script.py')
     assert model['type'] == 'file'
+
+
+def test_server_extension_issubclass():
+    class SubClassTextFileContentsManager(jupytext.TextFileContentsManager):
+        pass
+
+    assert not isinstance(SubClassTextFileContentsManager, jupytext.TextFileContentsManager)
+    assert issubclass(SubClassTextFileContentsManager, jupytext.TextFileContentsManager)


### PR DESCRIPTION
the isinstance check `if isinstance(app.contents_manager_class, TextFileContentsManager):` will always fail because app.contents_manager_class is not an instance.  

Changing this to `if issubclass(app.contents_manager_class, TextFileContentsManager):`  will allow others to extend.