### PR TITLE
Markdown format update

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,9 @@ Release History
 
 **Improvements**
 
-- Raw cells are now encoded using HTML comments (``<!-- #raw -->`` and ``<!-- #endraw -->``) in Markdown files. And code blocks from Markdown files, when they don't have an explicit language, are displayed as Markdown cells in Jupyter (#321)
+- Raw cells are now encoded using HTML comments (``<!-- #raw -->`` and ``<!-- #endraw -->``) in Markdown files (#321)
+- Markdown cells can be delimited with any of ``<!-- #region -->``,  ``<!-- #markdown -->`` or ``<!-- #md -->`` (#344)
+- Code blocks from Markdown files, when they don't have an explicit language, below to the text of the Markdown cell in Jupyter (#321)
 - Markdown and raw cells can use multiline comments in the ``py:percent`` format (#305)
 - ``jupytext notebook.py --to ipynb`` updates the timestamp of ``notebook.py`` so that the paired notebook still works in Jupyter (#335, #254)
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,7 +11,7 @@ Release History
 - Raw cells are now encoded using HTML comments (``<!-- #raw -->`` and ``<!-- #endraw -->``) in Markdown files (#321)
 - Markdown cells can be delimited with any of ``<!-- #region -->``,  ``<!-- #markdown -->`` or ``<!-- #md -->`` (#344)
 - Code blocks from Markdown files, when they don't have an explicit language, below to the text of the Markdown cell in Jupyter (#321)
-- Markdown and raw cells can use multiline comments in the ``py:percent`` format (#305)
+- Markdown and raw cells can use multiline comments in the ``py:percent`` format. And Markdown cells can start with just ``# %% [md]`` (#305)
 - ``jupytext notebook.py --to ipynb`` updates the timestamp of ``notebook.py`` so that the paired notebook still works in Jupyter (#335, #254)
 
 **BugFixes**

--- a/jupytext/cell_metadata.py
+++ b/jupytext/cell_metadata.py
@@ -36,8 +36,7 @@ _IGNORE_CELL_METADATA = ','.join('-{}'.format(name) for name in [
     # (these metadata are preserved in the paired Jupyter notebook).
     'autoscroll', 'collapsed', 'scrolled', 'trusted', 'ExecuteTime'] +
                                  _JUPYTEXT_CELL_METADATA)
-_PERCENT_CELL = re.compile(
-    r'(# |#)%%([^\{\[]*)(|\[raw\]|\[markdown\]||\[md\])([^\{\[]*)(|\{.*\})\s*$')
+
 _IDENTIFIER_RE = re.compile(r'^[a-zA-Z_\\.]+[a-zA-Z0-9_\\.]*$')
 
 
@@ -358,49 +357,6 @@ def is_active(ext, metadata):
     if 'active' not in metadata:
         return True
     return ext.replace('.', '') in re.split('\\.|,', metadata['active'])
-
-
-def double_percent_options_to_metadata(options):
-    """Parse double percent options"""
-    matches = _PERCENT_CELL.findall('# %%' + options)
-
-    # Fail safe when regexp matching fails #116
-    # (occurs e.g. if square brackets are found in the title)
-    if not matches:
-        return {'title': options.strip()}
-
-    matches = matches[0]
-
-    # Fifth match are JSON metadata
-    if matches[4]:
-        metadata = json_options_to_metadata(matches[4], add_brackets=False)
-    else:
-        metadata = {}
-
-    # Third match is cell type
-    cell_type = matches[2]
-    if cell_type:
-        cell_type = cell_type[1:-1]
-        if cell_type == 'md':
-            metadata['region_name'] = cell_type
-            cell_type = 'markdown'
-        metadata['cell_type'] = cell_type
-
-    # Second and fourth match are description
-    title = [matches[i].strip() for i in [1, 3]]
-    title = [part for part in title if part]
-    if title:
-        title = ' '.join(title)
-        cell_depth = 0
-        while title.startswith('%'):
-            cell_depth += 1
-            title = title[1:]
-
-        if cell_depth:
-            metadata['cell_depth'] = cell_depth
-        metadata['title'] = title.strip()
-
-    return metadata
 
 
 def metadata_to_double_percent_options(metadata):

--- a/jupytext/cell_metadata.py
+++ b/jupytext/cell_metadata.py
@@ -38,6 +38,7 @@ _IGNORE_CELL_METADATA = ','.join('-{}'.format(name) for name in [
                                  _JUPYTEXT_CELL_METADATA)
 _PERCENT_CELL = re.compile(
     r'(# |#)%%([^\{\[]*)(|\[raw\]|\[markdown\]||\[md\])([^\{\[]*)(|\{.*\})\s*$')
+_IDENTIFIER_RE = re.compile(r'^[a-zA-Z_\\.]+[a-zA-Z0-9_\\.]*$')
 
 
 def _r_logical_values(pybool):
@@ -422,6 +423,10 @@ def incorrectly_encoded_metadata(text):
     return {'incorrectly_encoded_metadata': text}
 
 
+def isidentifier(text):
+    return _IDENTIFIER_RE.match(text)
+
+
 def parse_key_equal_value(text):
     """Parse a string of the form 'key1=value1 key2=value2'"""
     # Empty metadata?
@@ -432,7 +437,7 @@ def parse_key_equal_value(text):
     last_space_pos = text.rfind(' ')
 
     # Just an identifier?
-    if text[last_space_pos + 1:].replace('.', '').isidentifier():
+    if isidentifier(text[last_space_pos + 1:]):
         key = text[last_space_pos + 1:]
         value = None
         result = {key: value}
@@ -450,7 +455,7 @@ def parse_key_equal_value(text):
         # Do we have an identifier on the left of the equal sign?
         prev_whitespace = text[:equal_sign_pos].rstrip().rfind(' ')
         key = text[prev_whitespace + 1:equal_sign_pos].strip()
-        if not key.replace('.', '').isidentifier():
+        if not isidentifier(key.replace('.', '')):
             continue
 
         try:

--- a/jupytext/cell_metadata.py
+++ b/jupytext/cell_metadata.py
@@ -417,7 +417,7 @@ def text_to_metadata(text, allow_title=False):
         # single expression
         if prev_whitespace < 0:
             # is is a title or a jupyter language?
-            if allow_title or is_jupyter_language(text):
+            if (allow_title and first_equal_sign < 0) or is_jupyter_language(text):
                 return text, {}
 
             # else, parse this expression as a key

--- a/jupytext/cell_metadata.py
+++ b/jupytext/cell_metadata.py
@@ -37,7 +37,7 @@ _IGNORE_CELL_METADATA = ','.join('-{}'.format(name) for name in [
     'autoscroll', 'collapsed', 'scrolled', 'trusted', 'ExecuteTime'] +
                                  _JUPYTEXT_CELL_METADATA)
 _PERCENT_CELL = re.compile(
-    r'(# |#)%%([^\{\[]*)(|\[raw\]|\[markdown\])([^\{\[]*)(|\{.*\})\s*$')
+    r'(# |#)%%([^\{\[]*)(|\[raw\]|\[markdown\]||\[md\])([^\{\[]*)(|\{.*\})\s*$')
 
 
 def _r_logical_values(pybool):
@@ -379,7 +379,10 @@ def double_percent_options_to_metadata(options):
     # Third match is cell type
     cell_type = matches[2]
     if cell_type:
-        metadata['cell_type'] = cell_type[1:-1]
+        cell_type = cell_type[1:-1]
+        if cell_type == 'md':
+            cell_type = 'markdown'
+        metadata['cell_type'] = cell_type
 
     # Second and fourth match are description
     title = [matches[i].strip() for i in [1, 3]]

--- a/jupytext/cell_metadata.py
+++ b/jupytext/cell_metadata.py
@@ -277,15 +277,15 @@ def try_eval_metadata(metadata, name):
         return
 
 
-def is_active(ext, metadata):
+def is_active(ext, metadata, default=True):
     """Is the cell active for the given file extension?"""
     if metadata.get('run_control', {}).get('frozen') is True:
-        return False
+        return ext == '.ipynb'
     for tag in metadata.get('tags', []):
         if tag.startswith('active-'):
             return ext.replace('.', '') in tag.split('-')
     if 'active' not in metadata:
-        return True
+        return default
     return ext.replace('.', '') in re.split('\\.|,', metadata['active'])
 
 

--- a/jupytext/cell_metadata.py
+++ b/jupytext/cell_metadata.py
@@ -317,15 +317,6 @@ def try_eval_metadata(metadata, name):
         return
 
 
-def json_options_to_metadata(options, add_brackets=True):
-    """Read metadata from its json representation"""
-    try:
-        options = loads('{' + options + '}' if add_brackets else options)
-        return options
-    except ValueError:
-        return {}
-
-
 def metadata_to_json_options(metadata):
     """Represent metadata as json text"""
     for key in _JUPYTEXT_CELL_METADATA:

--- a/jupytext/cell_metadata.py
+++ b/jupytext/cell_metadata.py
@@ -298,19 +298,6 @@ def parse_md_code_options(options):
     return metadata
 
 
-def md_options_to_metadata(options):
-    """Parse markdown options and return language and metadata"""
-    metadata = parse_md_code_options(options)
-
-    if metadata:
-        language = metadata[0][0]
-        for lang in _JUPYTER_LANGUAGES:
-            if language.lower() == lang.lower():
-                return lang, dict(metadata[1:])
-
-    return None, dict(metadata)
-
-
 def try_eval_metadata(metadata, name):
     """Evaluate given metadata to a python object, if possible"""
     value = metadata[name]

--- a/jupytext/cell_metadata.py
+++ b/jupytext/cell_metadata.py
@@ -381,6 +381,7 @@ def double_percent_options_to_metadata(options):
     if cell_type:
         cell_type = cell_type[1:-1]
         if cell_type == 'md':
+            metadata['region_name'] = cell_type
             cell_type = 'markdown'
         metadata['cell_type'] = cell_type
 
@@ -409,7 +410,7 @@ def metadata_to_double_percent_options(metadata):
     if 'title' in metadata:
         options.append(metadata.pop('title'))
     if 'cell_type' in metadata:
-        options.append('[{}]'.format(metadata.pop('cell_type')))
+        options.append('[{}]'.format(metadata.pop('region_name', metadata.pop('cell_type'))))
     metadata = metadata_to_json_options(metadata)
     if metadata != '{}':
         options.append(metadata)

--- a/jupytext/cell_metadata.py
+++ b/jupytext/cell_metadata.py
@@ -258,46 +258,6 @@ def metadata_to_md_options(metadata):
                      if metadata[key] is not None else key for key in metadata])
 
 
-def parse_md_code_options(options):
-    """Parse 'python class key="value"' into [('python', None), ('class', None), ('key', 'value')]"""
-
-    metadata = []
-    while options:
-        name_and_value = re.split(r'[\s=]+', options, maxsplit=1)
-        name = name_and_value[0]
-
-        # Equal sign in between name and what's next?
-        if len(name_and_value) == 2:
-            sep = options[len(name):-len(name_and_value[1])]
-            has_value = sep.find('=') >= 0
-            options = name_and_value[1]
-        else:
-            has_value = False
-            options = ''
-
-        if not has_value:
-            metadata.append((name, None))
-            continue
-
-        try:
-            value = loads(options)
-            options = ''
-        except JSONDecodeError as err:
-            try:
-                split = err.colno - 1
-            except AttributeError:
-                # str(err) is like: "ValueError: Extra data: line 1 column 7 - line 1 column 50 (char 6 - 49)"
-                match = re.match(r'.*char ([0-9]*)', str(err))
-                split = int(match.groups()[0])
-
-            value = loads(options[:split])
-            options = options[split:]
-
-        metadata.append((name, value))
-
-    return metadata
-
-
 def try_eval_metadata(metadata, name):
     """Evaluate given metadata to a python object, if possible"""
     value = metadata[name]

--- a/jupytext/cell_metadata.py
+++ b/jupytext/cell_metadata.py
@@ -380,7 +380,16 @@ def incorrectly_encoded_metadata(text):
 
 
 def isidentifier(text):
+    """Can this text be a proper key?"""
     return _IDENTIFIER_RE.match(text)
+
+
+def is_jupyter_language(language):
+    """Is this a jupyter language?"""
+    for lang in _JUPYTER_LANGUAGES:
+        if language.lower() == lang.lower():
+            return True
+    return False
 
 
 def parse_key_equal_value(text):
@@ -456,10 +465,7 @@ def text_to_metadata(text, allow_title=False):
     first_curly_bracket = text.find('{')
     first_equal_sign = text.find('=')
 
-    if first_equal_sign < 0 and not allow_title:
-        first_equal_sign = len(text)
-
-    if first_curly_bracket < 0 and first_equal_sign < 0:
+    if first_curly_bracket < 0 and first_equal_sign < 0 and allow_title:
         # no metadata
         return text, {}
 
@@ -469,6 +475,15 @@ def text_to_metadata(text, allow_title=False):
             prev_whitespace = text[:first_equal_sign].rstrip().rfind(' ')
         else:
             prev_whitespace = text.find(' ')
+
+        # single expression
+        if prev_whitespace < 0:
+            # is is a title or a jupyter language?
+            if allow_title or is_jupyter_language(text):
+                return text, {}
+
+            # else, parse this expression as a key
+            prev_whitespace = 0
 
         return text[:prev_whitespace].rstrip(), parse_key_equal_value(text[prev_whitespace:])
 

--- a/jupytext/cell_reader.py
+++ b/jupytext/cell_reader.py
@@ -10,8 +10,7 @@ try:
 except (ImportError, SyntaxError):
     rst2md = None
 
-from .cell_metadata import is_active, rmd_options_to_metadata
-from .cell_metadata import text_to_metadata
+from .cell_metadata import is_active, text_to_metadata, rmd_options_to_metadata
 from .languages import _JUPYTER_LANGUAGES
 from .stringparser import StringParser
 from .magics import uncomment_magic, is_magic, unescape_code_start
@@ -352,7 +351,7 @@ class RMarkdownCellReader(MarkdownCellReader):
         return rmd_options_to_metadata(options)
 
     def uncomment_code_and_magics(self, lines):
-        if self.cell_type == 'code' and self.comment_magics and is_active('.Rmd', self.metadata):
+        if self.cell_type == 'code' and self.comment_magics and is_active(self.ext, self.metadata):
             uncomment_magic(lines, self.language or self.default_language)
 
         return lines
@@ -624,7 +623,7 @@ class DoublePercentScriptCellReader(ScriptCellReader):
         source = lines[cell_start:cell_end_marker]
         self.org_content = [line for line in source]
 
-        if self.cell_type != 'code' or (self.metadata and not is_active('py', self.metadata)) \
+        if self.cell_type != 'code' or (self.metadata and not is_active(self.ext, self.metadata)) \
                 or (self.language is not None and self.language != self.default_language):
             if self.ext == '.py' and self.cell_type != 'code' and self.org_content \
                     and self.org_content[0].lstrip().startswith(('"""', "'''")):

--- a/jupytext/cell_reader.py
+++ b/jupytext/cell_reader.py
@@ -10,7 +10,7 @@ try:
 except (ImportError, SyntaxError):
     rst2md = None
 
-from .cell_metadata import is_active, json_options_to_metadata, rmd_options_to_metadata
+from .cell_metadata import is_active, rmd_options_to_metadata
 from .cell_metadata import text_to_metadata
 from .languages import _JUPYTER_LANGUAGES
 from .stringparser import StringParser
@@ -458,25 +458,14 @@ class LightScriptCellReader(ScriptCellReader):
         self.explicit_end_marker_required = False
         if fmt and 'cell_markers' in fmt and fmt['cell_markers'] != '+,-':
             self.cell_marker_start, self.cell_marker_end = fmt['cell_markers'].split(',', 1)
-            self.start_code_re = re.compile('^' + self.comment + r'\s*' + self.cell_marker_start + r'\s*(.*)$')
+            self.start_code_re = re.compile('^' + self.comment + r'\s*' + self.cell_marker_start + r'(.*)$')
             self.end_code_re = re.compile('^' + self.comment + r'\s*' + self.cell_marker_end + r'\s*$')
         else:
-            self.start_code_re = re.compile('^' + self.comment + r'\s*\+\s*{(.*)}$')
-            self.simple_start_code_re = re.compile('^' + self.comment + r'\s*\+\s*$')
+            self.start_code_re = re.compile('^' + self.comment + r'\s*\+(.*)$')
 
     def options_to_metadata(self, options):
-        if not self.cell_marker_start:
-            return json_options_to_metadata(options)
+        title, metadata = text_to_metadata(options, allow_title=True)
 
-        bracket = options.find('{')
-        if bracket < 0:
-            title = options
-            metadata = {}
-        else:
-            title = options[:bracket]
-            metadata = json_options_to_metadata(options[bracket:], False)
-
-        title = title.strip()
         if title:
             metadata['title'] = title
 

--- a/jupytext/cell_reader.py
+++ b/jupytext/cell_reader.py
@@ -192,7 +192,7 @@ class BaseCellReader(object):
             self.content = self.uncomment_code_and_magics(source)
 
         # Is this a raw cell?
-        if ('active' in self.metadata and not is_active('ipynb', self.metadata)) or \
+        if ('active' in self.metadata and not is_active('.ipynb', self.metadata)) or \
                 (self.ext in ['.md', '.markdown'] and self.cell_type == 'code' and not self.language):
             if self.metadata.get('active') == '':
                 del self.metadata['active']

--- a/jupytext/cell_to_text.py
+++ b/jupytext/cell_to_text.py
@@ -115,6 +115,7 @@ class MarkdownCellExporter(BaseCellExporter):
         self.comment = ''
 
     def html_comment(self, metadata, code='region'):
+        """Protect a Markdown or Raw cell with HTML comments"""
         if metadata:
             region_start = ['<!-- #' + code]
             if 'title' in metadata and '{' not in metadata['title']:
@@ -143,17 +144,17 @@ class MarkdownCellExporter(BaseCellExporter):
         comment_magic(source, self.language, self.comment_magics)
 
         options = []
+        self.language = self.metadata.pop('language', self.language)
         if self.cell_type == 'code' and self.language:
             options.append(self.language)
 
-        filtered_metadata = {key: self.metadata[key] for key in self.metadata
-                             if key not in ['active', 'language']}
-
-        if filtered_metadata:
-            options.append(metadata_to_md_options(filtered_metadata))
+        if self.metadata:
+            options.append(metadata_to_md_options(self.metadata))
 
         if self.cell_type == 'raw':
-            return self.html_comment(filtered_metadata, 'raw')
+            if self.metadata.get('active') == '':
+                self.metadata.pop('active')
+            return self.html_comment(self.metadata, 'raw')
 
         return ['```{}'.format(' '.join(options))] + source + ['```']
 

--- a/jupytext/cell_to_text.py
+++ b/jupytext/cell_to_text.py
@@ -132,7 +132,7 @@ class MarkdownCellExporter(BaseCellExporter):
         if self.cell_type == 'markdown':
             # Is an explicit region required?
             if self.metadata or self.cell_reader(self.fmt).read(self.source)[1] < len(self.source):
-                return self.html_comment(self.metadata)
+                return self.html_comment(self.metadata, self.metadata.pop('region_name', 'region'))
             return self.source
 
         return self.code_to_text()

--- a/jupytext/cell_to_text.py
+++ b/jupytext/cell_to_text.py
@@ -137,15 +137,14 @@ class MarkdownCellExporter(BaseCellExporter):
         source = copy(self.source)
         comment_magic(source, self.language, self.comment_magics)
 
-        self.language = self.metadata.pop('language', self.language)
-        if self.cell_type == 'code':
-            options = metadata_to_text(self.language, self.metadata)
+        if self.metadata.get('active') == '':
+            self.metadata.pop('active')
 
-        if self.cell_type == 'raw':
-            if self.metadata.get('active') == '':
-                self.metadata.pop('active')
+        self.language = self.metadata.pop('language', self.language)
+        if self.cell_type == 'raw' and not is_active(self.ext, self.metadata, False):
             return self.html_comment(self.metadata, 'raw')
 
+        options = metadata_to_text(self.language, self.metadata)
         return ['```' + options] + source + ['```']
 
 

--- a/jupytext/cell_to_text.py
+++ b/jupytext/cell_to_text.py
@@ -218,10 +218,7 @@ class LightScriptCellExporter(BaseCellExporter):
 
     def code_to_text(self):
         """Return the text representation of a code cell"""
-        active = is_active(self.ext, self.metadata)
-        if self.language != self.default_language and 'active' not in self.metadata:
-            active = False
-
+        active = is_active(self.ext, self.metadata, self.language == self.default_language)
         source = copy(self.source)
         escape_code_start(source, self.ext, self.language)
 
@@ -358,9 +355,7 @@ class DoublePercentCellExporter(BaseCellExporter):  # pylint: disable=W0223
         if self.cell_type != 'code':
             self.metadata['cell_type'] = self.cell_type
 
-        active = is_active(self.ext, self.metadata)
-        if self.language != self.default_language and 'active' not in self.metadata:
-            active = False
+        active = is_active(self.ext, self.metadata, self.language == self.default_language)
         if self.cell_type == 'raw' and 'active' in self.metadata and self.metadata['active'] == '':
             del self.metadata['active']
 

--- a/jupytext/cell_to_text.py
+++ b/jupytext/cell_to_text.py
@@ -168,7 +168,7 @@ class RMarkdownCellExporter(MarkdownCellExporter):
             comment_magic(source, self.language, self.comment_magics)
 
         lines = []
-        if not is_active('Rmd', self.metadata):
+        if not is_active(self.ext, self.metadata):
             self.metadata['eval'] = False
         options = metadata_to_rmd_options(self.language, self.metadata)
         lines.append('```{{{}}}'.format(options))
@@ -335,7 +335,7 @@ class RScriptCellExporter(BaseCellExporter):
             source = ['# ' + line if line else '#' for line in source]
 
         lines = []
-        if not is_active('R', self.metadata):
+        if not is_active(self.ext, self.metadata):
             self.metadata['eval'] = False
         options = metadata_to_rmd_options(None, self.metadata)
         if options:
@@ -358,7 +358,7 @@ class DoublePercentCellExporter(BaseCellExporter):  # pylint: disable=W0223
         if self.cell_type != 'code':
             self.metadata['cell_type'] = self.cell_type
 
-        active = is_active('py', self.metadata)
+        active = is_active(self.ext, self.metadata)
         if self.language != self.default_language and 'active' not in self.metadata:
             active = False
         if self.cell_type == 'raw' and 'active' in self.metadata and self.metadata['active'] == '':

--- a/jupytext/compare.py
+++ b/jupytext/compare.py
@@ -85,12 +85,8 @@ def same_content(ref_source, test_source, allow_removed_final_blank_line):
     return _BLANK_LINE.match(ref_source[-1])
 
 
-def compare_notebooks(notebook_expected,
-                      notebook_actual,
-                      fmt=None,
-                      allow_expected_differences=True,
-                      raise_on_first_difference=True,
-                      compare_outputs=False):
+def compare_notebooks(notebook_actual, notebook_expected, fmt=None, allow_expected_differences=True,
+                      raise_on_first_difference=True, compare_outputs=False):
     """Compare the two notebooks, and raise with a meaningful message
     that explains the differences, if any"""
     fmt = long_form_one_format(fmt)
@@ -245,5 +241,5 @@ def test_round_trip_conversion(notebook, fmt, update, allow_expected_differences
     if update:
         combine_inputs_with_outputs(round_trip, notebook, fmt)
 
-    compare_notebooks(notebook, round_trip, fmt, allow_expected_differences,
+    compare_notebooks(round_trip, notebook, fmt, allow_expected_differences,
                       raise_on_first_difference=stop_on_first_error)

--- a/jupytext/jupytext.py
+++ b/jupytext/jupytext.py
@@ -169,8 +169,8 @@ class TextNotebookConverter(NotebookReader, NotebookWriter):
             # two blank lines between markdown cells in Rmd when those do not have explicit region markers
             if self.ext in ['.md', '.markdown', '.Rmd'] and not cell.is_code():
                 if (i + 1 < len(cell_exporters) and not cell_exporters[i + 1].is_code() and
-                        not texts[i][0].startswith('<!-- #region') and
-                        not texts[i + 1][0].startswith('<!-- #region') and
+                        not texts[i][0].startswith('<!-- #') and
+                        not texts[i + 1][0].startswith('<!-- #') and
                         not texts[i][0].startswith('```') and
                         not texts[i + 1][0].startswith('```') and
                         (not split_at_heading or not (texts[i + 1] and texts[i + 1][0].startswith('#')))):

--- a/tests/notebooks/md/jupytext_markdown.md
+++ b/tests/notebooks/md/jupytext_markdown.md
@@ -33,10 +33,10 @@ Indented code is accepted, and consecutive blank lines there do not break Markdo
 
 ## Raw cells
 
-Raw cells starts with ` ``` `, like here:
-```
-THIS IS A RAW CELL
-```
+Raw cells are delimited with `<!-- #raw -->` and <!-- #endraw -->, like here:
+<!-- #raw -->
+this is a raw cell
+<!-- #endraw -->
 
 # Protected Markdown cells
 
@@ -62,7 +62,7 @@ Metadata are supported for all cell types.
 A cell with a title and additional metadata.
 <!-- #endregion -->
 
-## Code and raw cells
+## Code cells
 
 ```python tags=["parameters"]
 a = 2

--- a/tests/notebooks/mirror/md_to_ipynb/jupytext_markdown.ipynb
+++ b/tests/notebooks/mirror/md_to_ipynb/jupytext_markdown.ipynb
@@ -43,16 +43,14 @@
    "source": [
     "## Raw cells\n",
     "\n",
-    "Raw cells starts with ` ``` `, like here:"
+    "Raw cells are delimited with `<!-- #raw -->` and <!-- #endraw -->, like here:"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "raw",
    "metadata": {},
    "source": [
-    "```\n",
-    "THIS IS A RAW CELL\n",
-    "```"
+    "this is a raw cell"
    ]
   },
   {
@@ -102,7 +100,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Code and raw cells"
+    "## Code cells"
    ]
   },
   {

--- a/tests/notebooks/mirror/md_to_ipynb/plain_markdown.ipynb
+++ b/tests/notebooks/mirror/md_to_ipynb/plain_markdown.ipynb
@@ -46,26 +46,13 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "lines_to_next_cell": 0
-   },
-   "source": [
-    "Code snippet without an explicit language"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Code snippet without an explicit language\n",
     "```\n",
     "echo 'Hello world'\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "```\n",
+    "\n",
     "Markdown comments\n",
     "<!-- #comment -->\n",
     "\n",

--- a/tests/test_active_cells.py
+++ b/tests/test_active_cells.py
@@ -17,7 +17,13 @@ HEADER = {'.py': '''# ---
 # ---
 
 ''',
+          '.md': '''---
+jupyter:
+  jupytext:
+    main_language: python
+---
 
+''',
           '.Rmd': '''---
 jupyter:
   jupytext:
@@ -33,6 +39,10 @@ ACTIVE_ALL = {'.py': """# + {"active": "ipynb,py,R,Rmd"}
 # This cell is active in all extensions
 ```
 """,
+              '.md': """```python active="ipynb,py,R,Rmd"
+# This cell is active in all extensions
+```
+""",
               '.R': """# + {"active": "ipynb,py,R,Rmd"}
 # This cell is active in all extensions
 """,
@@ -43,7 +53,7 @@ ACTIVE_ALL = {'.py': """# + {"active": "ipynb,py,R,Rmd"}
                          'outputs': []}}
 
 
-@pytest.mark.parametrize('ext', ['.Rmd', '.py', '.R'])
+@pytest.mark.parametrize('ext', ['.Rmd', '.md', '.py', '.R'])
 def test_active_all(ext, no_jupytext_version_number):
     nb = jupytext.reads(HEADER[ext] + ACTIVE_ALL[ext], ext)
     assert len(nb.cells) == 1
@@ -56,6 +66,11 @@ ACTIVE_IPYNB = {'.py': """# + {"active": "ipynb"}
 # %matplotlib inline
 """,
                 '.Rmd': """```{python active="ipynb", eval=FALSE}
+# This cell is active only in ipynb
+%matplotlib inline
+```
+""",
+                '.md': """```python active="ipynb"
 # This cell is active only in ipynb
 %matplotlib inline
 ```
@@ -73,7 +88,7 @@ ACTIVE_IPYNB = {'.py': """# + {"active": "ipynb"}
 
 
 @skip_if_dict_is_not_ordered
-@pytest.mark.parametrize('ext', ['.Rmd', '.py', '.R'])
+@pytest.mark.parametrize('ext', ['.Rmd', '.md', '.py', '.R'])
 def test_active_ipynb(ext, no_jupytext_version_number):
     nb = jupytext.reads(HEADER[ext] + ACTIVE_IPYNB[ext], ext)
     assert len(nb.cells) == 1
@@ -90,6 +105,11 @@ ACTIVE_IPYNB_RMD_USING_TAG = {'.py': """# + {"tags": ["active-ipynb-Rmd"]}
 # %matplotlib inline
 ```
 """,
+                              '.md': """```python tags=["active-ipynb-Rmd"]
+# This cell is active only in ipynb and Rmd
+%matplotlib inline
+```
+""",
                               '.R': """# + {"tags": ["active-ipynb-Rmd"]}
 # # This cell is active only in ipynb and Rmd
 # %matplotlib inline
@@ -103,7 +123,7 @@ ACTIVE_IPYNB_RMD_USING_TAG = {'.py': """# + {"tags": ["active-ipynb-Rmd"]}
 
 
 @skip_if_dict_is_not_ordered
-@pytest.mark.parametrize('ext', ['.Rmd', '.py', '.R'])
+@pytest.mark.parametrize('ext', ['.Rmd', '.md', '.py', '.R'])
 def test_active_ipynb_rmd_using_tags(ext, no_jupytext_version_number):
     nb = jupytext.reads(HEADER[ext] + ACTIVE_IPYNB_RMD_USING_TAG[ext], ext)
     assert len(nb.cells) == 1
@@ -138,6 +158,10 @@ ACTIVE_PY_IPYNB = {'.py': """# + {"active": "ipynb,py"}
 # This cell is active in py and ipynb extensions
 ```
 """,
+                   '.md': """```python active="ipynb,py"
+# This cell is active in py and ipynb extensions
+```
+""",
                    '.R': """# + {"active": "ipynb,py"}
 # # This cell is active in py and ipynb extensions
 """,
@@ -150,7 +174,7 @@ ACTIVE_PY_IPYNB = {'.py': """# + {"active": "ipynb,py"}
 
 
 @skip_if_dict_is_not_ordered
-@pytest.mark.parametrize('ext', ['.Rmd', '.py', '.R'])
+@pytest.mark.parametrize('ext', ['.Rmd', '.md', '.py', '.R'])
 def test_active_py_ipynb(ext, no_jupytext_version_number):
     nb = jupytext.reads(HEADER[ext] + ACTIVE_PY_IPYNB[ext], ext)
     assert len(nb.cells) == 1

--- a/tests/test_cell_metadata.py
+++ b/tests/test_cell_metadata.py
@@ -3,7 +3,6 @@ from jupytext.compare import compare
 from jupytext.cell_metadata import rmd_options_to_metadata, metadata_to_rmd_options, parse_rmd_options
 from jupytext.cell_metadata import _IGNORE_CELL_METADATA, RMarkdownOptionParsingError, try_eval_metadata
 from jupytext.cell_metadata import json_options_to_metadata, metadata_to_json_options
-from jupytext.cell_metadata import md_options_to_metadata, metadata_to_md_options
 from jupytext.cell_metadata import text_to_metadata, metadata_to_text
 from jupytext.metadata_filter import filter_metadata
 from .utils import skip_if_dict_is_not_ordered
@@ -84,24 +83,6 @@ def test_try_eval_metadata():
 
 def test_parse_wrong_json():
     assert json_options_to_metadata("""{"key":'incorrect value'}""") == {}
-
-
-def test_parse_md_options():
-    assert md_options_to_metadata('python') == ('python', {})
-    assert md_options_to_metadata('not_a_language') == (None, {'not_a_language': None})
-
-
-def test_round_trip_md_options(metadata={'.class': None,
-                                         'long-and-str$ange.name': None,
-                                         'string': "Hello",
-                                         'number': .21,
-                                         'array': ['First', 'Second', 3, "string with single ' in it'"],
-                                         'dict': {"a": 5, "b": [1.2, "four"]},
-                                         '.another_class': None}):
-    options = metadata_to_md_options(metadata)
-    language, metadata2 = md_options_to_metadata('python ' + options)
-    assert language == 'python'
-    compare(metadata, metadata2)
 
 
 def test_write_parse_json():

--- a/tests/test_cell_metadata.py
+++ b/tests/test_cell_metadata.py
@@ -90,7 +90,12 @@ def test_language_no_metadata(text='python', value=('python', {})):
 
 def test_only_metadata(text='key="value"', value=('', {'key': 'value'})):
     compare(text_to_metadata(text), value)
-    assert metadata_to_text(*value) == text.strip()
+    assert metadata_to_text(*value) == text
+
+
+def test_only_metadata_2(text='key="value"', value=('', {'key': 'value'})):
+    compare(text_to_metadata(text, allow_title=True), value)
+    assert metadata_to_text(*value) == text
 
 
 def test_no_language(text='.class', value=('', {'.class': None})):

--- a/tests/test_cell_metadata.py
+++ b/tests/test_cell_metadata.py
@@ -114,6 +114,31 @@ def test_write_parse_json():
 pytestmark = skip_if_dict_is_not_ordered
 
 
+def test_language_no_metadata(text='python', value=('python', {})):
+    compare(text_to_metadata(text), value)
+    assert metadata_to_text(*value) == text.strip()
+
+
+def test_only_metadata(text='key="value"', value=('', {'key': 'value'})):
+    compare(text_to_metadata(text), value)
+    assert metadata_to_text(*value) == text.strip()
+
+
+def test_no_language(text='.class', value=('', {'.class': None})):
+    compare(text_to_metadata(text), value)
+    assert metadata_to_text(*value) == text
+
+
+def test_language_metadata_no_space(text='python{"a":1}', value=('python', {'a': 1})):
+    compare(text_to_metadata(text), value)
+    assert metadata_to_text(*value) == 'python a=1'
+
+
+def test_title_no_metadata(text='title', value=('title', {})):
+    compare(text_to_metadata(text, allow_title=True), value)
+    assert metadata_to_text(*value) == text.strip()
+
+
 def test_simple_metadata(text='python string="value" number=1.0 array=["a", "b"]',
                          value=('python', {'string': 'value', 'number': 1.0, 'array': ['a', 'b']})):
     compare(text_to_metadata(text), value)

--- a/tests/test_cell_metadata.py
+++ b/tests/test_cell_metadata.py
@@ -111,6 +111,9 @@ def test_write_parse_json():
     assert metadata == metadata2
 
 
+pytestmark = skip_if_dict_is_not_ordered
+
+
 def test_simple_metadata(text='python string="value" number=1.0 array=["a", "b"]',
                          value=('python', {'string': 'value', 'number': 1.0, 'array': ['a', 'b']})):
     compare(text_to_metadata(text), value)

--- a/tests/test_cell_metadata.py
+++ b/tests/test_cell_metadata.py
@@ -2,7 +2,6 @@ import pytest
 from jupytext.compare import compare
 from jupytext.cell_metadata import rmd_options_to_metadata, metadata_to_rmd_options, parse_rmd_options
 from jupytext.cell_metadata import _IGNORE_CELL_METADATA, RMarkdownOptionParsingError, try_eval_metadata
-from jupytext.cell_metadata import json_options_to_metadata, metadata_to_json_options
 from jupytext.cell_metadata import text_to_metadata, metadata_to_text
 from jupytext.metadata_filter import filter_metadata
 from .utils import skip_if_dict_is_not_ordered
@@ -79,17 +78,6 @@ def test_try_eval_metadata():
     try_eval_metadata(metadata, 'list')
     try_eval_metadata(metadata, 'c')
     assert metadata == {'list': ['a', 5], 'c': [1, 2, 3]}
-
-
-def test_parse_wrong_json():
-    assert json_options_to_metadata("""{"key":'incorrect value'}""") == {}
-
-
-def test_write_parse_json():
-    metadata = {"tags": ["parameters"]}
-    options = metadata_to_json_options(metadata)
-    metadata2 = json_options_to_metadata(options, add_brackets=False)
-    assert metadata == metadata2
 
 
 pytestmark = skip_if_dict_is_not_ordered

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -60,7 +60,7 @@ def test_convert_single_file_in_place(nb_file, tmpdir):
     nb1 = read(nb_org)
     nb2 = read(nb_other)
 
-    compare_notebooks(nb1, nb2)
+    compare_notebooks(nb2, nb1)
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb') + list_notebooks('Rmd'))
@@ -137,7 +137,7 @@ def test_convert_multiple_file(nb_files, tmpdir):
     for nb_org, nb_other in zip(nb_orgs, nb_others):
         nb1 = read(nb_org)
         nb2 = read(nb_other)
-        compare_notebooks(nb1, nb2)
+        compare_notebooks(nb2, nb1)
 
 
 def test_error_not_notebook_ext_input(tmpdir, capsys):
@@ -291,7 +291,7 @@ def test_convert_to_percent_format(nb_file, tmpdir):
     nb1 = read(tmp_ipynb)
     nb2 = read(tmp_nbpy)
 
-    compare_notebooks(nb1, nb2)
+    compare_notebooks(nb2, nb1)
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_py'))
@@ -312,7 +312,7 @@ def test_convert_to_percent_format_and_keep_magics(nb_file, tmpdir):
     nb1 = read(tmp_ipynb)
     nb2 = read(tmp_nbpy)
 
-    compare_notebooks(nb1, nb2)
+    compare_notebooks(nb2, nb1)
 
 
 def git_in_tmpdir(tmpdir):
@@ -617,22 +617,22 @@ def test_sync(nb_file, tmpdir, capsys):
     jupytext(['--sync', tmp_ipynb])
 
     assert os.path.isfile(tmp_py)
-    compare_notebooks(nb, read(tmp_py))
+    compare_notebooks(read(tmp_py), nb)
 
     assert os.path.isfile(tmp_rmd)
-    compare_notebooks(nb, read(tmp_rmd), 'Rmd')
+    compare_notebooks(read(tmp_rmd), nb, 'Rmd')
 
     write(nb, tmp_rmd, 'Rmd')
     jupytext(['--sync', tmp_ipynb])
 
     nb2 = read(tmp_ipynb)
-    compare_notebooks(nb, nb2, 'Rmd', compare_outputs=True)
+    compare_notebooks(nb2, nb, 'Rmd', compare_outputs=True)
 
     write(nb, tmp_py, 'py')
     jupytext(['--sync', tmp_ipynb])
 
     nb2 = read(tmp_ipynb)
-    compare_notebooks(nb, nb2, compare_outputs=True)
+    compare_notebooks(nb2, nb, compare_outputs=True)
 
     # Finally we recreate the ipynb
     os.remove(tmp_ipynb)
@@ -641,7 +641,7 @@ def test_sync(nb_file, tmpdir, capsys):
     jupytext(['--sync', tmp_py])
 
     nb2 = read(tmp_ipynb)
-    compare_notebooks(nb, nb2)
+    compare_notebooks(nb2, nb)
 
     # ipynb must be older than py file, otherwise our Contents Manager will complain
     assert os.path.getmtime(tmp_ipynb) <= os.path.getmtime(tmp_py)
@@ -668,7 +668,7 @@ def test_sync_pandoc(nb_file, tmpdir, capsys):
     jupytext(['--sync', tmp_ipynb])
 
     assert os.path.isfile(tmp_md)
-    compare_notebooks(nb, read(tmp_md), 'md:pandoc')
+    compare_notebooks(read(tmp_md), nb, 'md:pandoc')
 
     with open(tmp_md) as fp:
         assert 'pandoc' in fp.read()
@@ -687,13 +687,13 @@ def test_cli_can_infer_jupytext_format(nb_file, ext, tmpdir):
     write(nb, tmp_text)
     jupytext(['--to', 'notebook', tmp_text])
     nb2 = read(tmp_ipynb)
-    compare_notebooks(nb, nb2)
+    compare_notebooks(nb2, nb)
 
     # Percent format to Jupyter notebook
     write(nb, tmp_text, ext + ':percent')
     jupytext(['--to', 'notebook', tmp_text])
     nb2 = read(tmp_ipynb)
-    compare_notebooks(nb, nb2)
+    compare_notebooks(nb2, nb)
 
 
 @pytest.mark.parametrize('nb_file,ext',
@@ -707,7 +707,7 @@ def test_cli_to_script(nb_file, ext, tmpdir):
     write(nb, tmp_ipynb)
     jupytext(['--to', 'script', tmp_ipynb])
     nb2 = read(tmp_text)
-    compare_notebooks(nb, nb2)
+    compare_notebooks(nb2, nb)
 
 
 @pytest.mark.parametrize('nb_file,ext',
@@ -721,7 +721,7 @@ def test_cli_to_auto(nb_file, ext, tmpdir):
     write(nb, tmp_ipynb)
     jupytext(['--to', 'auto', tmp_ipynb])
     nb2 = read(tmp_text)
-    compare_notebooks(nb, nb2)
+    compare_notebooks(nb2, nb)
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_py'))
@@ -735,25 +735,25 @@ def test_cli_can_infer_jupytext_format_from_stdin(nb_file, tmpdir):
     with open(nb_file) as fp, mock.patch('sys.stdin', fp):
         jupytext(['--to', 'py:percent', '-o', tmp_py])
     nb2 = read(tmp_py)
-    compare_notebooks(nb, nb2)
+    compare_notebooks(nb2, nb)
 
     # read python notebook on stdin, write to ipynb
     with open(tmp_py) as fp, mock.patch('sys.stdin', fp):
         jupytext(['-o', tmp_ipynb])
     nb2 = read(tmp_ipynb)
-    compare_notebooks(nb, nb2)
+    compare_notebooks(nb2, nb)
 
     # read ipynb notebook on stdin, write to R markdown
     with open(nb_file) as fp, mock.patch('sys.stdin', fp):
         jupytext(['-o', tmp_rmd])
     nb2 = read(tmp_rmd)
-    compare_notebooks(nb, nb2, 'Rmd')
+    compare_notebooks(nb2, nb, 'Rmd')
 
     # read markdown notebook on stdin, write to ipynb
     with open(tmp_rmd) as fp, mock.patch('sys.stdin', fp):
         jupytext(['-o', tmp_ipynb])
     nb2 = read(tmp_ipynb)
-    compare_notebooks(nb, nb2, 'Rmd')
+    compare_notebooks(nb2, nb, 'Rmd')
 
 
 def test_set_kernel_works_with_pipes_326(capsys):

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -92,7 +92,7 @@ def test_raise_on_different_metadata():
     test = new_notebook(metadata={'kernelspec': {'language': 'R', 'name': 'R', 'display_name': 'R'}},
                         cells=[new_markdown_cell('Cell one')])
     with pytest.raises(NotebookDifference):
-        compare_notebooks(ref, test, 'md')
+        compare_notebooks(test, ref, 'md')
 
 
 @pytest.mark.parametrize('raise_on_first_difference', [True, False])
@@ -100,7 +100,7 @@ def test_raise_on_different_cell_type(raise_on_first_difference):
     ref = new_notebook(cells=[new_markdown_cell('Cell one'), new_code_cell('Cell two')])
     test = new_notebook(cells=[new_markdown_cell('Cell one'), new_raw_cell('Cell two')])
     with pytest.raises(NotebookDifference):
-        compare_notebooks(ref, test, 'md', raise_on_first_difference=raise_on_first_difference)
+        compare_notebooks(test, ref, 'md', raise_on_first_difference=raise_on_first_difference)
 
 
 @pytest.mark.parametrize('raise_on_first_difference', [True, False])
@@ -108,14 +108,14 @@ def test_raise_on_different_cell_content(raise_on_first_difference):
     ref = new_notebook(cells=[new_markdown_cell('Cell one'), new_code_cell('Cell two')])
     test = new_notebook(cells=[new_markdown_cell('Cell one'), new_code_cell('Modified cell two')])
     with pytest.raises(NotebookDifference):
-        compare_notebooks(ref, test, 'md', raise_on_first_difference=raise_on_first_difference)
+        compare_notebooks(test, ref, 'md', raise_on_first_difference=raise_on_first_difference)
 
 
 def test_raise_on_incomplete_markdown_cell():
     ref = new_notebook(cells=[new_markdown_cell('Cell one\n\n\nsecond line')])
     test = new_notebook(cells=[new_markdown_cell('Cell one')])
     with pytest.raises(NotebookDifference):
-        compare_notebooks(ref, test, 'md')
+        compare_notebooks(test, ref, 'md')
 
 
 def test_does_raise_on_split_markdown_cell():
@@ -123,14 +123,14 @@ def test_does_raise_on_split_markdown_cell():
     test = new_notebook(cells=[new_markdown_cell('Cell one'),
                                new_markdown_cell('second line')])
     with pytest.raises(NotebookDifference):
-        compare_notebooks(ref, test, 'md')
+        compare_notebooks(test, ref, 'md')
 
 
 def test_raise_on_different_cell_metadata():
     ref = new_notebook(cells=[new_code_cell('1+1')])
     test = new_notebook(cells=[new_code_cell('1+1', metadata={'metakey': 'value'})])
     with pytest.raises(NotebookDifference):
-        compare_notebooks(ref, test, 'py:light')
+        compare_notebooks(test, ref, 'py:light')
 
 
 @pytest.mark.parametrize('raise_on_first_difference', [True, False])
@@ -139,23 +139,23 @@ def test_raise_on_different_cell_count(raise_on_first_difference):
     test = new_notebook(cells=[new_code_cell('1'),
                                new_code_cell('2')])
     with pytest.raises(NotebookDifference):
-        compare_notebooks(ref, test, 'py:light', raise_on_first_difference=raise_on_first_difference)
+        compare_notebooks(test, ref, 'py:light', raise_on_first_difference=raise_on_first_difference)
 
     with pytest.raises(NotebookDifference):
-        compare_notebooks(test, ref, 'py:light', raise_on_first_difference=raise_on_first_difference)
+        compare_notebooks(ref, test, 'py:light', raise_on_first_difference=raise_on_first_difference)
 
 
 def test_does_not_raise_on_blank_line_removed():
     ref = new_notebook(cells=[new_code_cell('1+1\n    ')])
     test = new_notebook(cells=[new_code_cell('1+1')])
-    compare_notebooks(ref, test, 'py:light')
+    compare_notebooks(test, ref, 'py:light')
 
 
 def test_strict_raise_on_blank_line_removed():
     ref = new_notebook(cells=[new_code_cell('1+1\n')])
     test = new_notebook(cells=[new_code_cell('1+1')])
     with pytest.raises(NotebookDifference):
-        compare_notebooks(ref, test, 'py:light', allow_expected_differences=False)
+        compare_notebooks(test, ref, 'py:light', allow_expected_differences=False)
 
 
 def test_dont_raise_on_different_outputs():
@@ -172,7 +172,7 @@ def test_dont_raise_on_different_outputs():
             "output_type": "execute_result"
         }
     ])])
-    compare_notebooks(ref, test, 'md')
+    compare_notebooks(test, ref, 'md')
 
 
 @pytest.mark.parametrize('raise_on_first_difference', [True, False])
@@ -191,7 +191,7 @@ def test_raise_on_different_outputs(raise_on_first_difference):
         }
     ])])
     with pytest.raises(NotebookDifference):
-        compare_notebooks(ref, test, 'md', compare_outputs=True, raise_on_first_difference=raise_on_first_difference)
+        compare_notebooks(test, ref, 'md', raise_on_first_difference=raise_on_first_difference, compare_outputs=True)
 
 
 def test_test_round_trip_conversion():
@@ -217,7 +217,7 @@ def test_mutiple_cells_differ():
     nb2 = new_notebook(cells=[new_code_cell('1+1'),
                               new_code_cell('2\n2')])
     with pytest.raises(NotebookDifference) as exception_info:
-        compare_notebooks(nb1, nb2, raise_on_first_difference=False)
+        compare_notebooks(nb2, nb1, raise_on_first_difference=False)
     assert 'Cells 1,2 differ' in exception_info.value.args[0]
 
 
@@ -227,7 +227,7 @@ def test_cell_metadata_differ():
     nb2 = new_notebook(cells=[new_code_cell('1'),
                               new_code_cell('2', metadata={'additional': 'metadata2'})])
     with pytest.raises(NotebookDifference) as exception_info:
-        compare_notebooks(nb1, nb2, raise_on_first_difference=False)
+        compare_notebooks(nb2, nb1, raise_on_first_difference=False)
     assert "Cell metadata 'additional' differ" in exception_info.value.args[0]
 
 
@@ -238,5 +238,5 @@ def test_notebook_metadata_differ():
                               new_code_cell('2')],
                        metadata={'kernelspec': {'language': 'python', 'name': 'python', 'display_name': 'Python'}})
     with pytest.raises(NotebookDifference) as exception_info:
-        compare_notebooks(nb1, nb2, raise_on_first_difference=False, )
+        compare_notebooks(nb2, nb1, raise_on_first_difference=False)
     assert "Notebook metadata differ" in exception_info.value.args[0]

--- a/tests/test_contentsmanager.py
+++ b/tests/test_contentsmanager.py
@@ -85,7 +85,7 @@ def test_pair_unpair_notebook(tmpdir):
 
     # reload and get outputs
     nb2 = cm.get(tmp_md)['content']
-    compare_notebooks(nb2, nb)
+    compare_notebooks(nb, nb2)
 
     # unpair and save as md
     del nb['metadata']['jupytext']
@@ -93,7 +93,7 @@ def test_pair_unpair_notebook(tmpdir):
     nb2 = cm.get(tmp_md)['content']
 
     # we get no outputs here
-    compare_notebooks(nb2, nb, compare_outputs=False)
+    compare_notebooks(nb, nb2, compare_outputs=False)
     assert len(nb2.cells[0]['outputs']) == 0
 
 
@@ -111,7 +111,7 @@ def test_load_save_rename(nb_file, tmpdir):
     nb = jupytext.read(nb_file)
     cm.save(model=dict(type='notebook', content=nb), path=tmp_rmd)
     nb_rmd = cm.get(tmp_rmd)
-    compare_notebooks(nb, nb_rmd['content'], 'Rmd')
+    compare_notebooks(nb_rmd['content'], nb, 'Rmd')
 
     # save ipynb
     cm.save(model=dict(type='notebook', content=nb), path=tmp_ipynb)
@@ -157,7 +157,7 @@ def test_save_load_paired_md_notebook(nb_file, tmpdir):
     cm.save(model=dict(type='notebook', content=nb), path=tmp_ipynb)
     nb_md = cm.get(tmp_md)
 
-    compare_notebooks(nb, nb_md['content'], 'md')
+    compare_notebooks(nb_md['content'], nb, 'md')
     assert nb_md['content'].metadata['jupytext']['formats'] == 'ipynb,md'
 
 
@@ -178,7 +178,7 @@ def test_save_load_paired_md_pandoc_notebook(nb_file, tmpdir):
     cm.save(model=dict(type='notebook', content=nb), path=tmp_ipynb)
     nb_md = cm.get(tmp_md)
 
-    compare_notebooks(nb, nb_md['content'], 'md:pandoc')
+    compare_notebooks(nb_md['content'], nb, 'md:pandoc')
     assert nb_md['content'].metadata['jupytext']['formats'] == 'ipynb,md:pandoc'
 
 
@@ -210,7 +210,7 @@ def test_pair_plain_script(py_file, tmpdir):
 
     # reopen py file with the cm
     nb2 = cm.get(tmp_py)['content']
-    compare_notebooks(nb, nb2)
+    compare_notebooks(nb2, nb)
     assert nb2.metadata['jupytext']['formats'] == 'ipynb,py:hydrogen'
 
     # remove the pairing and save
@@ -219,7 +219,7 @@ def test_pair_plain_script(py_file, tmpdir):
 
     # reopen py file with the cm
     nb2 = cm.get(tmp_py)['content']
-    compare_notebooks(nb, nb2)
+    compare_notebooks(nb2, nb)
     assert 'formats' not in nb2.metadata['jupytext']
 
 
@@ -237,7 +237,7 @@ def test_load_save_rename_nbpy(nb_file, tmpdir):
     nb = jupytext.read(nb_file)
     cm.save(model=dict(type='notebook', content=nb), path=tmp_nbpy)
     nbpy = cm.get(tmp_nbpy)
-    compare_notebooks(nb, nbpy['content'])
+    compare_notebooks(nbpy['content'], nb)
 
     # save ipynb
     cm.save(model=dict(type='notebook', content=nb), path=tmp_ipynb)
@@ -295,7 +295,7 @@ def test_load_save_rename_notebook_with_dot(nb_file, tmpdir):
     nb = jupytext.read(nb_file)
     cm.save(model=dict(type='notebook', content=nb), path=tmp_nbpy)
     nbpy = cm.get(tmp_nbpy)
-    compare_notebooks(nb, nbpy['content'])
+    compare_notebooks(nbpy['content'], nb)
 
     # save ipynb
     cm.save(model=dict(type='notebook', content=nb), path=tmp_ipynb)
@@ -324,11 +324,11 @@ def test_load_save_rename_nbpy_default_config(nb_file, tmpdir):
 
     cm.save(model=dict(type='notebook', content=nb), path=tmp_nbpy)
     nbpy = cm.get(tmp_nbpy)
-    compare_notebooks(nb, nbpy['content'])
+    compare_notebooks(nbpy['content'], nb)
 
     # open ipynb
     nbipynb = cm.get(tmp_ipynb)
-    compare_notebooks(nb, nbipynb['content'])
+    compare_notebooks(nbipynb['content'], nb)
 
     # save ipynb
     cm.save(model=dict(type='notebook', content=nb), path=tmp_ipynb)
@@ -365,11 +365,11 @@ def test_load_save_rename_non_ascii_path(nb_file, tmpdir):
 
     cm.save(model=dict(type='notebook', content=nb), path=tmp_nbpy)
     nbpy = cm.get(tmp_nbpy)
-    compare_notebooks(nb, nbpy['content'])
+    compare_notebooks(nbpy['content'], nb)
 
     # open ipynb
     nbipynb = cm.get(tmp_ipynb)
-    compare_notebooks(nb, nbipynb['content'])
+    compare_notebooks(nbipynb['content'], nb)
 
     # save ipynb
     cm.save(model=dict(type='notebook', content=nb), path=tmp_ipynb)
@@ -455,8 +455,8 @@ def test_reload_notebook_after_jupytext_cli(nb_file, tmpdir):
     nb1 = cm.get('notebook.py')['content']
     nb2 = cm.get('notebook.ipynb')['content']
 
-    compare_notebooks(nb1, nb)
-    compare_notebooks(nb2, nb)
+    compare_notebooks(nb, nb1)
+    compare_notebooks(nb, nb2)
 
 
 @skip_if_dict_is_not_ordered
@@ -591,12 +591,12 @@ def test_open_using_preferred_and_default_format_174(nb_file, tmpdir):
 
     # read py file
     model2 = cm.get('python/notebook.py')
-    compare_notebooks(model['content'], model2['content'])
+    compare_notebooks(model2['content'], model['content'])
 
     # move py file to the another folder
     shutil.move(tmp_py, tmp_py2)
     model2 = cm.get('other/notebook.py')
-    compare_notebooks(model['content'], model2['content'])
+    compare_notebooks(model2['content'], model['content'])
     cm.save(model=model, path='other/notebook.py')
     assert not os.path.isfile(tmp_ipynb)
     assert not os.path.isfile(str(tmpdir.join('other/notebook.ipynb')))
@@ -626,7 +626,7 @@ def test_kernelspec_are_preserved(nb_file, tmpdir):
 
     # read ipynb
     model2 = cm.get('notebook.ipynb')
-    compare_notebooks(model['content'], model2['content'])
+    compare_notebooks(model2['content'], model['content'])
 
 
 @skip_if_dict_is_not_ordered
@@ -657,16 +657,16 @@ def test_save_to_light_percent_sphinx_format(nb_file, tmpdir):
         assert read_format_from_metadata(stream.read(), '.py') == 'sphinx'
 
     model = cm.get(path=tmp_pct_py)
-    compare_notebooks(nb, model['content'])
+    compare_notebooks(model['content'], nb)
 
     model = cm.get(path=tmp_lgt_py)
-    compare_notebooks(nb, model['content'])
+    compare_notebooks(model['content'], nb)
 
     model = cm.get(path=tmp_spx_py)
     # (notebooks not equal as we insert %matplotlib inline in sphinx)
 
     model = cm.get(path=tmp_ipynb)
-    compare_notebooks(nb, model['content'])
+    compare_notebooks(model['content'], nb)
 
 
 @skip_if_dict_is_not_ordered
@@ -693,11 +693,11 @@ def test_pair_notebook_with_dot(nb_file, tmpdir):
 
     model = cm.get(path=tmp_py)
     assert model['name'] == 'file.5.1.py'
-    compare_notebooks(nb, model['content'])
+    compare_notebooks(model['content'], nb)
 
     model = cm.get(path=tmp_ipynb)
     assert model['name'] == 'file.5.1.ipynb'
-    compare_notebooks(nb, model['content'])
+    compare_notebooks(model['content'], nb)
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_py')[:1])
@@ -728,7 +728,7 @@ def test_preferred_format_allows_to_read_others_format(nb_file, tmpdir):
     assert model['content']['metadata']['jupytext']['formats'] == 'ipynb,py:light'
 
     # Check contents
-    compare_notebooks(nb, model['content'])
+    compare_notebooks(model['content'], nb)
 
     # Change save format and save
     model['content']['metadata']['jupytext']['formats'] == 'ipynb,py'
@@ -737,7 +737,7 @@ def test_preferred_format_allows_to_read_others_format(nb_file, tmpdir):
 
     # Read notebook
     model = cm.get(tmp_nbpy)
-    compare_notebooks(nb, model['content'])
+    compare_notebooks(model['content'], nb)
 
     # Check that format is explicit
     assert model['content']['metadata']['jupytext']['formats'] == 'ipynb,py:percent'
@@ -790,7 +790,7 @@ def test_save_in_auto_extension_global(nb_file, tmpdir):
     # saving should not create a format entry #95
     assert 'formats' not in model['content'].metadata.get('jupytext', {})
 
-    compare_notebooks(nb, model['content'])
+    compare_notebooks(model['content'], nb)
 
 
 def test_global_auto_pairing_works_with_empty_notebook(tmpdir):
@@ -815,7 +815,7 @@ def test_global_auto_pairing_works_with_empty_notebook(tmpdir):
     assert 'notebook.ipynb' not in cm.paired_notebooks
 
     model = cm.get(path='notebook.ipynb')
-    compare_notebooks(nb, model['content'])
+    compare_notebooks(model['content'], nb)
 
     # add language information to the notebook
     nb.metadata['language_info'] = {
@@ -876,7 +876,7 @@ def test_save_in_auto_extension_global_with_format(nb_file, tmpdir):
     # saving should not create a format entry #95
     assert 'formats' not in model['content'].metadata.get('jupytext', {})
 
-    compare_notebooks(nb, model['content'])
+    compare_notebooks(model['content'], nb)
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb'))
@@ -903,7 +903,7 @@ def test_save_in_auto_extension_local(nb_file, tmpdir):
     # reload and compare with original notebook
     model = cm.get(path=tmp_script)
 
-    compare_notebooks(nb, model['content'])
+    compare_notebooks(model['content'], nb)
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb'))
@@ -972,7 +972,7 @@ def test_metadata_filter_is_effective(nb_file, tmpdir):
     # read paired notebook
     nb3 = cm.get(tmp_script)['content']
 
-    compare_notebooks(nb, nb3)
+    compare_notebooks(nb3, nb)
 
 
 def test_no_metadata_added_to_scripts_139(tmpdir):
@@ -1032,7 +1032,7 @@ def test_local_format_can_deactivate_pairing(nb_file, ext, tmpdir):
     assert os.path.isfile(str(tmpdir.join('notebook.py'))) == (ext == '.py')
     assert os.path.isfile(str(tmpdir.join('notebook.ipynb'))) == (ext == '.ipynb')
     nb2 = cm.get('notebook' + ext)['content']
-    compare_notebooks(nb, nb2)
+    compare_notebooks(nb2, nb)
 
     # resave, check again
     cm.save(model=dict(type='notebook', content=nb2), path='notebook' + ext)
@@ -1040,7 +1040,7 @@ def test_local_format_can_deactivate_pairing(nb_file, ext, tmpdir):
     assert os.path.isfile(str(tmpdir.join('notebook.py'))) == (ext == '.py')
     assert os.path.isfile(str(tmpdir.join('notebook.ipynb'))) == (ext == '.ipynb')
     nb3 = cm.get('notebook' + ext)['content']
-    compare_notebooks(nb, nb3)
+    compare_notebooks(nb3, nb)
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('Rmd'))
@@ -1062,7 +1062,7 @@ def test_global_pairing_allows_to_save_other_file_types(nb_file, tmpdir):
     assert not os.path.isfile(str(tmpdir.join('notebook.ipynb')))
 
     nb2 = cm.get('notebook.Rmd')['content']
-    compare_notebooks(nb, nb2)
+    compare_notebooks(nb2, nb)
 
 
 @skip_if_dict_is_not_ordered
@@ -1332,7 +1332,7 @@ def test_vim_folding_markers(tmpdir):
     assert os.path.isfile(tmp_py)
 
     nb2 = cm.get('nb.ipynb')['content']
-    compare_notebooks(nb, nb2)
+    compare_notebooks(nb2, nb)
 
     nb3 = read(tmp_py)
     assert nb3.metadata['jupytext']['cell_markers'] == '{{{,}}}'
@@ -1379,7 +1379,7 @@ def test_vscode_pycharm_folding_markers(tmpdir):
     assert os.path.isfile(tmp_py)
 
     nb2 = cm.get('nb.ipynb')['content']
-    compare_notebooks(nb, nb2)
+    compare_notebooks(nb2, nb)
 
     nb3 = read(tmp_py)
     assert nb3.metadata['jupytext']['cell_markers'] == 'region,endregion'
@@ -1474,7 +1474,7 @@ def test_save_file_with_default_cell_markers(tmpdir):
     compare('\n'.join(text.splitlines()), '\n'.join(text2.splitlines()[-len(text.splitlines()):]))
 
     nb2 = cm.get('nb.py')['content']
-    compare_notebooks(nb, nb2)
+    compare_notebooks(nb2, nb)
     assert nb2.metadata['jupytext']['cell_markers'] == '+,-'
 
 

--- a/tests/test_escape_magics.py
+++ b/tests/test_escape_magics.py
@@ -52,7 +52,7 @@ def test_magics_commented_default(fmt, commented):
     if 'sphinx' in fmt:
         nb2.cells = nb2.cells[1:]
 
-    compare_notebooks(nb, nb2)
+    compare_notebooks(nb2, nb)
 
 
 @pytest.mark.parametrize('fmt', ['md', 'Rmd', 'py:light', 'py:percent', 'py:sphinx', 'R', 'ss:light', 'ss:percent'])
@@ -69,7 +69,7 @@ def test_magics_are_commented(fmt):
     if 'sphinx' in fmt:
         nb2.cells = nb2.cells[1:]
 
-    compare_notebooks(nb, nb2)
+    compare_notebooks(nb2, nb)
 
 
 @pytest.mark.parametrize('fmt', ['md', 'Rmd', 'py:light', 'py:percent', 'py:sphinx', 'R', 'ss:light', 'ss:percent'])
@@ -86,7 +86,7 @@ def test_magics_are_not_commented(fmt):
     if 'sphinx' in fmt:
         nb2.cells = nb2.cells[1:]
 
-    compare_notebooks(nb, nb2)
+    compare_notebooks(nb2, nb)
 
 
 def test_force_comment_using_contents_manager(tmpdir):
@@ -150,4 +150,4 @@ def g(x):
 def g(x):
     return x+1
 """, text)
-    compare_notebooks(nb, jupytext.reads(text, 'py'))
+    compare_notebooks(jupytext.reads(text, 'py'), nb)

--- a/tests/test_ipynb_to_R.py
+++ b/tests/test_ipynb_to_R.py
@@ -19,4 +19,4 @@ def test_identity_source_write_read(nb_file, ext):
     R = jupytext.writes(nb1, ext)
     nb2 = jupytext.reads(R, ext)
 
-    compare_notebooks(nb1, nb2)
+    compare_notebooks(nb2, nb1)

--- a/tests/test_ipynb_to_py.py
+++ b/tests/test_ipynb_to_py.py
@@ -16,4 +16,4 @@ def test_identity_source_write_read(nb_file):
     py = jupytext.writes(nb1, 'py')
     nb2 = jupytext.reads(py, 'py')
 
-    compare_notebooks(nb1, nb2)
+    compare_notebooks(nb2, nb1)

--- a/tests/test_ipynb_to_rmd.py
+++ b/tests/test_ipynb_to_rmd.py
@@ -16,4 +16,4 @@ def test_identity_source_write_read(nb_file):
     rmd = jupytext.writes(nb1, 'Rmd')
     nb2 = jupytext.reads(rmd, 'Rmd')
 
-    compare_notebooks(nb1, nb2, 'Rmd')
+    compare_notebooks(nb2, nb1, 'Rmd')

--- a/tests/test_jupytext_read.py
+++ b/tests/test_jupytext_read.py
@@ -19,4 +19,4 @@ def test_read_file_with_explicit_fmt(tmpdir):
     nb1 = jupytext.read(tmp_py)
     nb2 = jupytext.read(tmp_py, fmt='py:percent')
 
-    compare_notebooks(nb1, nb2)
+    compare_notebooks(nb2, nb1)

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -62,7 +62,7 @@ def assert_conversion_same_as_mirror(nb_file, fmt, mirror_name, compare_notebook
 
     if not actual.endswith('\n'):
         actual = actual + '\n'
-    compare(expected, actual)
+    compare(actual, expected)
 
     # Compare the two notebooks
     if ext != '.ipynb':
@@ -76,10 +76,10 @@ def assert_conversion_same_as_mirror(nb_file, fmt, mirror_name, compare_notebook
             for cell in nb_mirror.cells:
                 cell.metadata = {}
 
-        compare_notebooks(notebook, nb_mirror, fmt)
+        compare_notebooks(nb_mirror, notebook, fmt)
 
         combine_inputs_with_outputs(nb_mirror, notebook)
-        compare_notebooks(notebook, nb_mirror, fmt, compare_outputs=True)
+        compare_notebooks(nb_mirror, notebook, fmt, compare_outputs=True)
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('julia') + list_notebooks('python') + list_notebooks('R'))

--- a/tests/test_preserve_empty_cells.py
+++ b/tests/test_preserve_empty_cells.py
@@ -27,4 +27,4 @@ def test_notebook_with_empty_cells(blank_cells):
     script = jupytext.writes(notebook, 'py')
     notebook2 = jupytext.reads(script, 'py')
 
-    compare_notebooks(notebook, notebook2)
+    compare_notebooks(notebook2, notebook)

--- a/tests/test_read_simple_markdown.py
+++ b/tests/test_read_simple_markdown.py
@@ -18,9 +18,21 @@ x = np.arange(0,1,eps)
 y = np.abs(x)-.5
 ```
 
+This is
+a Markdown cell
+
 ```
-# this is a code cell with no language info
+# followed by a code cell with no language info
 ```
+
+```
+# another code cell
+
+
+# with two blank lines
+```
+
+And the same markdown cell continues
 
 <!-- #raw -->
 this is a raw cell
@@ -52,7 +64,21 @@ cat(stringi::stri_rand_lipsum(3), sep='\n\n')
                         'outputs': []},
                        {'cell_type': 'markdown',
                         'metadata': {},
-                        'source': '```\n# this is a code cell with no language info\n```'},
+                        'source': '''This is
+a Markdown cell
+
+```
+# followed by a code cell with no language info
+```
+
+```
+# another code cell
+
+
+# with two blank lines
+```
+
+And the same markdown cell continues'''},
                        {'cell_type': 'raw',
                         'metadata': {},
                         'source': 'this is a raw cell'},

--- a/tests/test_read_simple_markdown.py
+++ b/tests/test_read_simple_markdown.py
@@ -98,6 +98,42 @@ And the same markdown cell continues'''},
     compare(markdown, markdown2)
 
 
+def test_read_md_and_markdown_regions(markdown="""Some text
+
+<!-- #md -->
+A
+
+
+long
+cell
+<!-- #endmd -->
+
+<!-- #markdown -->
+Another
+
+
+long
+cell
+<!-- #endmarkdown -->
+"""):
+    nb = jupytext.reads(markdown, 'md')
+    assert nb.metadata['jupytext']['main_language'] == 'python'
+    compare(nb.cells, [new_markdown_cell('Some text'),
+                       new_markdown_cell("""A
+
+
+long
+cell""", metadata={'region_name': 'md'}),
+                       new_markdown_cell("""Another
+
+
+long
+cell""", metadata={'region_name': 'markdown'})])
+
+    markdown2 = jupytext.writes(nb, 'md')
+    compare(markdown, markdown2)
+
+
 def test_read_mostly_R_markdown_file(markdown="""```R
 ls()
 ```

--- a/tests/test_read_simple_markdown.py
+++ b/tests/test_read_simple_markdown.py
@@ -1,5 +1,5 @@
-from nbformat.v4.nbbase import new_code_cell, new_raw_cell, new_markdown_cell
-from jupytext.compare import compare
+from nbformat.v4.nbbase import new_code_cell, new_raw_cell, new_markdown_cell, new_notebook
+from jupytext.compare import compare, compare_notebooks
 import jupytext
 from jupytext.combine import combine_inputs_with_outputs
 
@@ -431,3 +431,27 @@ a = 1
 
     text2 = jupytext.writes(nb, 'md')
     compare(text.replace('```IDL', '```idl'), text2)
+
+
+def test_inactive_cell(text='''```python active="md"
+# This becomes a raw cell in Jupyter
+```
+''', expected=new_notebook(
+    cells=[new_raw_cell('# This becomes a raw cell in Jupyter',
+                        metadata={'active': 'md'})])):
+    nb = jupytext.reads(text, 'md')
+    compare_notebooks(nb, expected)
+    text2 = jupytext.writes(nb, 'md')
+    # compare(text2, text)
+
+
+def test_inactive_cell_using_tag(text='''```python tags=["active-md"]
+# This becomes a raw cell in Jupyter
+```
+''', expected=new_notebook(
+    cells=[new_raw_cell('# This becomes a raw cell in Jupyter',
+                        metadata={'tags': ['active-md']})])):
+    nb = jupytext.reads(text, 'md')
+    compare_notebooks(nb, expected)
+    text2 = jupytext.writes(nb, 'md')
+    # compare(text2, text)

--- a/tests/test_read_simple_markdown.py
+++ b/tests/test_read_simple_markdown.py
@@ -442,7 +442,7 @@ def test_inactive_cell(text='''```python active="md"
     nb = jupytext.reads(text, 'md')
     compare_notebooks(nb, expected)
     text2 = jupytext.writes(nb, 'md')
-    # compare(text2, text)
+    compare(text2, text)
 
 
 def test_inactive_cell_using_tag(text='''```python tags=["active-md"]
@@ -454,4 +454,4 @@ def test_inactive_cell_using_tag(text='''```python tags=["active-md"]
     nb = jupytext.reads(text, 'md')
     compare_notebooks(nb, expected)
     text2 = jupytext.writes(nb, 'md')
-    # compare(text2, text)
+    compare(text2, text)

--- a/tests/test_read_simple_pandoc.py
+++ b/tests/test_read_simple_pandoc.py
@@ -20,7 +20,7 @@ print("hello")
     markdown2 = jupytext.writes(nb, 'md')
 
     nb2 = jupytext.reads(markdown2, 'md')
-    compare_notebooks(nb, nb2)
+    compare_notebooks(nb2, nb)
 
     markdown3 = jupytext.writes(nb2, 'md')
     compare(markdown2, markdown3)
@@ -58,4 +58,4 @@ This is the greek letter $\\pi$: π''')])):
     markdown = jupytext.writes(nb, 'md:pandoc')
     nb2 = jupytext.reads(markdown, 'md:pandoc')
     nb2.metadata.pop('jupytext')
-    compare_notebooks(nb2, nb, 'md:pandoc')
+    compare_notebooks(nb, nb2, 'md:pandoc')

--- a/tests/test_read_simple_percent.py
+++ b/tests/test_read_simple_percent.py
@@ -34,7 +34,7 @@ def test_read_simple_file(script="""# ---
 7
 """):
     nb = jupytext.reads(script, 'py:percent')
-    compare_notebooks(nb, new_notebook(cells=[
+    compare_notebooks(new_notebook(cells=[
         new_raw_cell('---\ntitle: Simple file\n---'),
         new_markdown_cell('This is a markdown cell'),
         new_markdown_cell('This is also a markdown cell', metadata={'region_name': 'md'}),
@@ -46,7 +46,7 @@ def test_read_simple_file(script="""# ---
 6
 %%magic # this is a commented magic, not a cell
 
-7''', metadata={'title': 'And now a code cell'})]))
+7''', metadata={'title': 'And now a code cell'})]), nb)
 
     script2 = jupytext.writes(nb, 'py:percent')
     compare(script, script2)
@@ -324,7 +324,7 @@ cell
 """)
 
     nb2 = jupytext.read(tmp_py)
-    compare_notebooks(nb2, nb)
+    compare_notebooks(nb, nb2)
 
 
 def test_default_cell_markers_in_contents_manager(tmpdir):
@@ -358,7 +358,7 @@ cell
 """)
 
     nb2 = jupytext.read(tmp_py)
-    compare_notebooks(nb2, nb)
+    compare_notebooks(nb, nb2)
 
 
 def test_default_cell_markers_in_contents_manager_does_not_impact_light_format(tmpdir):
@@ -388,4 +388,4 @@ def test_default_cell_markers_in_contents_manager_does_not_impact_light_format(t
 """)
 
     nb2 = jupytext.read(tmp_py)
-    compare_notebooks(nb2, nb)
+    compare_notebooks(nb, nb2)

--- a/tests/test_read_simple_percent.py
+++ b/tests/test_read_simple_percent.py
@@ -37,7 +37,7 @@ def test_read_simple_file(script="""# ---
     compare_notebooks(nb, new_notebook(cells=[
         new_raw_cell('---\ntitle: Simple file\n---'),
         new_markdown_cell('This is a markdown cell'),
-        new_markdown_cell('This is also a markdown cell'),
+        new_markdown_cell('This is also a markdown cell', metadata={'region_name': 'md'}),
         new_raw_cell('This is a raw cell'),
         new_code_cell('# This is a sub-cell', metadata={'title': 'sub-cell title', 'cell_depth': 1}),
         new_code_cell('# This is a sub-sub-cell', metadata={'title': 'sub-sub-cell title', 'cell_depth': 2}),
@@ -49,7 +49,7 @@ def test_read_simple_file(script="""# ---
 7''', metadata={'title': 'And now a code cell'})]))
 
     script2 = jupytext.writes(nb, 'py:percent')
-    compare(script.replace('[md]', '[markdown]'), script2)
+    compare(script, script2)
 
 
 def test_read_cell_with_metadata(

--- a/tests/test_read_simple_python.py
+++ b/tests/test_read_simple_python.py
@@ -716,7 +716,7 @@ def test_round_trip_markdown_cell_with_magic():
                             metadata={'jupytext': {'main_language': 'python'}})
     text = jupytext.writes(notebook, 'py')
     notebook2 = jupytext.reads(text, 'py')
-    compare_notebooks(notebook, notebook2)
+    compare_notebooks(notebook2, notebook)
 
 
 def test_round_trip_python_with_js_cell():
@@ -726,7 +726,7 @@ notebook.nbextensions.install_nbextension('jupytext.js', user=True)'''),
 Jupyter.utils.load_extensions('jupytext')''')])
     text = jupytext.writes(notebook, 'py')
     notebook2 = jupytext.reads(text, 'py')
-    compare_notebooks(notebook, notebook2)
+    compare_notebooks(notebook2, notebook)
 
 
 def test_round_trip_python_with_js_cell_no_cell_metadata():
@@ -738,4 +738,4 @@ Jupyter.utils.load_extensions('jupytext')''')],
                                                    'cell_metadata_filter': '-all'}})
     text = jupytext.writes(notebook, 'py')
     notebook2 = jupytext.reads(text, 'py')
-    compare_notebooks(notebook, notebook2)
+    compare_notebooks(notebook2, notebook)

--- a/tests/test_save_multiple.py
+++ b/tests/test_save_multiple.py
@@ -24,7 +24,7 @@ def test_rmd_is_ok(nb_file, tmpdir):
 
     nb2 = jupytext.read(str(tmpdir.join(tmp_rmd)))
 
-    compare_notebooks(nb, nb2, 'Rmd')
+    compare_notebooks(nb2, nb, 'Rmd')
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('Rmd'))
@@ -40,7 +40,7 @@ def test_ipynb_is_ok(nb_file, tmpdir):
     cm.save(model=dict(type='notebook', content=nb), path=tmp_rmd)
 
     nb2 = jupytext.read(str(tmpdir.join(tmp_ipynb)))
-    compare_notebooks(nb, nb2)
+    compare_notebooks(nb2, nb)
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('ipynb_py', skip='66'))
@@ -57,10 +57,10 @@ def test_all_files_created(nb_file, tmpdir):
     cm.save(model=dict(type='notebook', content=nb), path=tmp_ipynb)
 
     nb2 = jupytext.read(str(tmpdir.join(tmp_py)))
-    compare_notebooks(nb, nb2)
+    compare_notebooks(nb2, nb)
 
     nb3 = jupytext.read(str(tmpdir.join(tmp_rmd)))
-    compare_notebooks(nb, nb3, 'Rmd')
+    compare_notebooks(nb3, nb, 'Rmd')
 
 
 def test_no_files_created_on_no_format(tmpdir):


### PR DESCRIPTION
- Markdown cells can start with <!-- #md --> or <!-- #markdown --> (`.md` and `.markdown` files)
- Active/inactive cells behave the same in Markdown files than in the other formats #347 
- Shorter start of cell marker: `"# %% [md]"` for the `percent` format 
- All formats can now parse `key=value` metadata #344 