### PR TITLE
Fix shebang handling for languages with non-# comments

### DIFF
--- a/jupytext/header.py
+++ b/jupytext/header.py
@@ -47,7 +47,7 @@ def encoding_and_executable(notebook, metadata, ext):
     jupytext_metadata = metadata.get('jupytext', {})
 
     if comment is not None and 'executable' in jupytext_metadata:
-        lines.append(comment + '!' + jupytext_metadata.pop('executable'))
+        lines.append('#!' + jupytext_metadata.pop('executable'))
 
     if 'encoding' in jupytext_metadata:
         lines.append(jupytext_metadata.pop('encoding'))
@@ -144,7 +144,7 @@ def header_to_metadata_and_cell(lines, header_prefix, ext=None):
     encoding_re = re.compile(r'^[ \t\f]*{}.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)'.format(comment))
 
     for i, line in enumerate(lines):
-        if i == 0 and line.startswith(comment + '!'):
+        if i == 0 and line.startswith('#!'):
             metadata.setdefault('jupytext', {})['executable'] = line[2:]
             start = i + 1
             continue

--- a/tests/test_read_simple_rust.py
+++ b/tests/test_read_simple_rust.py
@@ -43,3 +43,26 @@ pub fn fib(x: i32) -> i32 {
 ::std::mem::drop''')
     ]))
     compare(jupytext.writes(nb, 'rs'), text)
+
+
+def test_read_write_script_with_metadata_241(no_jupytext_version_number, rsnb="""#!/usr/bin/env scriptisto
+// ---
+// jupyter:
+//   jupytext:
+//     text_representation:
+//       extension: .rs
+//       format_name: light
+//   kernelspec:
+//     display_name: Rust
+//     language: rust
+//     name: rust
+// ---
+
+let mut a: i32 = 2;
+a += 1;
+"""):
+    nb = jupytext.reads(rsnb, 'rs')
+    assert 'executable' in nb.metadata['jupytext']
+    rsnb2 = jupytext.writes(nb, 'rs')
+
+    compare(rsnb, rsnb2)


### PR DESCRIPTION
The shebang always starts with the sequence `#!` independent of the comment symbol of the programming language. Add a test with Rust, which uses `//` as the comment symbol.

The problem with the existing code is that it uses the comment symbol in the shebang line. The shebang can only start with `#!` though. This leads to two problems.
When parsing the shebang, when converting from text to notebook format, it uses a fixed offset of two characters to take the executable path ([`line[2:]`](https://github.com/mwouts/jupytext/pull/434/files#diff-e90356d1e1bc0107aa247e815ebc6147R148)), which fails if the comment is not only one character, like the two characters of `//`.
Similarly, when converting from notebook to text, it uses the comment symbol again and writes an invalid shebang.

The new test is mostly copied from the Python version with slight adaptions.