### PR TITLE
Add Robot Framework (.robot) -language support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,8 +28,7 @@ You want to submit an enhancement on Jupytext? Unless this is a small change, we
 A pull request for which you do not need to contact us in advance is the addition of a new language to Jupytext. In principle that should be easy - you would only have to:
 - document the language extension and comment by adding one line to `_SCRIPT_EXTENSIONS` in `languages.py`.
 - contribute a sample notebook in `tests/notebooks/ipynb_[language]`.
-- add two tests in `test_mirror.py`: one for the `light` format, and another one for the `percent` format.
-- Make sure that the tests pass, and that the text representations of your notebook, found in  `tests/notebooks/mirror/ipynb_to_script` and `tests/notebooks/mirror/ipynb_to_percent`, are valid scripts.
+- run the tests suite (with just `pytest`). The mirror tests will generate various text representations corresponding to your notebook under  `tests/notebooks/mirror/`. Please verify that these files are valid scripts, and commit them.
 
 # How to setup a development environment for Jupytext
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -25,6 +25,7 @@ Release History
 - ``jupytext --check pytest notebook.ipynb`` can be used to run test functions in a notebook (#286)
 - ``jupytext --check`` and ``jupytext --pipe`` can run commands that only operate on files: when ``{}`` is found in the text of the command, ``jupytext`` saves the text representation of the notebook in a temp file, and replaces ``{}`` with the name of that file before executing the command. (#286)
 - Added support for Rust/Evxcr, by Jonas Bushart (#351)
+- Added support for Robot Framework, by Akso Soukka (#378)
 - Added support for PowerShell (#349)
 
 **BugFixes**

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It can also convert these documents **into** Jupyter
 Notebooks, allowing you to synchronize content in both
 directions.
 
-The languages that are currently supported by Jupytext are: Julia, Python, R, Bash, Scheme, Clojure, Matlab, Octave, C++, q/kdb+, IDL, TypeScript, Javascript, Scala, Rust/Evxcr and PowerShell. Extending Jupytext to more languages should be easy - read more at [CONTRIBUTING.md](https://github.com/mwouts/jupytext/blob/master/CONTRIBUTING.md). In addition, jupytext users can choose between two formats for notebooks as scripts:
+The languages that are currently supported by Jupytext are: Julia, Python, R, Bash, Scheme, Clojure, Matlab, Octave, C++, q/kdb+, IDL, TypeScript, Javascript, Scala, Rust/Evxcr, PowerShell and Robot Framework. Extending Jupytext to more languages should be easy - read more at [CONTRIBUTING.md](https://github.com/mwouts/jupytext/blob/master/CONTRIBUTING.md). In addition, jupytext users can choose between two formats for notebooks as scripts:
 - The `percent` format, compatible with several IDEs, including Spyder, Hydrogen, VScode and PyCharm. In that format, cells are delimited with a commented `%%`.
 - The `light` format, designed for this project. Use that format to open standard scripts as notebooks, or to save notebooks as scripts with few cell markers - none when possible.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -10,7 +10,7 @@ Jupytext can save Jupyter notebooks as
 - Markdown and R Markdown documents,
 - Scripts in many languages.
 
-The languages that are currently supported by Jupytext are: Julia, Python, R, Bash, Scheme, Clojure, Matlab, Octave, C++, q/kdb+, IDL, TypeScript, Javascript and Scala. Extending Jupytext to more languages should be easy - read more at [CONTRIBUTING.md](https://github.com/mwouts/jupytext/blob/master/CONTRIBUTING.md#). In addition, jupytext users can choose between two formats for notebooks as scripts:
+The languages that are currently supported by Jupytext are: Julia, Python, R, Bash, Scheme, Clojure, Matlab, Octave, C++, q/kdb+, IDL, TypeScript, Javascript, Scala, Rust/Evxcr, PowerShell and Robot Framework. Extending Jupytext to more languages should be easy - read more at [CONTRIBUTING.md](https://github.com/mwouts/jupytext/blob/master/CONTRIBUTING.md#). In addition, jupytext users can choose between two formats for notebooks as scripts:
 - The `percent` format, compatible with several IDEs, including Spyder, Hydrogen, VScode and PyCharm. In that format, cells are delimited with a commented `%%`.
 - The `light` format, designed for this project. Use that format to open standard scripts as notebooks, or to save notebooks as scripts with few cell markers - none when possible.
 

--- a/jupytext/languages.py
+++ b/jupytext/languages.py
@@ -3,7 +3,7 @@
 # Jupyter magic commands that are also languages
 _JUPYTER_LANGUAGES = ['R', 'bash', 'sh', 'python', 'python2', 'python3', 'javascript', 'js', 'perl',
                       'html', 'latex', 'markdown', 'pypy', 'ruby', 'script', 'svg',
-                      'matlab', 'octave', 'idl', 'spark', 'sql']
+                      'matlab', 'octave', 'idl', 'robotframework', 'spark', 'sql']
 
 # Supported file extensions (and languages)
 # Please add more languages here (and add a few tests) - see CONTRIBUTING.md
@@ -23,7 +23,8 @@ _SCRIPT_EXTENSIONS = {'.py': {'language': 'python', 'comment': '#'},
                       '.js': {'language': 'javascript', 'comment': '//'},
                       '.ts': {'language': 'typescript', 'comment': '//'},
                       '.scala': {'language': 'scala', 'comment': '//'},
-                      '.rs': {'language': 'rust', 'comment': '//'}}
+                      '.rs': {'language': 'rust', 'comment': '//'},
+                      '.robot': {'language': 'robotframework', 'comment': '#'}}
 
 _COMMENT_CHARS = [_SCRIPT_EXTENSIONS[ext]['comment'] for ext in _SCRIPT_EXTENSIONS if
                   _SCRIPT_EXTENSIONS[ext]['comment'] != '#']

--- a/tests/notebooks/ipynb_robot/simple_robot_notebook.ipynb
+++ b/tests/notebooks/ipynb_robot/simple_robot_notebook.ipynb
@@ -1,0 +1,70 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "*** Settings ***\n",
+    "\n",
+    "Library  Collections"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "*** Keywords ***\n",
+    "\n",
+    "Head\n",
+    "    [Arguments]  ${list}\n",
+    "    ${value}=  Get from list  ${list}  0\n",
+    "    [Return]  ${value}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "lines_to_next_cell": 0
+   },
+   "outputs": [],
+   "source": [
+    "*** Tasks ***\n",
+    "\n",
+    "Get head\n",
+    "    ${array}=  Create list  1  2  3  4  5\n",
+    "    ${head}=  Head  ${array}\n",
+    "    Should be equal  ${head}  1"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Robot Framework",
+   "language": "robotframework",
+   "name": "robotkernel"
+  },
+  "language_info": {
+   "codemirror_mode": "robotframework",
+   "file_extension": ".robot",
+   "mimetype": "text/plain",
+   "name": "robotframework",
+   "pygments_lexer": "robotframework"
+  },
+  "pycharm": {
+   "stem_cell": {
+    "cell_type": "raw",
+    "source": [],
+    "metadata": {
+     "collapsed": false
+    }
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/notebooks/mirror/ipynb_to_Rmd/simple_robot_notebook.Rmd
+++ b/tests/notebooks/mirror/ipynb_to_Rmd/simple_robot_notebook.Rmd
@@ -1,0 +1,31 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Robot Framework
+    language: robotframework
+    name: robotkernel
+---
+
+```{robotframework}
+*** Settings ***
+
+Library  Collections
+```
+
+```{robotframework}
+*** Keywords ***
+
+Head
+    [Arguments]  ${list}
+    ${value}=  Get from list  ${list}  0
+    [Return]  ${value}
+```
+
+```{robotframework}
+*** Tasks ***
+
+Get head
+    ${array}=  Create list  1  2  3  4  5
+    ${head}=  Head  ${array}
+    Should be equal  ${head}  1
+```

--- a/tests/notebooks/mirror/ipynb_to_hydrogen/simple_robot_notebook.robot
+++ b/tests/notebooks/mirror/ipynb_to_hydrogen/simple_robot_notebook.robot
@@ -1,0 +1,28 @@
+# ---
+# jupyter:
+#   kernelspec:
+#     display_name: Robot Framework
+#     language: robotframework
+#     name: robotkernel
+# ---
+
+# %%
+*** Settings ***
+
+Library  Collections
+
+# %%
+*** Keywords ***
+
+Head
+    [Arguments]  ${list}
+    ${value}=  Get from list  ${list}  0
+    [Return]  ${value}
+
+# %%
+*** Tasks ***
+
+Get head
+    ${array}=  Create list  1  2  3  4  5
+    ${head}=  Head  ${array}
+    Should be equal  ${head}  1

--- a/tests/notebooks/mirror/ipynb_to_md/simple_robot_notebook.md
+++ b/tests/notebooks/mirror/ipynb_to_md/simple_robot_notebook.md
@@ -1,0 +1,31 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Robot Framework
+    language: robotframework
+    name: robotkernel
+---
+
+```robotframework
+*** Settings ***
+
+Library  Collections
+```
+
+```robotframework
+*** Keywords ***
+
+Head
+    [Arguments]  ${list}
+    ${value}=  Get from list  ${list}  0
+    [Return]  ${value}
+```
+
+```robotframework
+*** Tasks ***
+
+Get head
+    ${array}=  Create list  1  2  3  4  5
+    ${head}=  Head  ${array}
+    Should be equal  ${head}  1
+```

--- a/tests/notebooks/mirror/ipynb_to_percent/simple_robot_notebook.robot
+++ b/tests/notebooks/mirror/ipynb_to_percent/simple_robot_notebook.robot
@@ -1,0 +1,28 @@
+# ---
+# jupyter:
+#   kernelspec:
+#     display_name: Robot Framework
+#     language: robotframework
+#     name: robotkernel
+# ---
+
+# %%
+*** Settings ***
+
+Library  Collections
+
+# %%
+*** Keywords ***
+
+Head
+    [Arguments]  ${list}
+    ${value}=  Get from list  ${list}  0
+    [Return]  ${value}
+
+# %%
+*** Tasks ***
+
+Get head
+    ${array}=  Create list  1  2  3  4  5
+    ${head}=  Head  ${array}
+    Should be equal  ${head}  1

--- a/tests/notebooks/mirror/ipynb_to_script/simple_robot_notebook.robot
+++ b/tests/notebooks/mirror/ipynb_to_script/simple_robot_notebook.robot
@@ -1,0 +1,28 @@
+# ---
+# jupyter:
+#   kernelspec:
+#     display_name: Robot Framework
+#     language: robotframework
+#     name: robotkernel
+# ---
+
+# +
+*** Settings ***
+
+Library  Collections
+
+# +
+*** Keywords ***
+
+Head
+    [Arguments]  ${list}
+    ${value}=  Get from list  ${list}  0
+    [Return]  ${value}
+
+# +
+*** Tasks ***
+
+Get head
+    ${array}=  Create list  1  2  3  4  5
+    ${head}=  Head  ${array}
+    Should be equal  ${head}  1

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -248,3 +248,13 @@ def test_ipynb_to_scheme_percent(nb_file, extension, no_jupytext_version_number)
     assert_conversion_same_as_mirror(nb_file,
                                      '{}:percent'.format(extension),
                                      'ipynb_to_percent')
+
+
+@pytest.mark.parametrize('nb_file', list_notebooks('ipynb_robot'))
+def test_ipynb_to_robot_light(nb_file, no_jupytext_version_number):
+    assert_conversion_same_as_mirror(nb_file, 'auto', 'ipynb_to_script')
+
+
+@pytest.mark.parametrize('nb_file', list_notebooks('ipynb_robot'))
+def test_ipynb_to_robot_percent(nb_file, no_jupytext_version_number):
+    assert_conversion_same_as_mirror(nb_file, 'auto:percent', 'ipynb_to_percent')

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -248,13 +248,3 @@ def test_ipynb_to_scheme_percent(nb_file, extension, no_jupytext_version_number)
     assert_conversion_same_as_mirror(nb_file,
                                      '{}:percent'.format(extension),
                                      'ipynb_to_percent')
-
-
-@pytest.mark.parametrize('nb_file', list_notebooks('ipynb_robot'))
-def test_ipynb_to_robot_light(nb_file, no_jupytext_version_number):
-    assert_conversion_same_as_mirror(nb_file, 'auto', 'ipynb_to_script')
-
-
-@pytest.mark.parametrize('nb_file', list_notebooks('ipynb_robot'))
-def test_ipynb_to_robot_percent(nb_file, no_jupytext_version_number):
-    assert_conversion_same_as_mirror(nb_file, 'auto:percent', 'ipynb_to_percent')


### PR DESCRIPTION
* [x] document the language extension and comment by adding one line to _SCRIPT_EXTENSIONS in languages.py.
* [x] contribute a sample notebook in tests/notebooks/ipynb_[language].
* [x] add two tests in test_mirror.py: one for the light format, and another one for the percent format.
* [x] Make sure that the tests pass, and that the text representations of your notebook, found in tests/notebooks/mirror/ipynb_to_script and tests/notebooks/mirror/ipynb_to_percent, are valid scripts.
