### PR TITLE
1.2.4

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,7 @@
+
+coverage:
+  status:
+    # pull-requests only
+    patch:
+      default:
+        threshold: 0.1%

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,8 @@ before_script:
   - flake8 . --count --exit-zero --max-complexity=10 --statistics
 script:
   - coverage run --source=. -m py.test
+  # Test HTML display of Utf-8 chars with pipes
+  - echo "from IPython.core.display import HTML; HTML(u'\xd7')" | jupytext --from py --to ipynb --set-kernel - --execute > out.ipynb
 after_success:
   - coverage report -m
   - codecov

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,8 @@ Release History
 **BugFixes**
 
 - Flag `--warn-only` catches every possible error (#263)
+- Treat `.md` and `.markdown` files identically (#325)
+- Make sure `--set-kernel` can be used with pipes (#326)
 
 1.2.3 (2019-09-02)
 ++++++++++++++++++++++

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,18 @@
 Release History
 ---------------
 
+1.2.4 (2019-09-??)
+++++++++++++++++++++++
+
+**Improvements**
+
+- Documentation includes a mention on how to set metadata filters at the command line (#330)
+- Do not catch errors when the flag `--warn-only` is not set (#327)
+
+**BugFixes**
+
+- Flag `--warn-only` catches every possible error (#263)
+
 1.2.3 (2019-09-02)
 ++++++++++++++++++++++
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,14 +8,14 @@ Release History
 
 **Improvements**
 
-- Documentation includes a mention on how to set metadata filters at the command line (#330)
-- Do not catch errors when the flag `--warn-only` is not set (#327)
+- The documentation includes a mention on how to set metadata filters at the command line (#330)
+- Jupytext will not catch any error when the flag ``--warn-only`` is not set (#327)
 
 **BugFixes**
 
-- Flag `--warn-only` catches every possible error (#263)
-- Treat `.md` and `.markdown` files identically (#325)
-- Make sure `--set-kernel` can be used with pipes (#326)
+- Now the flag ``--warn-only`` catches every possible error (#263)
+- ``.md`` and ``.markdown`` files are treated identically (#325)
+- Fixed ``--set-kernel`` when using pipes (#326)
 - Fixed utf-8 encoding on stdout on Python 2 (#331)
 
 1.2.3 (2019-09-02)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -16,6 +16,7 @@ Release History
 - Flag `--warn-only` catches every possible error (#263)
 - Treat `.md` and `.markdown` files identically (#325)
 - Make sure `--set-kernel` can be used with pipes (#326)
+- Fixed utf-8 encoding on stdout on Python 2 (#331)
 
 1.2.3 (2019-09-02)
 ++++++++++++++++++++++

--- a/jupytext/cell_reader.py
+++ b/jupytext/cell_reader.py
@@ -191,7 +191,7 @@ class BaseCellReader(object):
 
         # Is this a raw cell?
         if ('active' in self.metadata and not is_active('ipynb', self.metadata)) or \
-                (self.ext == '.md' and self.cell_type == 'code' and self.language is None):
+                (self.ext in ['.md', '.markdown'] and self.cell_type == 'code' and self.language is None):
             if self.metadata.get('active') == '':
                 del self.metadata['active']
             self.cell_type = 'raw'

--- a/jupytext/cli.py
+++ b/jupytext/cli.py
@@ -311,8 +311,7 @@ def jupytext_single_file(nb_file, args, log):
     if args.update_metadata:
         log("[jupytext] Updating notebook metadata with '{}'".format(json.dumps(args.update_metadata)))
         # Are we updating a text file that has a metadata filter? #212
-        if fmt['extension'] != '.ipynb' and \
-                notebook.metadata.get('jupytext', {}).get('notebook_metadata_filter') == '-all':
+        if notebook.metadata.get('jupytext', {}).get('notebook_metadata_filter') == '-all':
             notebook.metadata.get('jupytext', {}).pop('notebook_metadata_filter')
         recursive_update(notebook.metadata, args.update_metadata)
 

--- a/jupytext/cli.py
+++ b/jupytext/cli.py
@@ -281,18 +281,19 @@ def jupytext_single_file(nb_file, args, log):
 
     # Set the kernel
     set_kernel = args.set_kernel
-    if args.execute and notebook.metadata.get('kernelspec', {}).get('name') is None:
-        log("[jupytext] Setting default kernel with --set-kernel -")
+    if (not set_kernel) and args.execute and notebook.metadata.get('kernelspec', {}).get('name') is None:
         set_kernel = '-'
 
     if set_kernel:
         if set_kernel == '-':
             language = notebook.metadata.get('jupytext', {}).get('main_language') \
                        or notebook.metadata['kernelspec']['language']
+
             if not language:
                 raise ValueError('Cannot infer a kernel as notebook language is not defined')
 
             kernelspec = kernelspec_from_language(language)
+
             if not kernelspec:
                 raise ValueError('Found no kernel for {}'.format(language))
         else:
@@ -301,10 +302,12 @@ def jupytext_single_file(nb_file, args, log):
             except KeyError:
                 raise KeyError('Please choose a kernel name among {}'
                                .format([name for name in find_kernel_specs()]))
+
             kernelspec = {'name': args.set_kernel,
                           'language': kernelspec.language,
                           'display_name': kernelspec.display_name}
 
+        log("[jupytext] Setting kernel {}".format(kernelspec.get('name')))
         args.update_metadata['kernelspec'] = kernelspec
 
     # Update the metadata

--- a/jupytext/cli.py
+++ b/jupytext/cli.py
@@ -341,8 +341,8 @@ def jupytext_single_file(nb_file, args, log):
 
     # Execute the notebook
     if args.execute:
-        log("[jupytext] Executing notebook")
         kernel_name = notebook.metadata.get('kernelspec', {}).get('name')
+        log("[jupytext] Executing notebook with kernel {}".format(kernel_name))
         exec_proc = ExecutePreprocessor(timeout=None, kernel_name=kernel_name)
         exec_proc.preprocess(notebook, resources={})
 

--- a/jupytext/combine.py
+++ b/jupytext/combine.py
@@ -46,8 +46,8 @@ def combine_inputs_with_outputs(nb_source, nb_outputs, fmt=None):
         if key not in nb_outputs_filtered_metadata:
             nb_source.metadata[key] = nb_outputs.metadata[key]
 
-    source_is_md_version_one = ext in ['.md', '.Rmd'] and text_repr.get('format_version') == '1.0'
-    if nb_source.metadata.get('jupytext', {}).get('formats') or ext in ['.md', '.Rmd']:
+    source_is_md_version_one = ext in ['.md', '.markdown', '.Rmd'] and text_repr.get('format_version') == '1.0'
+    if nb_source.metadata.get('jupytext', {}).get('formats') or ext in ['.md', '.markdown', '.Rmd']:
         nb_source.metadata.get('jupytext', {}).pop('text_representation', None)
 
     if not nb_source.metadata.get('jupytext', {}):

--- a/jupytext/contentsmanager.py
+++ b/jupytext/contentsmanager.py
@@ -36,7 +36,7 @@ def preferred_format(incomplete_format, preferred_formats):
     for fmt in long_form_multiple_formats(preferred_formats):
         if ((incomplete_format['extension'] == fmt['extension'] or (
                 fmt['extension'] == '.auto' and
-                incomplete_format['extension'] not in ['.md', '.Rmd', '.ipynb'])) and
+                incomplete_format['extension'] not in ['.md', '.markdown', '.Rmd', '.ipynb'])) and
                 incomplete_format.get('suffix') == fmt.get('suffix', incomplete_format.get('suffix')) and
                 incomplete_format.get('prefix') == fmt.get('prefix', incomplete_format.get('prefix'))):
             fmt.update(incomplete_format)
@@ -264,7 +264,7 @@ def build_jupytext_contents_manager_class(base_contents_manager_class):
 
                     alt_path = full_path(base, fmt)
                     self.create_prefix_dir(alt_path, fmt)
-                    if 'format_name' in fmt and fmt['extension'] not in ['.Rmd', '.md']:
+                    if 'format_name' in fmt and fmt['extension'] not in ['.md', '.markdown', '.Rmd']:
                         self.log.info("Saving %s in format %s:%s",
                                       os.path.basename(alt_path), fmt['extension'][1:], fmt['format_name'])
                     else:

--- a/jupytext/formats.py
+++ b/jupytext/formats.py
@@ -170,7 +170,7 @@ def get_format_implementation(ext, format_name=None):
             formats_for_extension.append(fmt.format_name)
 
     if formats_for_extension:
-        if ext == '.md' and format_name == 'pandoc':
+        if ext in ['.md', '.markdown'] and format_name == 'pandoc':
             raise JupytextFormatError('Please install pandoc>=2.7.2')
 
         raise JupytextFormatError("Format '{}' is not associated to extension '{}'. "
@@ -184,7 +184,7 @@ def read_metadata(text, ext):
     ext = '.' + ext.split('.')[-1]
     lines = text.splitlines()
 
-    if ext in ['.md', '.Rmd']:
+    if ext in ['.md', '.markdown', '.Rmd']:
         comment = ''
     else:
         comment = _SCRIPT_EXTENSIONS.get(ext, {}).get('comment', '#')
@@ -274,7 +274,7 @@ def guess_format(text, ext):
         if rspin_comment_count >= 1:
             return 'spin', {}
 
-    if ext == '.md':
+    if ext in ['.md', '.markdown']:
         for line in lines:
             if line.startswith(':::'):  # Pandoc div
                 return 'pandoc', {}
@@ -355,7 +355,7 @@ def format_name_for_ext(metadata, ext, cm_default_formats=None, explicit_default
             if (not explicit_default) or fmt.get('format_name'):
                 return fmt.get('format_name')
 
-    if (not explicit_default) or ext in ['.Rmd', '.md']:
+    if (not explicit_default) or ext in ['.md', '.markdown', '.Rmd']:
         return None
 
     return get_format_implementation(ext).format_name
@@ -509,7 +509,8 @@ def short_form_one_format(jupytext_format):
         fmt = jupytext_format['prefix'] + '/' + fmt
 
     if jupytext_format.get('format_name'):
-        if jupytext_format['extension'] not in ['.md', '.Rmd'] or jupytext_format['format_name'] == 'pandoc':
+        if jupytext_format['extension'] not in ['.md', '.markdown', '.Rmd'] or \
+                jupytext_format['format_name'] == 'pandoc':
             fmt = fmt + ':' + jupytext_format['format_name']
 
     return fmt

--- a/jupytext/header.py
+++ b/jupytext/header.py
@@ -54,12 +54,12 @@ def encoding_and_executable(notebook, metadata, ext):
     comment = _SCRIPT_EXTENSIONS.get(ext, {}).get('comment')
     jupytext_metadata = metadata.get('jupytext', {})
 
-    if ext not in ['.Rmd', '.md'] and 'executable' in jupytext_metadata:
+    if comment is not None and 'executable' in jupytext_metadata:
         lines.append(comment + '!' + jupytext_metadata.pop('executable'))
 
     if 'encoding' in jupytext_metadata:
         lines.append(jupytext_metadata.pop('encoding'))
-    elif ext not in ['.Rmd', '.md']:
+    elif comment is not None:
         for cell in notebook.cells:
             try:
                 cell.source.encode('ascii')

--- a/jupytext/jupytext.py
+++ b/jupytext/jupytext.py
@@ -161,7 +161,7 @@ class TextNotebookConverter(NotebookReader, NotebookWriter):
             text.extend([''] * lines_to_next_cell)
 
             # two blank lines between markdown cells in Rmd when those do not have explicit region markers
-            if self.ext in ['.Rmd', '.md'] and not cell.is_code():
+            if self.ext in ['.md', '.markdown', '.Rmd'] and not cell.is_code():
                 if (i + 1 < len(cell_exporters) and not cell_exporters[i + 1].is_code() and
                         not texts[i][0].startswith('<!-- #region') and
                         not texts[i + 1][0].startswith('<!-- #region') and

--- a/jupytext/jupytext.py
+++ b/jupytext/jupytext.py
@@ -318,7 +318,13 @@ def write(nb, fp, version=nbformat.NO_CONVERT, fmt=None, **kwargs):
     :param kwargs: (not used) additional parameters for nbformat.write
     """
     if fp == '-':
-        write(nb, sys.stdout, version=version, fmt=fmt, **kwargs)
+        # Use sys.stdout.buffer when possible, and explicit utf-8 encoding, cf. #331
+        content = writes(nb, version=version, fmt=fmt, **kwargs)
+        try:
+            # Python 3
+            sys.stdout.buffer.write(content.encode('utf-8'))
+        except AttributeError:
+            sys.stdout.write(content.encode('utf-8'))
         return
 
     if not hasattr(fp, 'write'):

--- a/jupytext/kernels.py
+++ b/jupytext/kernels.py
@@ -31,6 +31,12 @@ def kernelspec_from_language(language):
                 if kernel_specs.language == 'python' and kernel_specs.argv[0] == sys.executable:
                     return {'name': name, 'language': language, 'display_name': kernel_specs.display_name}
 
+            # If none was found, return the first kernel that has 'python' as argv[0]
+            for name in find_kernel_specs():
+                kernel_specs = get_kernel_spec(name)
+                if kernel_specs.language == 'python' and kernel_specs.argv[0] == 'python':
+                    return {'name': name, 'language': language, 'display_name': kernel_specs.display_name}
+
         for name in find_kernel_specs():
             kernel_specs = get_kernel_spec(name)
             if kernel_specs.language == language or (language == 'c++' and kernel_specs.language.startswith('C++')):

--- a/jupytext/magics.py
+++ b/jupytext/magics.py
@@ -77,7 +77,8 @@ def uncomment_magic(source, language='python', global_escape_flag=True):
 
 
 _ESCAPED_CODE_START = {'.Rmd': re.compile(r"^(# |#)*```{.*}"),
-                       '.md': re.compile(r"^(# |#)*```")}
+                       '.md': re.compile(r"^(# |#)*```"),
+                       '.markdown': re.compile(r"^(# |#)*```")}
 _ESCAPED_CODE_START.update({ext: re.compile(
     r"^({0} |{0})*({0}|{0} )\+".format(_SCRIPT_EXTENSIONS[ext]['comment'])) for ext in _SCRIPT_EXTENSIONS})
 

--- a/jupytext/version.py
+++ b/jupytext/version.py
@@ -1,3 +1,3 @@
 """Jupytext's version number"""
 
-__version__ = '1.2.3'
+__version__ = '1.2.4-dev'

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
                                                          'jupytext/nbextension/jupytext_menu_zoom.png',
                                                          'jupytext/nbextension/jupytext.yml']),
                 ('share/jupyter/lab/extensions', ['packages/labextension/jupyterlab-jupytext-1.0.2.tgz'])],
-    entry_points={'console_scripts': ['jupytext = jupytext.cli:jupytext_cli']},
+    entry_points={'console_scripts': ['jupytext = jupytext.cli:jupytext']},
     tests_require=['pytest'],
     install_requires=['nbformat>=4.0.0', 'pyyaml', 'mock;python_version<"3"'],
     license='MIT',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import os
 import sys
 import time
@@ -766,6 +768,20 @@ def test_set_kernel_works_with_pipes_326(capsys):
     assert err == ''
     nb = reads(out, 'ipynb')
     assert 'kernelspec' in nb.metadata
+
+
+def test_utf8_out_331(capsys):
+    py = u"from IPython.core.display import HTML; HTML(u'\xd7')"
+
+    with mock.patch('sys.stdin', StringIO(py)):
+        jupytext(['--to', 'ipynb', '--execute', '-'])
+
+    out, err = capsys.readouterr()
+    assert err == ''
+    nb = reads(out, 'ipynb')
+    assert len(nb.cells) == 1
+    print(nb.cells[0].outputs)
+    assert nb.cells[0].outputs[0]['data']['text/html'] == u'\xd7'
 
 
 @requires_jupytext_installed

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,7 +17,7 @@ from nbformat.v4.nbbase import new_notebook, new_markdown_cell, new_code_cell
 from jupyter_client.kernelspec import find_kernel_specs, get_kernel_spec
 from jupytext import __version__
 from jupytext import read, write, writes
-from jupytext.cli import parse_jupytext_args, jupytext, jupytext_cli, system, str2bool
+from jupytext.cli import parse_jupytext_args, jupytext, system, str2bool
 from jupytext.compare import compare_notebooks
 from jupytext.paired_paths import paired_paths, InconsistentPath
 from jupytext.formats import long_form_one_format, JupytextFormatError
@@ -765,8 +765,8 @@ def test_cli_expect_errors(tmp_ipynb):
         jupytext(['--pre-commit', 'notebook.ipynb'])
     with pytest.raises(ValueError):
         jupytext(['notebook.ipynb', '--from', 'py:percent', '--to', 'md'])
-    with pytest.raises(SystemExit):
-        jupytext_cli([])
+    with pytest.raises(ValueError):
+        jupytext([])
     with pytest.raises((SystemExit, TypeError)):  # SystemExit on Windows, TypeError on Linux
         system('jupytext', ['notebook.ipynb', '--from', 'py:percent', '--to', 'md'])
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -542,7 +542,7 @@ def test_set_kernel_inplace(py_file, tmpdir):
 
     nb = read(tmp_py)
     kernel_name = nb.metadata['kernelspec']['name']
-    assert get_kernel_spec(kernel_name).argv[0].lower() in ['python', sys.executable]
+    assert get_kernel_spec(kernel_name).argv[0].lower() in ['python', sys.executable.lower()]
 
 
 @pytest.mark.parametrize('py_file', list_notebooks('python'))
@@ -556,7 +556,7 @@ def test_set_kernel_auto(py_file, tmpdir):
 
     nb = read(tmp_ipynb)
     kernel_name = nb.metadata['kernelspec']['name']
-    assert get_kernel_spec(kernel_name).argv[0].lower() in ['python', sys.executable]
+    assert get_kernel_spec(kernel_name).argv[0].lower() in ['python', sys.executable.lower()]
 
 
 @pytest.mark.parametrize('py_file', list_notebooks('python'))


### PR DESCRIPTION
**Improvements**

- The documentation includes a mention on how to set metadata filters at the command line (#330)
- Jupytext will not catch any error when the flag `--warn-only` is not set (#327)

**BugFixes**

- Now the flag `--warn-only` catches every possible error (#263)
- `.md` and `.markdown` files are treated identically (#325)
- Fixed `--set-kernel` when using pipes (#326)
- Fixed utf-8 encoding on stdout on Python 2 (#331)