### PR TITLE
add instructions in the docs to enable Jupytext extension in Jupyter Lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,17 +53,16 @@ If you want to use Jupytext within Jupyter Notebook or JupyterLab, make sure you
 /path_to_your_jupyter_environment/python -m pip install jupytext --upgrade --user
 ```
 
-Then, enable the Jupytext extension in Jupyter Lab and/or Jupyter Notebook:
-
-```
-jupyter serverextension enable jupytext
-```
-
 ### Jupytext's contents manager
 
-Jupytext includes a contents manager for Jupyter that allows Jupyter to open and save notebooks as text files. When Jupytext's content manager is active in Jupyter, scripts and Markdown documents have a notebook icon.
+Jupytext provides a contents manager for Jupyter that allows Jupyter to open and save notebooks as text files. When Jupytext's content manager is active in Jupyter, scripts and Markdown documents have a notebook icon.
 
-If you don't have the notebook icon on text documents after a fresh restart of your Jupyter server, install the contents manager manually. Append
+In most cases, Jupytext's contents manager is activated automatically by Jupytext's server extension. When you restart either `jupyter lab` or `jupyter notebook`, you should see a line that looks like:
+```bash
+[I 10:28:31.646 LabApp] [Jupytext Server Extension] Changing NotebookApp.contents_manager_class from LargeFileManager to jupytext.TextFileContentsManager
+```
+
+If you don't have the notebook icon on text documents after a fresh restart of your Jupyter server, you can either enable our server extension explicitly (with `jupyter serverextension enable jupytext`), or install the contents manager manually. Append
 ```python
 c.NotebookApp.contents_manager_class = "jupytext.TextFileContentsManager"
 ```

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ If you want to use Jupytext within Jupyter Notebook or JupyterLab, make sure you
 /path_to_your_jupyter_environment/python -m pip install jupytext --upgrade --user
 ```
 
+Then, enable the Jupytext extension in Jupyter Lab and/or Jupyter Notebook:
+
+```
+jupyter serverextension enable jupytext
+```
+
 ### Jupytext's contents manager
 
 Jupytext includes a contents manager for Jupyter that allows Jupyter to open and save notebooks as text files. When Jupytext's content manager is active in Jupyter, scripts and Markdown documents have a notebook icon.
@@ -87,12 +93,6 @@ In JupyterLab, Jupytext adds a set of commands to the command palette:
 The Jupytext extension for JupyterLab is bundled with Jupytext. Installing Jupytext will trigger a build of JupyterLab the next time you open it. If you prefer, you can trigger the build manually with
 ```
 jupyter lab build
-```
-
-You may also need to manually enable the Jupytext extension in Jupyter Lab:
-
-```
-jupyter serverextension enable jupytext
 ```
 
 The version of the extension that is shipped with Jupytext requires JupyterLab 1.0. If you prefer to continue using JupyterLab in version 0.35, you should install the version 0.19 of the extension:

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ The Jupytext extension for JupyterLab is bundled with Jupytext. Installing Jupyt
 jupyter lab build
 ```
 
+You may also need to manually enable the Jupytext extension in Jupyter Lab:
+
+```
+jupyter serverextension enable jupytext
+```
+
 The version of the extension that is shipped with Jupytext requires JupyterLab 1.0. If you prefer to continue using JupyterLab in version 0.35, you should install the version 0.19 of the extension:
 ```
 jupyter labextension install jupyterlab-jupytext@0.19

--- a/docs/install.md
+++ b/docs/install.md
@@ -20,13 +20,18 @@ If you want to use Jupytext within Jupyter Notebook or JupyterLab, make sure you
 
 ## Jupytext's contents manager
 
-Jupytext includes a contents manager for Jupyter that allows Jupyter to open and save notebooks as text files. When Jupytext's content manager is active in Jupyter, scripts and Markdown documents have a notebook icon.
+Jupytext provides a contents manager for Jupyter that allows Jupyter to open and save notebooks as text files. When Jupytext's content manager is active in Jupyter, scripts and Markdown documents have a notebook icon.
 
-If you don't have the notebook icon on text documents after a fresh restart of your Jupyter server, install the contents manager manually. Append
+In most cases, Jupytext's contents manager is activated automatically by Jupytext's server extension. When you restart either `jupyter lab` or `jupyter notebook`, you should see a line that looks like:
+```bash
+[I 10:28:31.646 LabApp] [Jupytext Server Extension] Changing NotebookApp.contents_manager_class from LargeFileManager to jupytext.TextFileContentsManager
+```
+
+If you don't have the notebook icon on text documents after a fresh restart of your Jupyter server, you can either enable our server extension explicitly (with `jupyter serverextension enable jupytext`), or install the contents manager manually. Append
 ```python
 c.NotebookApp.contents_manager_class = "jupytext.TextFileContentsManager"
 ```
-to your `.jupyter/jupyter_notebook_config.py` file (generate a Jupyter config, if you don't have one yet, with `jupyter notebook --generate-config`). Our contents manager accepts a few options: default formats, default metadata filter, etc &mdash; read more on this [below](using-server.html#global-configuration). Then, restart Jupyter Notebook or JupyterLab, either from the JupyterHub interface or from the command line with
+to your `.jupyter/jupyter_notebook_config.py` file (generate a Jupyter config, if you don't have one yet, with `jupyter notebook --generate-config`). Our contents manager accepts a few options: default formats, default metadata filter, etc. Then, restart Jupyter Notebook or JupyterLab, either from the JupyterHub interface or from the command line with
 ```bash
 jupyter notebook # or lab
 ```


### PR DESCRIPTION
Improve the README.md documentation installation instructions in order to avoid the problem reported in #298.