### PR TITLE
Fix round trip to md with %%python3 cell magic

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -28,6 +28,7 @@ Release History
 - Fixed an inconsistent round trip (code cell with ``"cat"`` being converted to a markdown cell) in the ``py:light`` format (#339)
 - ``jupytext --test textfile.ext`` now really compares the text file to its round trip (rather than the corresponding notebook) (#339)
 - Markdown cells that contain code are now preserved in a round trip through the Markdown and R Markdown formats (#361)
+- Code cells with a ``%%python3`` cell magic are now preserved in a round trip through the Markdown format (#365)
 
 
 1.2.4 (2019-09-19)

--- a/jupytext/cell_reader.py
+++ b/jupytext/cell_reader.py
@@ -262,7 +262,7 @@ class BaseCellReader(object):
 class MarkdownCellReader(BaseCellReader):
     """Read notebook cells from Markdown documents"""
     comment = ''
-    start_code_re = re.compile(r"^```({})(.*)".format('|'.join(
+    start_code_re = re.compile(r"^```({})($|\s(.*)$)".format('|'.join(
         _JUPYTER_LANGUAGES.union({str.upper(lang) for lang in _JUPYTER_LANGUAGES})).replace('+', '\\+')))
     non_jupyter_code_re = re.compile(r"^```")
     end_code_re = re.compile(r"^```\s*$")

--- a/tests/test_read_simple_markdown.py
+++ b/tests/test_read_simple_markdown.py
@@ -590,3 +590,34 @@ def test_two_markdown_cell_with_no_language_code_works(nb=new_notebook(cells=[
     text = jupytext.writes(nb, 'md')
     nb2 = jupytext.reads(text, 'md')
     compare_notebooks(nb2, nb)
+
+
+def test_notebook_with_python3_magic(no_jupytext_version_number,
+                                     nb=new_notebook(metadata={
+                                         'kernelspec': {'display_name': 'Python 3', 'language': 'python',
+                                                        'name': 'python3'}},
+                                                     cells=[new_code_cell('%%python2\na = 1\nprint a'),
+                                                            new_code_cell('%%python3\nb = 2\nprint(b)')]),
+                                     text="""---
+jupyter:
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+---
+
+```python2
+a = 1
+print a
+```
+
+```python3
+b = 2
+print(b)
+```
+"""):
+    md = jupytext.writes(nb, 'md')
+    compare(md, text)
+
+    nb2 = jupytext.reads(md, 'md')
+    compare_notebooks(nb2, nb)


### PR DESCRIPTION
Code cells can start with ` ```python3` in Markdown files. In that case we insert a `%%python3` cell magic at the top of the cell.

Closes #365.