### PR TITLE
pip install . is optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
       pip install -r requirements.txt;
     fi
   # install is required for testing the pre-commit mode
-  - pip install .
+  - pip install . || true
   # install black if available (Python 3.6 and above), and autopep8 for testing the pipe mode
   - pip install black || true
   - pip install autopep8 || true


### PR DESCRIPTION
As it fails with Python 3.4 on Travis with this error
FileNotFoundError: [Errno 2] No such file or directory: '/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/six-1.10.0.dist-info/METADATA'