### PR TITLE
Noeval attribute md

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,7 @@ Release History
 - Raw cells are now encoded using HTML comments (``<!-- #raw -->`` and ``<!-- #endraw -->``) in Markdown files (#321)
 - Markdown cells can be delimited with any of ``<!-- #region -->``,  ``<!-- #markdown -->`` or ``<!-- #md -->`` (#344)
 - Code blocks from Markdown files, when they don't have an explicit language, appear in Markdown cells in Jupyter (#321)
+- Code blocks with an explicit language and a ``.noeval`` attribute are inactive in Jupyter (#347)
 - Markdown and raw cells can be quoted with triple quotes in the ``py:percent`` format. And Markdown cells can start with just ``# %% [md]`` (#305)
 - ``jupytext notebook.py --to ipynb`` updates the timestamp of ``notebook.py`` so that the paired notebook still works in Jupyter (#335, #254)
 - The Jupyter Notebook extension for Jupytext is compatible with Jupyter Notebook 6.0 (#346)

--- a/jupytext/cell_metadata.py
+++ b/jupytext/cell_metadata.py
@@ -285,7 +285,7 @@ def is_active(ext, metadata, default=True):
             return ext.replace('.', '') in tag.split('-')
     if 'active' not in metadata:
         return default
-    return ext.replace('.', '') in re.split('\\.|,', metadata['active'])
+    return ext.replace('.', '') in re.split(r'\.|,', metadata['active'])
 
 
 def metadata_to_double_percent_options(metadata):

--- a/jupytext/cell_reader.py
+++ b/jupytext/cell_reader.py
@@ -237,7 +237,7 @@ class MarkdownCellReader(BaseCellReader):
     """Read notebook cells from Markdown documents"""
     comment = ''
     start_code_re = re.compile(r"^```({})(.*)".format('|'.join(
-        _JUPYTER_LANGUAGES + [str.upper(lang) for lang in _JUPYTER_LANGUAGES]).replace('+', '\\+')))
+        _JUPYTER_LANGUAGES.union({str.upper(lang) for lang in _JUPYTER_LANGUAGES})).replace('+', '\\+')))
     non_jupyter_code_re = re.compile(r"^```")
     end_code_re = re.compile(r"^```\s*$")
     start_region_re = re.compile(r"^<!--\s*#(region|markdown|md|raw)(.*)-->\s*$")

--- a/jupytext/languages.py
+++ b/jupytext/languages.py
@@ -29,10 +29,7 @@ _COMMENT_CHARS = [_SCRIPT_EXTENSIONS[ext]['comment'] for ext in _SCRIPT_EXTENSIO
                   _SCRIPT_EXTENSIONS[ext]['comment'] != '#']
 
 _COMMENT = {_SCRIPT_EXTENSIONS[ext]['language']: _SCRIPT_EXTENSIONS[ext]['comment'] for ext in _SCRIPT_EXTENSIONS}
-
-_JUPYTER_LANGUAGES = _JUPYTER_LANGUAGES + [
-    _SCRIPT_EXTENSIONS[ext]['language'] for ext in _SCRIPT_EXTENSIONS if
-    _SCRIPT_EXTENSIONS[ext]['language'] not in _JUPYTER_LANGUAGES]
+_JUPYTER_LANGUAGES = set(_JUPYTER_LANGUAGES).union(_COMMENT.keys())
 
 
 def default_language_from_metadata_and_ext(metadata, ext):

--- a/tests/test_read_simple_markdown.py
+++ b/tests/test_read_simple_markdown.py
@@ -455,3 +455,34 @@ def test_inactive_cell_using_tag(text='''```python tags=["active-md"]
     compare_notebooks(nb, expected)
     text2 = jupytext.writes(nb, 'md')
     compare(text2, text)
+
+
+def test_inactive_cell_using_noeval(text='''This is text
+
+```python .noeval
+# This is python code.
+# It should not become a code cell
+```
+'''):
+    expected = new_notebook(cells=[new_markdown_cell(text[:-1])])
+    nb = jupytext.reads(text, 'md')
+    compare_notebooks(nb, expected)
+    text2 = jupytext.writes(nb, 'md')
+    compare(text2, text)
+
+
+def test_noeval_followed_by_code_works(text='''```python .noeval
+# Not a code cell in Jupyter
+```
+
+```python
+1 + 1
+```
+''', expected=new_notebook(cells=[new_markdown_cell('''```python .noeval
+# Not a code cell in Jupyter
+```'''),
+                                  new_code_cell('1 + 1')])):
+    nb = jupytext.reads(text, 'md')
+    compare_notebooks(nb, expected)
+    text2 = jupytext.writes(nb, 'md')
+    compare(text2, text)


### PR DESCRIPTION
- Improve the compare_notebook function (show the difference in cell content, and catch a missing line break)
- Code cells with a Jupyter language, and a `.noeval` attribute, are not turned into code cells in Jupyter #347 