### PR TITLE
Fix inconsistent cell type

### DIFF
--- a/jupytext/cell_reader.py
+++ b/jupytext/cell_reader.py
@@ -38,7 +38,9 @@ def paragraph_is_fully_commented(lines, comment, main_language):
     """Is the paragraph fully commented?"""
     for i, line in enumerate(lines):
         if line.startswith(comment):
-            if line.startswith((comment + ' %', comment + ' ?', comment + ' !')) and is_magic(line, main_language):
+            if line[len(comment):].lstrip().startswith(comment):
+                continue
+            if is_magic(line, main_language):
                 return False
             continue
         return i > 0 and _BLANK_LINE.match(line)

--- a/tests/notebooks/ipynb_py/cat_variable.ipynb
+++ b/tests/notebooks/ipynb_py/cat_variable.ipynb
@@ -1,0 +1,34 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cat = 42"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/notebooks/mirror/ipynb_to_Rmd/cat_variable.Rmd
+++ b/tests/notebooks/mirror/ipynb_to_Rmd/cat_variable.Rmd
@@ -1,0 +1,11 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+---
+
+```{python}
+# cat = 42
+```

--- a/tests/notebooks/mirror/ipynb_to_hydrogen/cat_variable.py
+++ b/tests/notebooks/mirror/ipynb_to_hydrogen/cat_variable.py
@@ -1,0 +1,10 @@
+# ---
+# jupyter:
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# %%
+cat = 42

--- a/tests/notebooks/mirror/ipynb_to_md/cat_variable.md
+++ b/tests/notebooks/mirror/ipynb_to_md/cat_variable.md
@@ -1,0 +1,11 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+---
+
+```python
+cat = 42
+```

--- a/tests/notebooks/mirror/ipynb_to_pandoc/cat_variable.md
+++ b/tests/notebooks/mirror/ipynb_to_pandoc/cat_variable.md
@@ -1,0 +1,15 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+  nbformat: 4
+  nbformat_minor: 2
+---
+
+::: {.cell .code}
+``` {.python}
+cat = 42
+```
+:::

--- a/tests/notebooks/mirror/ipynb_to_percent/cat_variable.py
+++ b/tests/notebooks/mirror/ipynb_to_percent/cat_variable.py
@@ -1,0 +1,10 @@
+# ---
+# jupyter:
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# %%
+# cat = 42

--- a/tests/notebooks/mirror/ipynb_to_script/cat_variable.py
+++ b/tests/notebooks/mirror/ipynb_to_script/cat_variable.py
@@ -1,0 +1,9 @@
+# ---
+# jupyter:
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# cat = 42

--- a/tests/notebooks/mirror/ipynb_to_script_vim_folding_markers/cat_variable.py
+++ b/tests/notebooks/mirror/ipynb_to_script_vim_folding_markers/cat_variable.py
@@ -1,0 +1,11 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_markers: '{{{,}}}'
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# cat = 42

--- a/tests/notebooks/mirror/ipynb_to_script_vscode_folding_markers/cat_variable.py
+++ b/tests/notebooks/mirror/ipynb_to_script_vscode_folding_markers/cat_variable.py
@@ -1,0 +1,11 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_markers: region,endregion
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# cat = 42

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -958,3 +958,12 @@ def test_warn_only_skips_incorrect_notebook(tmpdir, capsys):
 
     assert not os.path.exists(incorrect_md)
     assert os.path.exists(correct_md)
+
+
+@pytest.mark.parametrize('fmt', ['md', 'Rmd', 'py', 'py:percent', 'py:hydrogen'])
+def test_339_ipynb(tmpdir, fmt):
+    tmp_ipynb = str(tmpdir.join('test.ipynb'))
+    nb = new_notebook(cells=[new_code_cell('cat = 42')])
+    nbformat.write(nb, tmp_ipynb)
+
+    assert jupytext([tmp_ipynb, '--to', fmt, '--test-strict']) == 0


### PR DESCRIPTION
When a code cell contained a magic command like `cat` or `ls`, the round-trip conversion through the `py` format changed the cell type to markdown (#339).

The correction is to use the same function (`is_magic`) to detect when a line contains a Jupyter magic, both at the time of encoding and decoding it.