### PR TITLE
Change SO link to turn off autosave permanently in faq

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -71,7 +71,7 @@ By default, Jupyter saves your notebook every 2 minutes. Fortunately, it is also
 
 You should simply click on _Reload_.
 
-Note you can deactivate Jupyter's autosave function with the Jupytext Menu in Jupyter Notebook, and with the _Autosave Document_ setting in JupyterLab. See [here](https://stackoverflow.com/questions/25631344/turn-off-autosave-in-ipython-notebook/56549758#56549758) if you want to permanently deactivate the autosave in Jupyter Notebook.
+Note you can deactivate Jupyter's autosave function with the Jupytext Menu in Jupyter Notebook, and with the _Autosave Document_ setting in JupyterLab. See [here](https://stackoverflow.com/a/45980165) if you want to permanently deactivate the autosave in Jupyter Notebook.
 
 ## When I reload, Jupyter warns me that my notebook has unsaved changes
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -71,7 +71,12 @@ By default, Jupyter saves your notebook every 2 minutes. Fortunately, it is also
 
 You should simply click on _Reload_.
 
-Note you can deactivate Jupyter's autosave function with the Jupytext Menu in Jupyter Notebook, and with the _Autosave Document_ setting in JupyterLab. See [here](https://stackoverflow.com/a/45980165) if you want to permanently deactivate the autosave in Jupyter Notebook.
+Note you can deactivate Jupyter's autosave function with the Jupytext Menu in Jupyter Notebook, and with the _Autosave Document_ setting in JupyterLab. If you want to permanently deactivate autosave in Jupyter Notebook, it is [recommended by Jupyter](https://github.com/jupyter/notebook/blob/master/docs/source/examples/Notebook/JavaScript%20Notebook%20Extensions.ipynb) to do so via a *custom.js* file:
+
+```sh
+mkdir -p ~/.jupyter/custom
+echo "Jupyter.notebook.set_autosave_interval(0);" >> ~/.jupyter/custom/custom.js
+```
 
 ## When I reload, Jupyter warns me that my notebook has unsaved changes
 

--- a/docs/using-server.md
+++ b/docs/using-server.md
@@ -77,7 +77,7 @@ NB: All these global options (and more) are documented [here](https://github.com
 When saving a paired notebook using Jupytext's contents manager, Jupyter updates both the `.ipynb` and its text representation. The text representation can be edited outside of Jupyter. When the notebook is refreshed in Jupyter, the input cells are read from the text file, and the output cells from the `.ipynb` file.
 
 It is possible (and convenient) to leave the notebook open in Jupyter while you edit its text representation. However, you don't want that the two editors save the notebook simultaneously. To avoid this:
-- deactivate Jupyter's autosave, by toggling the `"Autosave notebook"` menu entry (or run `%autosave 0` in a cell of the notebook)
+- deactivate Jupyter's autosave, by either toggling the `"Autosave notebook"` menu entry or run `%autosave 0` in a cell of the notebook (see in the [faq](https://github.com/mwouts/jupytext/blob/master/docs/faq.md#jupyter-warns-me-that-the-file-has-changed-on-disk) how to deactivate autosave permanently)
 - and refresh the notebook when you switch back from the editor to Jupyter.
 
 In case you forgot to refresh, and saved the Jupyter notebook while the text representation had changed, no worries: Jupyter will ask you which version you want to keep:


### PR DESCRIPTION
I followed the [original solution](https://stackoverflow.com/questions/25631344/turn-off-autosave-in-ipython-notebook/56549758#56549758) an it does not work anymore. Furthermore I find it is a bit an overkill to install jupyter_contrib_nbextension just to turn off autosave.

I tried [this solution](https://stackoverflow.com/a/45980165) with a fresh jupyter and it worked fine:
```sh
mkdir -p ~/.jupyter/custom
echo "Jupyter.notebook.set_autosave_interval(0)" > ~/.jupyter/custom/custom.js
```