### PR TITLE
Remove Python 2.6 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
   - "3.6"
   - "pypy"
-  - "2.6"
   - "2.7"
   - "3.4"
   - "3.5"
@@ -16,27 +15,6 @@ matrix:
       sudo: required
 
 install:
-  # We use conda in order to install pandoc
-  # Actually, 2.6 here just means conda, with Python 3!
-  # https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/use-conda-with-travis-ci.html
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.6" ]]; then
-      sudo apt-get update;
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-      bash miniconda.sh -b -p $HOME/miniconda;
-      export PATH="$HOME/miniconda/bin:$PATH";
-      hash -r;
-      conda config --set always_yes yes --set changeps1 no;
-      conda update -q conda;
-      conda config --append channels conda-forge;
-      conda info -a;
-      conda create -q -n jupytext-env python=3 --file requirements-dev.txt --file requirements.txt;
-      source activate jupytext-env;
-      conda install pandoc codecov -c conda-forge;
-      pandoc -v;
-    else
-      pip install -r requirements-dev.txt;
-      pip install -r requirements.txt;
-    fi
   # install is required for testing the pre-commit mode
   - pip install . || true
   # install black if available (Python 3.6 and above), and autopep8 for testing the pipe mode

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ matrix:
       sudo: required
 
 install:
+  # install Jupytext requirements
+  - pip install -r requirements-dev.txt
+  - pip install -r requirements.txt
   # install is required for testing the pre-commit mode
   - pip install . || true
   # install black if available (Python 3.6 and above), and autopep8 for testing the pipe mode


### PR DESCRIPTION
Python 2.6 is not available any more on Travis. We'll have to find a better way to test Jupytext with Pandoc from conda-forge - see #313 !