### PR TITLE
Fix typo in command line arguments doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ jupytext --to py notebook.ipynb                 # convert notebook.ipynb to a .p
 jupytext --to notebook notebook.py              # convert notebook.py to an .ipynb file with no outputs
 jupytext --to notebook --execute notebook.md    # convert notebook.md to an .ipynb file and run it 
 jupytext --update --to notebook notebook.py     # update the input cells in the .ipynb file and preserve outputs and metadata
-jupytext --set-formats --ipynb,py notebook.ipynb  # Turn notebook.ipynb into a paired ipynb/py notebook
+jupytext --set-formats ipynb,py notebook.ipynb  # Turn notebook.ipynb into a paired ipynb/py notebook
 jupytext --sync notebook.ipynb                  # Update all paired representations of notebook.ipynb
 ```
 

--- a/docs/using-cli.md
+++ b/docs/using-cli.md
@@ -22,7 +22,7 @@ jupytext --from ipynb --to py:percent           # read ipynb from stdin and writ
 
 Jupytext has a `--sync` mode that updates all the paired representations of a notebook based on timestamps: 
 ```bash
-jupytext --set-formats --ipynb,py notebook.ipynb  # Turn notebook.ipynb into a paired ipynb/py notebook
+jupytext --set-formats ipynb,py notebook.ipynb  # Turn notebook.ipynb into a paired ipynb/py notebook
 jupytext --sync notebook.ipynb                    # Update whichever of notebook.ipynb/notebook.py is outdated
 ```
 


### PR DESCRIPTION
I was getting an error when following blindly the doc:

```
jupytext: error: argument --set-formats: expected one argument
usage: jupytext [-h] [--from INPUT_FORMAT] [--pre-commit] [--to TO]
                [--format-options FORMAT_OPTIONS] [--set-formats SET_FORMATS]
                [--set-kernel SET_KERNEL] [--update-metadata UPDATE_METADATA]
                [-o OUTPUT] [--update]
                [--version | --paired-paths | --sync | --test | --test-strict]
                [--stop] [--pipe PIPE] [--check CHECK] [--pipe-fmt PIPE_FMT]
                [--quiet]
                [notebooks [notebooks ...]]
jupytext: error: argument --set-formats: expected one argument
```