### PR TITLE
Use the `no_jupytext_version_number` fixture

### DIFF
--- a/tests/test_read_simple_python.py
+++ b/tests/test_read_simple_python.py
@@ -534,7 +534,7 @@ print('Hello world')
     compare(pynb2, pynb)
 
 
-def test_read_write_script_with_metadata_241(pynb="""#!/usr/bin/env python3
+def test_read_write_script_with_metadata_241(no_jupytext_version_number, pynb="""#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # ---
 # jupyter:
@@ -542,8 +542,6 @@ def test_read_write_script_with_metadata_241(pynb="""#!/usr/bin/env python3
 #     text_representation:
 #       extension: .py
 #       format_name: light
-#       format_version: '1.4'
-#       jupytext_version: 1.1.2
 #   kernelspec:
 #     display_name: Python 3
 #     language: python
@@ -559,11 +557,7 @@ a + 1
     assert 'encoding' in nb.metadata['jupytext']
     pynb2 = jupytext.writes(nb, 'py')
 
-    # remove version information
-    def remove_version_info(text):
-        return '\n'.join([line for line in text.splitlines() if 'version' not in line])
-
-    compare(remove_version_info(pynb2), remove_version_info(pynb))
+    compare(pynb2, pynb)
 
 
 def test_notebook_blank_lines(script="""# +


### PR DESCRIPTION
This is a follow-up on #434 : we use the `no_jupytext_version_number` fixture rather than the custom filter.