### PR TITLE
Remove the dependency on mock

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -16,7 +16,7 @@ Release History
 (or not) the metadata in the text representation of the notebook.
 - Jupytext's contents manager class is derived dynamically from the default CM class for compatibility with
 ``jupyter_server`` (#270)
-- Removed dependency on ``testfixtures`` (#279)
+- Removed dependency on ``mock`` and ``testfixtures``, thanks to Jean-Sebastien Dieu (#279)
 
 **BugFixes**
 

--- a/jupytext/contentsmanager.py
+++ b/jupytext/contentsmanager.py
@@ -3,7 +3,10 @@
 import os
 from datetime import timedelta
 import nbformat
-import mock
+try:
+    import mock
+except ImportError:
+    import unittest.mock as mock
 from tornado.web import HTTPError
 from traitlets import Unicode, Float, Bool, Enum
 from traitlets.config import Configurable

--- a/jupytext/contentsmanager.py
+++ b/jupytext/contentsmanager.py
@@ -3,10 +3,11 @@
 import os
 from datetime import timedelta
 import nbformat
+
 try:
-    import mock
-except ImportError:
     import unittest.mock as mock
+except ImportError:
+    import mock
 from tornado.web import HTTPError
 from traitlets import Unicode, Float, Bool, Enum
 from traitlets.config import Configurable

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 nbformat>=4.0.0
 pyyaml
-mock;python_version<"3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 nbformat>=4.0.0
 pyyaml
-mock
+mock;python_version<"3"

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
                 ('share/jupyter/lab/extensions', ['packages/labextension/jupyterlab-jupytext-1.0.0.tgz'])],
     entry_points={'console_scripts': ['jupytext = jupytext.cli:jupytext_cli']},
     tests_require=['pytest'],
-    install_requires=['nbformat>=4.0.0', 'mock', 'pyyaml'],
+    install_requires=['nbformat>=4.0.0', 'pyyaml', 'mock;python_version<"3"'],
     license='MIT',
     classifiers=['Development Status :: 5 - Production/Stable',
                  'License :: OSI Approved :: MIT License',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,8 +7,6 @@ except ImportError:
 
 
 @pytest.fixture
-def header_insert_and_check_version_number_patch():
-    m = mock.patch('jupytext.header.INSERT_AND_CHECK_VERSION_NUMBER', False)
-    m.start()
-    yield m
-    m.stop()
+def no_jupytext_version_number():
+    with mock.patch('jupytext.header.INSERT_AND_CHECK_VERSION_NUMBER', False):
+        yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import jupytext
 import pytest
 try:
     import mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,9 @@
 import pytest
+
 try:
-    import mock
-except ImportError:
     import unittest.mock as mock
+except ImportError:
+    import mock
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import jupytext
+import pytest
+try:
+    import mock
+except ImportError:
+    import unittest.mock as mock
+
+
+@pytest.fixture
+def header_insert_and_check_version_number_patch():
+    m = mock.patch('jupytext.header.INSERT_AND_CHECK_VERSION_NUMBER', False)
+    m.start()
+    yield m
+    m.stop()

--- a/tests/test_active_cells.py
+++ b/tests/test_active_cells.py
@@ -44,7 +44,7 @@ ACTIVE_ALL = {'.py': """# + {"active": "ipynb,py,R,Rmd"}
 
 
 @pytest.mark.parametrize('ext', ['.Rmd', '.py', '.R'])
-def test_active_all(ext, header_insert_and_check_version_number_patch):
+def test_active_all(ext, no_jupytext_version_number):
     nb = jupytext.reads(HEADER[ext] + ACTIVE_ALL[ext], ext)
     assert len(nb.cells) == 1
     compare(ACTIVE_ALL[ext], jupytext.writes(nb, ext))
@@ -74,7 +74,7 @@ ACTIVE_IPYNB = {'.py': """# + {"active": "ipynb"}
 
 @skip_if_dict_is_not_ordered
 @pytest.mark.parametrize('ext', ['.Rmd', '.py', '.R'])
-def test_active_ipynb(ext, header_insert_and_check_version_number_patch):
+def test_active_ipynb(ext, no_jupytext_version_number):
     nb = jupytext.reads(HEADER[ext] + ACTIVE_IPYNB[ext], ext)
     assert len(nb.cells) == 1
     compare(ACTIVE_IPYNB[ext], jupytext.writes(nb, ext))
@@ -104,7 +104,7 @@ ACTIVE_IPYNB_RMD_USING_TAG = {'.py': """# + {"tags": ["active-ipynb-Rmd"]}
 
 @skip_if_dict_is_not_ordered
 @pytest.mark.parametrize('ext', ['.Rmd', '.py', '.R'])
-def test_active_ipynb_rmd_using_tags(ext, header_insert_and_check_version_number_patch):
+def test_active_ipynb_rmd_using_tags(ext, no_jupytext_version_number):
     nb = jupytext.reads(HEADER[ext] + ACTIVE_IPYNB_RMD_USING_TAG[ext], ext)
     assert len(nb.cells) == 1
     compare(ACTIVE_IPYNB_RMD_USING_TAG[ext], jupytext.writes(nb, ext))
@@ -124,7 +124,7 @@ ACTIVE_IPYNB_RSPIN = {'.R': """#+ active="ipynb", eval=FALSE
 
 
 @skip_if_dict_is_not_ordered
-def test_active_ipynb_rspin(header_insert_and_check_version_number_patch):
+def test_active_ipynb_rspin(no_jupytext_version_number):
     nb = jupytext.reads(ACTIVE_IPYNB_RSPIN['.R'], 'R:spin')
     assert len(nb.cells) == 1
     compare(ACTIVE_IPYNB_RSPIN['.R'], jupytext.writes(nb, 'R:spin'))
@@ -151,7 +151,7 @@ ACTIVE_PY_IPYNB = {'.py': """# + {"active": "ipynb,py"}
 
 @skip_if_dict_is_not_ordered
 @pytest.mark.parametrize('ext', ['.Rmd', '.py', '.R'])
-def test_active_py_ipynb(ext, header_insert_and_check_version_number_patch):
+def test_active_py_ipynb(ext, no_jupytext_version_number):
     nb = jupytext.reads(HEADER[ext] + ACTIVE_PY_IPYNB[ext], ext)
     assert len(nb.cells) == 1
     compare(ACTIVE_PY_IPYNB[ext], jupytext.writes(nb, ext))
@@ -178,7 +178,7 @@ ACTIVE_PY_R_IPYNB = {'.py': """# + {"active": "ipynb,py,R"}
 
 @skip_if_dict_is_not_ordered
 @pytest.mark.parametrize('ext', ['.Rmd', '.py', '.R'])
-def test_active_py_r_ipynb(ext, header_insert_and_check_version_number_patch):
+def test_active_py_r_ipynb(ext, no_jupytext_version_number):
     nb = jupytext.reads(HEADER[ext] + ACTIVE_PY_R_IPYNB[ext], ext)
     assert len(nb.cells) == 1
     compare(ACTIVE_PY_R_IPYNB[ext], jupytext.writes(nb, ext))
@@ -202,7 +202,7 @@ ACTIVE_RMD = {'.py': """# + {"active": "Rmd"}
 
 @skip_if_dict_is_not_ordered
 @pytest.mark.parametrize('ext', ['.Rmd', '.py', '.R'])
-def test_active_rmd(ext, header_insert_and_check_version_number_patch):
+def test_active_rmd(ext, no_jupytext_version_number):
     nb = jupytext.reads(HEADER[ext] + ACTIVE_RMD[ext], ext)
     assert len(nb.cells) == 1
     compare(ACTIVE_RMD[ext], jupytext.writes(nb, ext))
@@ -228,7 +228,7 @@ ACTIVE_NOT_INCLUDE_RMD = {'.py': """# + {"hide_output": true, "active": "Rmd"}
 
 @skip_if_dict_is_not_ordered
 @pytest.mark.parametrize('ext', ['.Rmd', '.py', '.R'])
-def test_active_not_include_rmd(ext, header_insert_and_check_version_number_patch):
+def test_active_not_include_rmd(ext, no_jupytext_version_number):
     nb = jupytext.reads(ACTIVE_NOT_INCLUDE_RMD[ext], ext)
     assert len(nb.cells) == 1
     compare(ACTIVE_NOT_INCLUDE_RMD[ext], jupytext.writes(nb, ext))

--- a/tests/test_active_cells.py
+++ b/tests/test_active_cells.py
@@ -1,4 +1,3 @@
-import mock
 import pytest
 from jupytext.compare import compare
 import jupytext
@@ -45,12 +44,12 @@ ACTIVE_ALL = {'.py': """# + {"active": "ipynb,py,R,Rmd"}
 
 
 @pytest.mark.parametrize('ext', ['.Rmd', '.py', '.R'])
-def test_active_all(ext):
-    with mock.patch('jupytext.header.INSERT_AND_CHECK_VERSION_NUMBER', False):
-        nb = jupytext.reads(HEADER[ext] + ACTIVE_ALL[ext], ext)
-        assert len(nb.cells) == 1
-        compare(ACTIVE_ALL[ext], jupytext.writes(nb, ext))
-        compare(nb.cells[0], ACTIVE_ALL['.ipynb'])
+def test_active_all(ext, header_insert_and_check_version_number_patch):
+    assert jupytext.header.INSERT_AND_CHECK_VERSION_NUMBER == False
+    nb = jupytext.reads(HEADER[ext] + ACTIVE_ALL[ext], ext)
+    assert len(nb.cells) == 1
+    compare(ACTIVE_ALL[ext], jupytext.writes(nb, ext))
+    compare(nb.cells[0], ACTIVE_ALL['.ipynb'])
 
 
 ACTIVE_IPYNB = {'.py': """# + {"active": "ipynb"}
@@ -76,12 +75,11 @@ ACTIVE_IPYNB = {'.py': """# + {"active": "ipynb"}
 
 @skip_if_dict_is_not_ordered
 @pytest.mark.parametrize('ext', ['.Rmd', '.py', '.R'])
-def test_active_ipynb(ext):
-    with mock.patch('jupytext.header.INSERT_AND_CHECK_VERSION_NUMBER', False):
-        nb = jupytext.reads(HEADER[ext] + ACTIVE_IPYNB[ext], ext)
-        assert len(nb.cells) == 1
-        compare(ACTIVE_IPYNB[ext], jupytext.writes(nb, ext))
-        compare(nb.cells[0], ACTIVE_IPYNB['.ipynb'])
+def test_active_ipynb(ext, header_insert_and_check_version_number_patch):
+    nb = jupytext.reads(HEADER[ext] + ACTIVE_IPYNB[ext], ext)
+    assert len(nb.cells) == 1
+    compare(ACTIVE_IPYNB[ext], jupytext.writes(nb, ext))
+    compare(nb.cells[0], ACTIVE_IPYNB['.ipynb'])
 
 
 ACTIVE_IPYNB_RMD_USING_TAG = {'.py': """# + {"tags": ["active-ipynb-Rmd"]}
@@ -107,12 +105,11 @@ ACTIVE_IPYNB_RMD_USING_TAG = {'.py': """# + {"tags": ["active-ipynb-Rmd"]}
 
 @skip_if_dict_is_not_ordered
 @pytest.mark.parametrize('ext', ['.Rmd', '.py', '.R'])
-def test_active_ipynb_rmd_using_tags(ext):
-    with mock.patch('jupytext.header.INSERT_AND_CHECK_VERSION_NUMBER', False):
-        nb = jupytext.reads(HEADER[ext] + ACTIVE_IPYNB_RMD_USING_TAG[ext], ext)
-        assert len(nb.cells) == 1
-        compare(ACTIVE_IPYNB_RMD_USING_TAG[ext], jupytext.writes(nb, ext))
-        compare(nb.cells[0], ACTIVE_IPYNB_RMD_USING_TAG['.ipynb'])
+def test_active_ipynb_rmd_using_tags(ext, header_insert_and_check_version_number_patch):
+    nb = jupytext.reads(HEADER[ext] + ACTIVE_IPYNB_RMD_USING_TAG[ext], ext)
+    assert len(nb.cells) == 1
+    compare(ACTIVE_IPYNB_RMD_USING_TAG[ext], jupytext.writes(nb, ext))
+    compare(nb.cells[0], ACTIVE_IPYNB_RMD_USING_TAG['.ipynb'])
 
 
 ACTIVE_IPYNB_RSPIN = {'.R': """#+ active="ipynb", eval=FALSE
@@ -128,12 +125,11 @@ ACTIVE_IPYNB_RSPIN = {'.R': """#+ active="ipynb", eval=FALSE
 
 
 @skip_if_dict_is_not_ordered
-def test_active_ipynb_rspin():
-    with mock.patch('jupytext.header.INSERT_AND_CHECK_VERSION_NUMBER', False):
-        nb = jupytext.reads(ACTIVE_IPYNB_RSPIN['.R'], 'R:spin')
-        assert len(nb.cells) == 1
-        compare(ACTIVE_IPYNB_RSPIN['.R'], jupytext.writes(nb, 'R:spin'))
-        compare(nb.cells[0], ACTIVE_IPYNB_RSPIN['.ipynb'])
+def test_active_ipynb_rspin(header_insert_and_check_version_number_patch):
+    nb = jupytext.reads(ACTIVE_IPYNB_RSPIN['.R'], 'R:spin')
+    assert len(nb.cells) == 1
+    compare(ACTIVE_IPYNB_RSPIN['.R'], jupytext.writes(nb, 'R:spin'))
+    compare(nb.cells[0], ACTIVE_IPYNB_RSPIN['.ipynb'])
 
 
 ACTIVE_PY_IPYNB = {'.py': """# + {"active": "ipynb,py"}
@@ -156,12 +152,11 @@ ACTIVE_PY_IPYNB = {'.py': """# + {"active": "ipynb,py"}
 
 @skip_if_dict_is_not_ordered
 @pytest.mark.parametrize('ext', ['.Rmd', '.py', '.R'])
-def test_active_py_ipynb(ext):
-    with mock.patch('jupytext.header.INSERT_AND_CHECK_VERSION_NUMBER', False):
-        nb = jupytext.reads(HEADER[ext] + ACTIVE_PY_IPYNB[ext], ext)
-        assert len(nb.cells) == 1
-        compare(ACTIVE_PY_IPYNB[ext], jupytext.writes(nb, ext))
-        compare(nb.cells[0], ACTIVE_PY_IPYNB['.ipynb'])
+def test_active_py_ipynb(ext, header_insert_and_check_version_number_patch):
+    nb = jupytext.reads(HEADER[ext] + ACTIVE_PY_IPYNB[ext], ext)
+    assert len(nb.cells) == 1
+    compare(ACTIVE_PY_IPYNB[ext], jupytext.writes(nb, ext))
+    compare(nb.cells[0], ACTIVE_PY_IPYNB['.ipynb'])
 
 
 ACTIVE_PY_R_IPYNB = {'.py': """# + {"active": "ipynb,py,R"}
@@ -184,12 +179,11 @@ ACTIVE_PY_R_IPYNB = {'.py': """# + {"active": "ipynb,py,R"}
 
 @skip_if_dict_is_not_ordered
 @pytest.mark.parametrize('ext', ['.Rmd', '.py', '.R'])
-def test_active_py_r_ipynb(ext):
-    with mock.patch('jupytext.header.INSERT_AND_CHECK_VERSION_NUMBER', False):
-        nb = jupytext.reads(HEADER[ext] + ACTIVE_PY_R_IPYNB[ext], ext)
-        assert len(nb.cells) == 1
-        compare(ACTIVE_PY_R_IPYNB[ext], jupytext.writes(nb, ext))
-        compare(nb.cells[0], ACTIVE_PY_R_IPYNB['.ipynb'])
+def test_active_py_r_ipynb(ext, header_insert_and_check_version_number_patch):
+    nb = jupytext.reads(HEADER[ext] + ACTIVE_PY_R_IPYNB[ext], ext)
+    assert len(nb.cells) == 1
+    compare(ACTIVE_PY_R_IPYNB[ext], jupytext.writes(nb, ext))
+    compare(nb.cells[0], ACTIVE_PY_R_IPYNB['.ipynb'])
 
 
 ACTIVE_RMD = {'.py': """# + {"active": "Rmd"}
@@ -209,12 +203,11 @@ ACTIVE_RMD = {'.py': """# + {"active": "Rmd"}
 
 @skip_if_dict_is_not_ordered
 @pytest.mark.parametrize('ext', ['.Rmd', '.py', '.R'])
-def test_active_rmd(ext):
-    with mock.patch('jupytext.header.INSERT_AND_CHECK_VERSION_NUMBER', False):
-        nb = jupytext.reads(HEADER[ext] + ACTIVE_RMD[ext], ext)
-        assert len(nb.cells) == 1
-        compare(ACTIVE_RMD[ext], jupytext.writes(nb, ext))
-        compare(nb.cells[0], ACTIVE_RMD['.ipynb'])
+def test_active_rmd(ext, header_insert_and_check_version_number_patch):
+    nb = jupytext.reads(HEADER[ext] + ACTIVE_RMD[ext], ext)
+    assert len(nb.cells) == 1
+    compare(ACTIVE_RMD[ext], jupytext.writes(nb, ext))
+    compare(nb.cells[0], ACTIVE_RMD['.ipynb'])
 
 
 ACTIVE_NOT_INCLUDE_RMD = {'.py': """# + {"hide_output": true, "active": "Rmd"}
@@ -236,9 +229,8 @@ ACTIVE_NOT_INCLUDE_RMD = {'.py': """# + {"hide_output": true, "active": "Rmd"}
 
 @skip_if_dict_is_not_ordered
 @pytest.mark.parametrize('ext', ['.Rmd', '.py', '.R'])
-def test_active_not_include_rmd(ext):
-    with mock.patch('jupytext.header.INSERT_AND_CHECK_VERSION_NUMBER', False):
-        nb = jupytext.reads(ACTIVE_NOT_INCLUDE_RMD[ext], ext)
-        assert len(nb.cells) == 1
-        compare(ACTIVE_NOT_INCLUDE_RMD[ext], jupytext.writes(nb, ext))
-        compare(nb.cells[0], ACTIVE_NOT_INCLUDE_RMD['.ipynb'])
+def test_active_not_include_rmd(ext, header_insert_and_check_version_number_patch):
+    nb = jupytext.reads(ACTIVE_NOT_INCLUDE_RMD[ext], ext)
+    assert len(nb.cells) == 1
+    compare(ACTIVE_NOT_INCLUDE_RMD[ext], jupytext.writes(nb, ext))
+    compare(nb.cells[0], ACTIVE_NOT_INCLUDE_RMD['.ipynb'])

--- a/tests/test_active_cells.py
+++ b/tests/test_active_cells.py
@@ -45,7 +45,6 @@ ACTIVE_ALL = {'.py': """# + {"active": "ipynb,py,R,Rmd"}
 
 @pytest.mark.parametrize('ext', ['.Rmd', '.py', '.R'])
 def test_active_all(ext, header_insert_and_check_version_number_patch):
-    assert jupytext.header.INSERT_AND_CHECK_VERSION_NUMBER == False
     nb = jupytext.reads(HEADER[ext] + ACTIVE_ALL[ext], ext)
     assert len(nb.cells) == 1
     compare(ACTIVE_ALL[ext], jupytext.writes(nb, ext))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,10 @@ import os
 import sys
 import time
 import stat
-import mock
+try:
+    import mock
+except ImportError:
+    import unittest.mock as mock
 import pytest
 import nbformat
 import itertools

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,10 +2,11 @@ import os
 import sys
 import time
 import stat
+
 try:
-    import mock
-except ImportError:
     import unittest.mock as mock
+except ImportError:
+    import mock
 import pytest
 import nbformat
 import itertools

--- a/tests/test_escape_magics.py
+++ b/tests/test_escape_magics.py
@@ -131,7 +131,7 @@ def test_markdown_image_is_not_magic():
     assert not is_magic('# ![Image name](image.png', 'python')
 
 
-def test_multiline_python_magic(header_insert_and_check_version_number_patch):
+def test_multiline_python_magic(no_jupytext_version_number):
     nb = new_notebook(cells=[new_code_cell("""%load_ext watermark
 %watermark -u -n -t -z \\
     -p jupytext -v

--- a/tests/test_escape_magics.py
+++ b/tests/test_escape_magics.py
@@ -1,5 +1,4 @@
 import pytest
-import mock
 from nbformat.v4.nbbase import new_code_cell, new_notebook
 from jupytext.compare import compare
 from jupytext.magics import comment_magic, uncomment_magic, unesc, is_magic
@@ -132,7 +131,7 @@ def test_markdown_image_is_not_magic():
     assert not is_magic('# ![Image name](image.png', 'python')
 
 
-def test_multiline_python_magic():
+def test_multiline_python_magic(header_insert_and_check_version_number_patch):
     nb = new_notebook(cells=[new_code_cell("""%load_ext watermark
 %watermark -u -n -t -z \\
     -p jupytext -v
@@ -140,8 +139,7 @@ def test_multiline_python_magic():
 def g(x):
     return x+1""")])
 
-    with mock.patch('jupytext.header.INSERT_AND_CHECK_VERSION_NUMBER', False):
-        text = jupytext.writes(nb, 'py')
+    text = jupytext.writes(nb, 'py')
     compare("""# +
 # %load_ext watermark
 # %watermark -u -n -t -z \\

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -1,5 +1,4 @@
 from nbformat.v4.nbbase import new_notebook, new_raw_cell, new_markdown_cell
-import mock
 from jupytext.compare import compare
 import jupytext
 from jupytext.header import uncomment_line, header_to_metadata_and_cell, metadata_and_cell_to_header
@@ -68,13 +67,12 @@ title: Sample header
     assert pos == len(lines)
 
 
-def test_metadata_and_cell_to_header():
+def test_metadata_and_cell_to_header(header_insert_and_check_version_number_patch):
     metadata = {'jupytext': {'mainlanguage': 'python'}}
     nb = new_notebook(
         metadata=metadata,
         cells=[new_raw_cell(source="---\ntitle: Sample header\n---")])
-    with mock.patch('jupytext.header.INSERT_AND_CHECK_VERSION_NUMBER', False):
-        header, lines_to_next_cell = metadata_and_cell_to_header(nb, metadata, get_format_implementation('.md'), '.md')
+    header, lines_to_next_cell = metadata_and_cell_to_header(nb, metadata, get_format_implementation('.md'), '.md')
     assert '\n'.join(header) == """---
 title: Sample header
 jupyter:
@@ -85,10 +83,9 @@ jupyter:
     assert lines_to_next_cell is None
 
 
-def test_metadata_and_cell_to_header2():
+def test_metadata_and_cell_to_header2(header_insert_and_check_version_number_patch):
     nb = new_notebook(cells=[new_markdown_cell(source="Some markdown\ntext")])
-    with mock.patch('jupytext.header.INSERT_AND_CHECK_VERSION_NUMBER', False):
-        header, lines_to_next_cell = metadata_and_cell_to_header(nb, {}, get_format_implementation('.md'), '.md')
+    header, lines_to_next_cell = metadata_and_cell_to_header(nb, {}, get_format_implementation('.md'), '.md')
     assert header == []
     assert len(nb.cells) == 1
     assert lines_to_next_cell is None

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -67,7 +67,7 @@ title: Sample header
     assert pos == len(lines)
 
 
-def test_metadata_and_cell_to_header(header_insert_and_check_version_number_patch):
+def test_metadata_and_cell_to_header(no_jupytext_version_number):
     metadata = {'jupytext': {'mainlanguage': 'python'}}
     nb = new_notebook(
         metadata=metadata,
@@ -83,7 +83,7 @@ jupyter:
     assert lines_to_next_cell is None
 
 
-def test_metadata_and_cell_to_header2(header_insert_and_check_version_number_patch):
+def test_metadata_and_cell_to_header2(no_jupytext_version_number):
     nb = new_notebook(cells=[new_markdown_cell(source="Some markdown\ntext")])
     header, lines_to_next_cell = metadata_and_cell_to_header(nb, {}, get_format_implementation('.md'), '.md')
     assert header == []

--- a/tests/test_load_multiple.py
+++ b/tests/test_load_multiple.py
@@ -1,5 +1,4 @@
 import pytest
-import mock
 from tornado.web import HTTPError
 from nbformat.v4.nbbase import new_notebook
 import jupytext
@@ -55,6 +54,4 @@ def test_combine_lower_version_raises(tmpdir):
     cm.root_dir = str(tmpdir)
 
     with pytest.raises(HTTPError):
-        with mock.patch('jupytext.header.INSERT_AND_CHECK_VERSION_NUMBER',
-                        True):
-            cm.get(tmp_ipynb)
+        cm.get(tmp_ipynb)

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -22,7 +22,7 @@ def create_mirror_file_if_missing(mirror_file, notebook, fmt):
         jupytext.write(notebook, mirror_file, fmt=fmt)
 
 
-def test_create_mirror_file_if_missing(tmpdir, header_insert_and_check_version_number_patch):
+def test_create_mirror_file_if_missing(tmpdir, no_jupytext_version_number):
     py_file = str(tmpdir.join('notebook.py'))
     assert not os.path.isfile(py_file)
     create_mirror_file_if_missing(py_file, new_notebook(), 'py')
@@ -83,44 +83,44 @@ def assert_conversion_same_as_mirror(nb_file, fmt, mirror_name, compare_notebook
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('julia') + list_notebooks('python') + list_notebooks('R'))
-def test_script_to_ipynb(nb_file, header_insert_and_check_version_number_patch):
+def test_script_to_ipynb(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'ipynb', 'script_to_ipynb')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_julia'))
-def test_ipynb_to_julia(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_julia(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'jl', 'ipynb_to_script')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_py', skip='many hash'))
-def test_ipynb_to_python(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_python(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'py', 'ipynb_to_script')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_py', skip=''))
-def test_ipynb_to_python_vim(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_python_vim(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, {'extension': '.py', 'cell_markers': '{{{,}}}'},
                                      'ipynb_to_script_vim_folding_markers')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_py', skip=''))
-def test_ipynb_to_python_vscode(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_python_vscode(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, {'extension': '.py', 'cell_markers': 'region,endregion'},
                                      'ipynb_to_script_vscode_folding_markers')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_R'))
-def test_ipynb_to_R(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_R(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'R', 'ipynb_to_script')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_R'))
-def test_ipynb_to_r(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_r(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, '.low.r', 'ipynb_to_script')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_m'))
-def test_ipynb_to_m(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_m(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, '.m', 'ipynb_to_script')
 
 
@@ -128,72 +128,72 @@ def test_ipynb_to_m(nb_file, header_insert_and_check_version_number_patch):
                          [(nb_file, extension)
                           for nb_file in list_notebooks('ipynb_scheme')
                           for extension in ('ss', 'scm')])
-def test_ipynb_to_scheme(nb_file, extension, header_insert_and_check_version_number_patch):
+def test_ipynb_to_scheme(nb_file, extension, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, extension, 'ipynb_to_script')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_clojure'))
-def test_ipynb_to_clojure(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_clojure(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'clj', 'ipynb_to_script')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_bash'))
-def test_ipynb_to_bash(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_bash(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'sh', 'ipynb_to_script')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_cpp'))
-def test_ipynb_to_cpp(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_cpp(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'cpp', 'ipynb_to_script')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_q'))
-def test_ipynb_to_q(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_q(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'q', 'ipynb_to_script')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_julia'))
-def test_ipynb_to_julia_percent(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_julia_percent(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'jl:percent', 'ipynb_to_percent')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_m'))
-def test_ipynb_to_m_percent(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_m_percent(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'm:percent', 'ipynb_to_percent')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_py', skip=''))
-def test_ipynb_to_python_percent(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_python_percent(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'py:percent', 'ipynb_to_percent')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_py'))
-def test_ipynb_to_python_hydrogen(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_python_hydrogen(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'py:hydrogen', 'ipynb_to_hydrogen')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_R'))
-def test_ipynb_to_R_percent(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_R_percent(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'R:percent', 'ipynb_to_percent')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_R'))
-def test_ipynb_to_r_percent(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_r_percent(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, '.low.r:percent', 'ipynb_to_percent')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_R'))
-def test_ipynb_to_R_spin(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_R_spin(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'R', 'ipynb_to_spin')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_R'))
-def test_ipynb_to_r_spin(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_r_spin(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, '.low.r', 'ipynb_to_spin')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_cpp'))
-def test_ipynb_to_cpp_percent(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_cpp_percent(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'cpp:percent', 'ipynb_to_percent')
 
 
@@ -201,123 +201,123 @@ def test_ipynb_to_cpp_percent(nb_file, header_insert_and_check_version_number_pa
                          [(nb_file, extension)
                           for nb_file in list_notebooks('ipynb_scheme')
                           for extension in ('ss', 'scm')])
-def test_ipynb_to_scheme_percent(nb_file, extension, header_insert_and_check_version_number_patch):
+def test_ipynb_to_scheme_percent(nb_file, extension, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file,
                                      '{}:percent'.format(extension),
                                      'ipynb_to_percent')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_clojure'))
-def test_ipynb_to_clojure_percent(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_clojure_percent(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'clj:percent', 'ipynb_to_percent')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_bash'))
-def test_ipynb_to_bash_percent(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_bash_percent(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'sh:percent', 'ipynb_to_percent')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_q'))
-def test_ipynb_to_q_percent(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_q_percent(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'q:percent', 'ipynb_to_percent')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('percent'))
-def test_percent_to_ipynb(nb_file, header_insert_and_check_version_number_patch):
+def test_percent_to_ipynb(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'ipynb:percent', 'script_to_ipynb')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('hydrogen'))
-def test_hydrogen_to_ipynb(nb_file, header_insert_and_check_version_number_patch):
+def test_hydrogen_to_ipynb(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'ipynb:hydrogen', 'script_to_ipynb')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('R_spin'))
-def test_spin_to_ipynb(nb_file, header_insert_and_check_version_number_patch):
+def test_spin_to_ipynb(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'ipynb:spin', 'script_to_ipynb')
 
 
 @requires_sphinx_gallery
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_py', skip='(raw|hash|frozen|magic|html|164|long)'))
-def test_ipynb_to_python_sphinx(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_python_sphinx(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'py:sphinx', 'ipynb_to_sphinx')
 
 
 @requires_sphinx_gallery
 @pytest.mark.parametrize('nb_file', list_notebooks('sphinx'))
-def test_sphinx_to_ipynb(nb_file, header_insert_and_check_version_number_patch):
+def test_sphinx_to_ipynb(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'ipynb:sphinx', 'sphinx_to_ipynb')
 
 
 @requires_sphinx_gallery
 @pytest.mark.parametrize('nb_file', list_notebooks('sphinx'))
-def test_sphinx_md_to_ipynb(nb_file, header_insert_and_check_version_number_patch):
+def test_sphinx_md_to_ipynb(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, {'extension': '.ipynb', 'format_name': 'sphinx', 'rst2md': True},
                                      'sphinx-rst2md_to_ipynb', compare_notebook=True)
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('md'))
-def test_md_to_ipynb(nb_file, header_insert_and_check_version_number_patch):
+def test_md_to_ipynb(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'ipynb', 'md_to_ipynb')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('Rmd'))
-def test_Rmd_to_ipynb(nb_file, header_insert_and_check_version_number_patch):
+def test_Rmd_to_ipynb(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'ipynb', 'Rmd_to_ipynb')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_all', skip='Calysto|66'))
-def test_ipynb_to_Rmd(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_Rmd(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'Rmd', 'ipynb_to_Rmd')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_all', skip='Calysto'))
-def test_ipynb_to_md(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_md(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'md', 'ipynb_to_md')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_idl'))
-def test_ipynb_to_pro(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_pro(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'pro', 'ipynb_to_script')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_idl'))
-def test_ipynb_to_pro_percent(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_pro_percent(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'pro:percent', 'ipynb_to_percent')
 
 
 @requires_pandoc
 @pytest.mark.parametrize('nb_file',
                          list_notebooks('ipynb', skip='(functional|Notebook with|flavors|invalid)'))
-def test_ipynb_to_pandoc(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_pandoc(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'md:pandoc', 'ipynb_to_pandoc')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_js'))
-def test_ipynb_to_js(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_js(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'js', 'ipynb_to_script')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_js'))
-def test_ipynb_to_js_percent(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_js_percent(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'js:percent', 'ipynb_to_percent')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_ts'))
-def test_ipynb_to_ts(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_ts(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'ts', 'ipynb_to_script')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_ts'))
-def test_ipynb_to_ts_percent(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_ts_percent(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'ts:percent', 'ipynb_to_percent')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_scala'))
-def test_ipynb_to_scala(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_scala(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'scala', 'ipynb_to_script')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_scala'))
-def test_ipynb_to_scala_percent(nb_file, header_insert_and_check_version_number_patch):
+def test_ipynb_to_scala_percent(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'scala:percent', 'ipynb_to_percent')

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -4,8 +4,6 @@ change on new releases.
 """
 
 import os
-
-import mock
 import pytest
 from nbformat.v4.nbbase import new_notebook
 from jupytext.compare import compare
@@ -21,11 +19,10 @@ pytestmark = skip_if_dict_is_not_ordered
 
 def create_mirror_file_if_missing(mirror_file, notebook, fmt):
     if not os.path.isfile(mirror_file):
-        with mock.patch('jupytext.header.INSERT_AND_CHECK_VERSION_NUMBER', False):
-            jupytext.write(notebook, mirror_file, fmt=fmt)
+        jupytext.write(notebook, mirror_file, fmt=fmt)
 
 
-def test_create_mirror_file_if_missing(tmpdir):
+def test_create_mirror_file_if_missing(tmpdir, header_insert_and_check_version_number_patch):
     py_file = str(tmpdir.join('notebook.py'))
     assert not os.path.isfile(py_file)
     create_mirror_file_if_missing(py_file, new_notebook(), 'py')
@@ -39,12 +36,11 @@ def assert_conversion_same_as_mirror(nb_file, fmt, mirror_name, compare_notebook
     ext = fmt['extension']
     mirror_file = os.path.join(dirname, '..', 'mirror', mirror_name, full_path(file_name, fmt))
 
-    with mock.patch('jupytext.header.INSERT_AND_CHECK_VERSION_NUMBER', False):
-        notebook = jupytext.read(nb_file, fmt=fmt)
-        # it's better not to have Jupytext metadata in test notebooks:
-        if fmt == 'ipynb' and 'jupytext' in notebook.metadata:  # pragma: no cover
-            notebook.metadata.pop('jupytext')
-            jupytext.write(nb_file, fmt=fmt)
+    notebook = jupytext.read(nb_file, fmt=fmt)
+    # it's better not to have Jupytext metadata in test notebooks:
+    if fmt == 'ipynb' and 'jupytext' in notebook.metadata:  # pragma: no cover
+        notebook.metadata.pop('jupytext')
+        jupytext.write(nb_file, fmt=fmt)
 
     create_mirror_file_if_missing(mirror_file, notebook, fmt)
 
@@ -56,13 +52,11 @@ def assert_conversion_same_as_mirror(nb_file, fmt, mirror_name, compare_notebook
     elif ext == '.ipynb':
         notebook = jupytext.read(mirror_file)
         fmt.update({'extension': org_ext})
-        with mock.patch('jupytext.header.INSERT_AND_CHECK_VERSION_NUMBER', False):
-            actual = jupytext.writes(notebook, fmt)
+        actual = jupytext.writes(notebook, fmt)
         with open(nb_file, encoding='utf-8') as fp:
             expected = fp.read()
     else:
-        with mock.patch('jupytext.header.INSERT_AND_CHECK_VERSION_NUMBER', False):
-            actual = jupytext.writes(notebook, fmt)
+        actual = jupytext.writes(notebook, fmt)
         with open(mirror_file, encoding='utf-8') as fp:
             expected = fp.read()
 
@@ -72,9 +66,8 @@ def assert_conversion_same_as_mirror(nb_file, fmt, mirror_name, compare_notebook
 
     # Compare the two notebooks
     if ext != '.ipynb':
-        with mock.patch('jupytext.header.INSERT_AND_CHECK_VERSION_NUMBER', False):
-            notebook = jupytext.read(nb_file)
-            nb_mirror = jupytext.read(mirror_file, fmt=fmt)
+        notebook = jupytext.read(nb_file)
+        nb_mirror = jupytext.read(mirror_file, fmt=fmt)
 
         if fmt.get('format_name') == 'sphinx':
             nb_mirror.cells = nb_mirror.cells[1:]
@@ -90,44 +83,44 @@ def assert_conversion_same_as_mirror(nb_file, fmt, mirror_name, compare_notebook
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('julia') + list_notebooks('python') + list_notebooks('R'))
-def test_script_to_ipynb(nb_file):
+def test_script_to_ipynb(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'ipynb', 'script_to_ipynb')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_julia'))
-def test_ipynb_to_julia(nb_file):
+def test_ipynb_to_julia(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'jl', 'ipynb_to_script')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_py', skip='many hash'))
-def test_ipynb_to_python(nb_file):
+def test_ipynb_to_python(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'py', 'ipynb_to_script')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_py', skip=''))
-def test_ipynb_to_python_vim(nb_file):
+def test_ipynb_to_python_vim(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, {'extension': '.py', 'cell_markers': '{{{,}}}'},
                                      'ipynb_to_script_vim_folding_markers')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_py', skip=''))
-def test_ipynb_to_python_vscode(nb_file):
+def test_ipynb_to_python_vscode(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, {'extension': '.py', 'cell_markers': 'region,endregion'},
                                      'ipynb_to_script_vscode_folding_markers')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_R'))
-def test_ipynb_to_R(nb_file):
+def test_ipynb_to_R(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'R', 'ipynb_to_script')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_R'))
-def test_ipynb_to_r(nb_file):
+def test_ipynb_to_r(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, '.low.r', 'ipynb_to_script')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_m'))
-def test_ipynb_to_m(nb_file):
+def test_ipynb_to_m(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, '.m', 'ipynb_to_script')
 
 
@@ -135,72 +128,72 @@ def test_ipynb_to_m(nb_file):
                          [(nb_file, extension)
                           for nb_file in list_notebooks('ipynb_scheme')
                           for extension in ('ss', 'scm')])
-def test_ipynb_to_scheme(nb_file, extension):
+def test_ipynb_to_scheme(nb_file, extension, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, extension, 'ipynb_to_script')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_clojure'))
-def test_ipynb_to_clojure(nb_file):
+def test_ipynb_to_clojure(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'clj', 'ipynb_to_script')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_bash'))
-def test_ipynb_to_bash(nb_file):
+def test_ipynb_to_bash(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'sh', 'ipynb_to_script')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_cpp'))
-def test_ipynb_to_cpp(nb_file):
+def test_ipynb_to_cpp(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'cpp', 'ipynb_to_script')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_q'))
-def test_ipynb_to_q(nb_file):
+def test_ipynb_to_q(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'q', 'ipynb_to_script')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_julia'))
-def test_ipynb_to_julia_percent(nb_file):
+def test_ipynb_to_julia_percent(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'jl:percent', 'ipynb_to_percent')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_m'))
-def test_ipynb_to_m_percent(nb_file):
+def test_ipynb_to_m_percent(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'm:percent', 'ipynb_to_percent')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_py', skip=''))
-def test_ipynb_to_python_percent(nb_file):
+def test_ipynb_to_python_percent(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'py:percent', 'ipynb_to_percent')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_py'))
-def test_ipynb_to_python_hydrogen(nb_file):
+def test_ipynb_to_python_hydrogen(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'py:hydrogen', 'ipynb_to_hydrogen')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_R'))
-def test_ipynb_to_R_percent(nb_file):
+def test_ipynb_to_R_percent(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'R:percent', 'ipynb_to_percent')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_R'))
-def test_ipynb_to_r_percent(nb_file):
+def test_ipynb_to_r_percent(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, '.low.r:percent', 'ipynb_to_percent')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_R'))
-def test_ipynb_to_R_spin(nb_file):
+def test_ipynb_to_R_spin(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'R', 'ipynb_to_spin')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_R'))
-def test_ipynb_to_r_spin(nb_file):
+def test_ipynb_to_r_spin(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, '.low.r', 'ipynb_to_spin')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_cpp'))
-def test_ipynb_to_cpp_percent(nb_file):
+def test_ipynb_to_cpp_percent(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'cpp:percent', 'ipynb_to_percent')
 
 
@@ -208,123 +201,123 @@ def test_ipynb_to_cpp_percent(nb_file):
                          [(nb_file, extension)
                           for nb_file in list_notebooks('ipynb_scheme')
                           for extension in ('ss', 'scm')])
-def test_ipynb_to_scheme_percent(nb_file, extension):
+def test_ipynb_to_scheme_percent(nb_file, extension, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file,
                                      '{}:percent'.format(extension),
                                      'ipynb_to_percent')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_clojure'))
-def test_ipynb_to_clojure_percent(nb_file):
+def test_ipynb_to_clojure_percent(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'clj:percent', 'ipynb_to_percent')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_bash'))
-def test_ipynb_to_bash_percent(nb_file):
+def test_ipynb_to_bash_percent(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'sh:percent', 'ipynb_to_percent')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_q'))
-def test_ipynb_to_q_percent(nb_file):
+def test_ipynb_to_q_percent(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'q:percent', 'ipynb_to_percent')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('percent'))
-def test_percent_to_ipynb(nb_file):
+def test_percent_to_ipynb(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'ipynb:percent', 'script_to_ipynb')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('hydrogen'))
-def test_hydrogen_to_ipynb(nb_file):
+def test_hydrogen_to_ipynb(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'ipynb:hydrogen', 'script_to_ipynb')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('R_spin'))
-def test_spin_to_ipynb(nb_file):
+def test_spin_to_ipynb(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'ipynb:spin', 'script_to_ipynb')
 
 
 @requires_sphinx_gallery
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_py', skip='(raw|hash|frozen|magic|html|164|long)'))
-def test_ipynb_to_python_sphinx(nb_file):
+def test_ipynb_to_python_sphinx(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'py:sphinx', 'ipynb_to_sphinx')
 
 
 @requires_sphinx_gallery
 @pytest.mark.parametrize('nb_file', list_notebooks('sphinx'))
-def test_sphinx_to_ipynb(nb_file):
+def test_sphinx_to_ipynb(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'ipynb:sphinx', 'sphinx_to_ipynb')
 
 
 @requires_sphinx_gallery
 @pytest.mark.parametrize('nb_file', list_notebooks('sphinx'))
-def test_sphinx_md_to_ipynb(nb_file):
+def test_sphinx_md_to_ipynb(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, {'extension': '.ipynb', 'format_name': 'sphinx', 'rst2md': True},
                                      'sphinx-rst2md_to_ipynb', compare_notebook=True)
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('md'))
-def test_md_to_ipynb(nb_file):
+def test_md_to_ipynb(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'ipynb', 'md_to_ipynb')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('Rmd'))
-def test_Rmd_to_ipynb(nb_file):
+def test_Rmd_to_ipynb(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'ipynb', 'Rmd_to_ipynb')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_all', skip='Calysto|66'))
-def test_ipynb_to_Rmd(nb_file):
+def test_ipynb_to_Rmd(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'Rmd', 'ipynb_to_Rmd')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_all', skip='Calysto'))
-def test_ipynb_to_md(nb_file):
+def test_ipynb_to_md(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'md', 'ipynb_to_md')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_idl'))
-def test_ipynb_to_pro(nb_file):
+def test_ipynb_to_pro(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'pro', 'ipynb_to_script')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_idl'))
-def test_ipynb_to_pro_percent(nb_file):
+def test_ipynb_to_pro_percent(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'pro:percent', 'ipynb_to_percent')
 
 
 @requires_pandoc
 @pytest.mark.parametrize('nb_file',
                          list_notebooks('ipynb', skip='(functional|Notebook with|flavors|invalid)'))
-def test_ipynb_to_pandoc(nb_file):
+def test_ipynb_to_pandoc(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'md:pandoc', 'ipynb_to_pandoc')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_js'))
-def test_ipynb_to_js(nb_file):
+def test_ipynb_to_js(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'js', 'ipynb_to_script')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_js'))
-def test_ipynb_to_js_percent(nb_file):
+def test_ipynb_to_js_percent(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'js:percent', 'ipynb_to_percent')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_ts'))
-def test_ipynb_to_ts(nb_file):
+def test_ipynb_to_ts(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'ts', 'ipynb_to_script')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_ts'))
-def test_ipynb_to_ts_percent(nb_file):
+def test_ipynb_to_ts_percent(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'ts:percent', 'ipynb_to_percent')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_scala'))
-def test_ipynb_to_scala(nb_file):
+def test_ipynb_to_scala(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'scala', 'ipynb_to_script')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_scala'))
-def test_ipynb_to_scala_percent(nb_file):
+def test_ipynb_to_scala_percent(nb_file, header_insert_and_check_version_number_patch):
     assert_conversion_same_as_mirror(nb_file, 'scala:percent', 'ipynb_to_percent')

--- a/tests/test_read_simple_markdown.py
+++ b/tests/test_read_simple_markdown.py
@@ -1,4 +1,7 @@
-import mock
+try:
+    import mock
+except ImportError:
+    import unittest.mock as mock
 from nbformat.v4.nbbase import new_code_cell, new_raw_cell, new_markdown_cell
 from jupytext.compare import compare
 import jupytext

--- a/tests/test_read_simple_markdown.py
+++ b/tests/test_read_simple_markdown.py
@@ -1,7 +1,7 @@
 try:
-    import mock
-except ImportError:
     import unittest.mock as mock
+except ImportError:
+    import mock
 from nbformat.v4.nbbase import new_code_cell, new_raw_cell, new_markdown_cell
 from jupytext.compare import compare
 import jupytext

--- a/tests/test_read_simple_markdown.py
+++ b/tests/test_read_simple_markdown.py
@@ -1,7 +1,3 @@
-try:
-    import unittest.mock as mock
-except ImportError:
-    import mock
 from nbformat.v4.nbbase import new_code_cell, new_raw_cell, new_markdown_cell
 from jupytext.compare import compare
 import jupytext
@@ -302,7 +298,7 @@ nor be split into two pieces."""
     assert len(nb.cells) == 1
 
 
-def test_read_markdown_idl(text='''---
+def test_read_markdown_idl(no_jupytext_version_number, text='''---
 jupyter:
   kernelspec:
     display_name: IDL [conda env:gdl] *
@@ -321,13 +317,11 @@ a = 1
     assert nb.cells[1].cell_type == 'code'
     assert nb.cells[1].source == 'a = 1'
 
-    nb.metadata.pop('jupytext')
-    with mock.patch('jupytext.header.INSERT_AND_CHECK_VERSION_NUMBER', False):
-        text2 = jupytext.writes(nb, 'md')
+    text2 = jupytext.writes(nb, 'md')
     compare(text, text2)
 
 
-def test_read_markdown_IDL(text='''---
+def test_read_markdown_IDL(no_jupytext_version_number, text='''---
 jupyter:
   kernelspec:
     display_name: IDL [conda env:gdl] *
@@ -346,7 +340,5 @@ a = 1
     assert nb.cells[1].cell_type == 'code'
     assert nb.cells[1].source == 'a = 1'
 
-    nb.metadata.pop('jupytext')
-    with mock.patch('jupytext.header.INSERT_AND_CHECK_VERSION_NUMBER', False):
-        text2 = jupytext.writes(nb, 'md')
+    text2 = jupytext.writes(nb, 'md')
     compare(text.replace('```IDL', '```idl'), text2)

--- a/tests/test_rmd_to_ipynb.py
+++ b/tests/test_rmd_to_ipynb.py
@@ -7,7 +7,7 @@ from .utils import skip_if_dict_is_not_ordered
 
 @skip_if_dict_is_not_ordered
 @pytest.mark.parametrize('nb_file', list_notebooks('Rmd'))
-def test_identity_write_read(nb_file, header_insert_and_check_version_number_patch):
+def test_identity_write_read(nb_file, no_jupytext_version_number):
     """Test that writing the notebook with ipynb, and read again, yields identity"""
 
     with open(nb_file) as fp:

--- a/tests/test_rmd_to_ipynb.py
+++ b/tests/test_rmd_to_ipynb.py
@@ -1,4 +1,3 @@
-import mock
 import pytest
 from jupytext.compare import compare
 import jupytext
@@ -8,15 +7,14 @@ from .utils import skip_if_dict_is_not_ordered
 
 @skip_if_dict_is_not_ordered
 @pytest.mark.parametrize('nb_file', list_notebooks('Rmd'))
-def test_identity_write_read(nb_file):
+def test_identity_write_read(nb_file, header_insert_and_check_version_number_patch):
     """Test that writing the notebook with ipynb, and read again, yields identity"""
 
     with open(nb_file) as fp:
         rmd = fp.read()
 
-    with mock.patch('jupytext.header.INSERT_AND_CHECK_VERSION_NUMBER', False):
-        nb = jupytext.reads(rmd, 'Rmd')
-        rmd2 = jupytext.writes(nb, 'Rmd')
+    nb = jupytext.reads(rmd, 'Rmd')
+    rmd2 = jupytext.writes(nb, 'Rmd')
 
     compare(rmd, rmd2)
 

--- a/tests/test_trust_notebook.py
+++ b/tests/test_trust_notebook.py
@@ -26,7 +26,7 @@ def test_rmd_notebooks_are_trusted(nb_file):
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_py', skip='hash sign'))
-def test_ipynb_notebooks_can_be_trusted(nb_file, tmpdir, header_insert_and_check_version_number_patch):
+def test_ipynb_notebooks_can_be_trusted(nb_file, tmpdir, no_jupytext_version_number):
     cm = TextFileContentsManager()
     root, file = os.path.split(nb_file)
     tmp_ipynb = str(tmpdir.join(file))
@@ -72,7 +72,7 @@ def test_ipynb_notebooks_can_be_trusted(nb_file, tmpdir, header_insert_and_check
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_py', skip='hash sign'))
 def test_ipynb_notebooks_can_be_trusted_even_with_metadata_filter(nb_file, tmpdir,
-                                                                  header_insert_and_check_version_number_patch):
+                                                                  no_jupytext_version_number):
     cm = TextFileContentsManager()
     root, file = os.path.split(nb_file)
     tmp_ipynb = str(tmpdir.join(file))

--- a/tests/test_trust_notebook.py
+++ b/tests/test_trust_notebook.py
@@ -1,5 +1,4 @@
 import os
-import mock
 import shutil
 import pytest
 from jupytext.contentsmanager import TextFileContentsManager
@@ -27,87 +26,86 @@ def test_rmd_notebooks_are_trusted(nb_file):
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_py', skip='hash sign'))
-def test_ipynb_notebooks_can_be_trusted(nb_file, tmpdir):
-    with mock.patch('jupytext.header.INSERT_AND_CHECK_VERSION_NUMBER', False):
-        cm = TextFileContentsManager()
-        root, file = os.path.split(nb_file)
-        tmp_ipynb = str(tmpdir.join(file))
-        py_file = file.replace('.ipynb', '.py')
-        tmp_py = str(tmpdir.join(py_file))
-        shutil.copy(nb_file, tmp_ipynb)
+def test_ipynb_notebooks_can_be_trusted(nb_file, tmpdir, header_insert_and_check_version_number_patch):
+    cm = TextFileContentsManager()
+    root, file = os.path.split(nb_file)
+    tmp_ipynb = str(tmpdir.join(file))
+    py_file = file.replace('.ipynb', '.py')
+    tmp_py = str(tmpdir.join(py_file))
+    shutil.copy(nb_file, tmp_ipynb)
 
-        cm.default_jupytext_formats = 'ipynb,py'
-        cm.root_dir = str(tmpdir)
-        model = cm.get(file)
-        cm.save(model, py_file)
+    cm.default_jupytext_formats = 'ipynb,py'
+    cm.root_dir = str(tmpdir)
+    model = cm.get(file)
+    cm.save(model, py_file)
 
-        # Unsign and test notebook
-        nb = model['content']
-        for cell in nb.cells:
-            if 'trusted' in cell.metadata:
-                cell.metadata.pop('trusted')
+    # Unsign and test notebook
+    nb = model['content']
+    for cell in nb.cells:
+        if 'trusted' in cell.metadata:
+            cell.metadata.pop('trusted')
 
-        cm.notary.unsign(nb)
+    cm.notary.unsign(nb)
 
-        model = cm.get(file)
-        for cell in model['content'].cells:
-            assert 'trusted' not in cell.metadata or not cell.metadata['trusted'] or not cell.outputs
+    model = cm.get(file)
+    for cell in model['content'].cells:
+        assert 'trusted' not in cell.metadata or not cell.metadata['trusted'] or not cell.outputs
 
-        # Trust and reload
-        cm.trust_notebook(py_file)
+    # Trust and reload
+    cm.trust_notebook(py_file)
 
-        model = cm.get(file)
-        for cell in model['content'].cells:
-            assert cell.metadata.get('trusted', True)
+    model = cm.get(file)
+    for cell in model['content'].cells:
+        assert cell.metadata.get('trusted', True)
 
-        # Remove py file, content should be the same
-        os.remove(tmp_py)
-        nb2 = cm.get(file)
-        for cell in nb2['content'].cells:
-            assert cell.metadata.get('trusted', True)
+    # Remove py file, content should be the same
+    os.remove(tmp_py)
+    nb2 = cm.get(file)
+    for cell in nb2['content'].cells:
+        assert cell.metadata.get('trusted', True)
 
-        assert model['content'] == nb2['content']
+    assert model['content'] == nb2['content']
 
-        # Just for coverage
-        cm.trust_notebook(file)
+    # Just for coverage
+    cm.trust_notebook(file)
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_py', skip='hash sign'))
-def test_ipynb_notebooks_can_be_trusted_even_with_metadata_filter(nb_file, tmpdir):
-    with mock.patch('jupytext.header.INSERT_AND_CHECK_VERSION_NUMBER', False):
-        cm = TextFileContentsManager()
-        root, file = os.path.split(nb_file)
-        tmp_ipynb = str(tmpdir.join(file))
-        py_file = file.replace('.ipynb', '.py')
-        tmp_py = str(tmpdir.join(py_file))
-        shutil.copy(nb_file, tmp_ipynb)
+def test_ipynb_notebooks_can_be_trusted_even_with_metadata_filter(nb_file, tmpdir,
+                                                                  header_insert_and_check_version_number_patch):
+    cm = TextFileContentsManager()
+    root, file = os.path.split(nb_file)
+    tmp_ipynb = str(tmpdir.join(file))
+    py_file = file.replace('.ipynb', '.py')
+    tmp_py = str(tmpdir.join(py_file))
+    shutil.copy(nb_file, tmp_ipynb)
 
-        cm.default_jupytext_formats = 'ipynb,py'
-        cm.default_notebook_metadata_filter = 'all'
-        cm.default_cell_metadata_filter = '-all'
-        cm.root_dir = str(tmpdir)
-        model = cm.get(file)
-        cm.save(model, py_file)
+    cm.default_jupytext_formats = 'ipynb,py'
+    cm.default_notebook_metadata_filter = 'all'
+    cm.default_cell_metadata_filter = '-all'
+    cm.root_dir = str(tmpdir)
+    model = cm.get(file)
+    cm.save(model, py_file)
 
-        # Unsign notebook
-        nb = model['content']
-        for cell in nb.cells:
-            if 'trusted' in cell.metadata:
-                cell.metadata.pop('trusted')
+    # Unsign notebook
+    nb = model['content']
+    for cell in nb.cells:
+        if 'trusted' in cell.metadata:
+            cell.metadata.pop('trusted')
 
-        cm.notary.unsign(nb)
+    cm.notary.unsign(nb)
 
-        # Trust and reload
-        cm.trust_notebook(py_file)
+    # Trust and reload
+    cm.trust_notebook(py_file)
 
-        model = cm.get(file)
-        for cell in model['content'].cells:
-            assert cell.metadata.get('trusted', True)
+    model = cm.get(file)
+    for cell in model['content'].cells:
+        assert cell.metadata.get('trusted', True)
 
-        # Remove py file, content should be the same
-        os.remove(tmp_py)
-        nb2 = cm.get(file)
-        for cell in nb2['content'].cells:
-            assert cell.metadata.get('trusted', True)
+    # Remove py file, content should be the same
+    os.remove(tmp_py)
+    nb2 = cm.get(file)
+    for cell in nb2['content'].cells:
+        assert cell.metadata.get('trusted', True)
 
-        assert model['content'] == nb2['content']
+    assert model['content'] == nb2['content']


### PR DESCRIPTION
In Python 3, mock is available in base Python as `unittest.mock`. See #279 