### PR TITLE
Include tests in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,5 @@ include LICENSE
 include *.md
 include *.txt
 include *.rst
+
+graft tests

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,5 @@ include *.txt
 include *.rst
 
 graft tests
+prune tests\__pycache__
+global-exclude *population.ipynb


### PR DESCRIPTION
This lets downstream users and packagers check their installation.