### PR TITLE
Add mystnb format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
       pip install -r requirements.txt;
     fi
   # install is required for testing the pre-commit mode
-  - pip install . || true
+  - pip install .[myst] || true
   # install black if available (Python 3.6 and above), and autopep8 for testing the pipe mode
   - pip install black || true
   - pip install autopep8 || true

--- a/demo/Benchmarking Jupytext.py
+++ b/demo/Benchmarking Jupytext.py
@@ -30,6 +30,13 @@ except jupytext.formats.JupytextFormatError as err:
     print(str(err))
 
 
+# Let's see if we have myst-parser installed here
+try:
+    jupytext.writes(notebook, fmt='mystnb')
+    JUPYTEXT_FORMATS.append('mystnb')
+except jupytext.formats.JupytextFormatError as err:
+    print(str(err))
+
 # -
 
 

--- a/demo/World population.mystnb
+++ b/demo/World population.mystnb
@@ -1,0 +1,114 @@
+---
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+nbformat: 4
+nbformat_minor: 2
+---
+
+# A quick insight at world population
+
+## Collecting population data
+
+In the below we retrieve population data from the
+[World Bank](http://www.worldbank.org/)
+using the [wbdata](https://github.com/OliverSherouse/wbdata) python package
+
+```{nb-code} ipython3
+import pandas as pd
+import wbdata as wb
+
+pd.options.display.max_rows = 6
+pd.options.display.max_columns = 20
+```
+
+Corresponding indicator is found using search method - or, directly,
+the World Bank site.
+
+```{nb-code} ipython3
+wb.search_indicators('Population, total')  # SP.POP.TOTL
+# wb.search_indicators('area')
+# => https://data.worldbank.org/indicator is easier to use
+```
+
+Now we download the population data
+
+```{nb-code} ipython3
+indicators = {'SP.POP.TOTL': 'Population, total',
+              'AG.SRF.TOTL.K2': 'Surface area (sq. km)',
+              'AG.LND.TOTL.K2': 'Land area (sq. km)',
+              'AG.LND.ARBL.ZS': 'Arable land (% of land area)'}
+data = wb.get_dataframe(indicators, convert_date=True).sort_index()
+data
+```
+
+World is one of the countries
+
+```{nb-code} ipython3
+data.loc['World']
+```
+
+Can we classify over continents?
+
+```{nb-code} ipython3
+data.loc[(slice(None), '2017-01-01'), :]['Population, total'].dropna(
+).sort_values().tail(60).index.get_level_values('country')
+```
+
+Extract zones manually (in order of increasing population)
+
+```{nb-code} ipython3
+zones = ['North America', 'Middle East & North Africa',
+         'Latin America & Caribbean', 'Europe & Central Asia',
+         'Sub-Saharan Africa', 'South Asia',
+         'East Asia & Pacific'][::-1]
+```
+
+And extract population information (and check total is right)
+
+```{nb-code} ipython3
+population = data.loc[zones]['Population, total'].swaplevel().unstack()
+population = population[zones]
+assert all(data.loc['World']['Population, total'] == population.sum(axis=1))
+```
+
+## Stacked area plot with matplotlib
+
+```{nb-code} ipython3
+import matplotlib.pyplot as plt
+```
+
+```{nb-code} ipython3
+plt.clf()
+plt.figure(figsize=(10, 5), dpi=100)
+plt.stackplot(population.index, population.values.T / 1e9)
+plt.legend(population.columns, loc='upper left')
+plt.ylabel('Population count (B)')
+plt.show()
+```
+
+## Stacked bar plot with plotly
+
++++
+
+Stacked area plots (with cumulated values computed depending on
+selected legends) are
+[on their way](https://github.com/plotly/plotly.js/pull/2960) at Plotly. For
+now we just do a stacked bar plot.
+
+```{nb-code} ipython3
+import plotly.offline as offline
+import plotly.graph_objs as go
+
+offline.init_notebook_mode()
+```
+
+```{nb-code} ipython3
+bars = [go.Bar(x=population.index, y=population[zone], name=zone)
+        for zone in zones]
+fig = go.Figure(data=bars,
+                layout=go.Layout(title='World population',
+                                 barmode='stack'))
+offline.iplot(fig)
+```

--- a/environment.yml
+++ b/environment.yml
@@ -22,3 +22,4 @@ dependencies:
   - setuptools
   - twine
   - pandoc
+  - myst-parser

--- a/jupytext/formats.py
+++ b/jupytext/formats.py
@@ -19,6 +19,12 @@ from .stringparser import StringParser
 from .languages import _SCRIPT_EXTENSIONS, _COMMENT_CHARS, same_language
 from .pandoc import pandoc_version, is_pandoc_available
 from .magics import is_magic
+from .myst import (
+    MYST_FORMAT_NAME,
+    is_myst_available,
+    myst_version,
+    myst_extensions,
+)
 
 
 class JupytextFormatError(ValueError):
@@ -161,6 +167,15 @@ if is_pandoc_available():
         cell_reader_class=None,
         cell_exporter_class=None,
         current_version_number=pandoc_version()))
+
+if is_myst_available():
+    JUPYTEXT_FORMATS.extend([NotebookFormatDescription(
+        format_name=MYST_FORMAT_NAME,
+        extension=ext,
+        header_prefix='',
+        cell_reader_class=None,
+        cell_exporter_class=None,
+        current_version_number=myst_version()) for ext in myst_extensions()])
 
 NOTEBOOK_EXTENSIONS = list(dict.fromkeys(['.ipynb'] + [fmt.extension for fmt in JUPYTEXT_FORMATS]))
 EXTENSION_PREFIXES = ['.lgt', '.spx', '.pct', '.hyd', '.nb']

--- a/jupytext/jupytext.py
+++ b/jupytext/jupytext.py
@@ -128,6 +128,7 @@ class TextNotebookConverter(NotebookReader, NotebookWriter):
                 cells=cells))
 
         if self.ext in myst_extensions():
+            pygments_lexer = metadata.get("language_info", {}).get("pygments_lexer", None)
             metadata = insert_jupytext_info_and_filter_metadata(metadata, self.ext, self.implementation)
 
             cells = []
@@ -143,7 +144,8 @@ class TextNotebookConverter(NotebookReader, NotebookWriter):
                 nbformat=nb.nbformat,
                 nbformat_minor=nb.nbformat_minor,
                 metadata=metadata,
-                cells=cells))
+                cells=cells),
+                default_lexer=pygments_lexer)
 
         # Copy the notebook, in order to be sure we do not modify the original notebook
         nb = NotebookNode(

--- a/jupytext/myst.py
+++ b/jupytext/myst.py
@@ -31,7 +31,7 @@ CompactDumper.add_representer(dict, represent_dict)
 
 def dump_yaml_blocks(data, compact=True):
     """Where possible, we try to use a more compact metadata style.
-    
+
     For blocks with no nested dicts, the block is denoted by starting colons::
 
         :other: true

--- a/jupytext/myst.py
+++ b/jupytext/myst.py
@@ -46,7 +46,10 @@ class MockDirective:
 
 
 def _fmt_md(text):
-    return text.rstrip()
+    text = text.rstrip()
+    while text and text.startswith("\n"):
+        text = text[1:]
+    return text
 
 
 def myst_to_notebook(
@@ -216,7 +219,7 @@ def notebook_to_myst(
                     string += "\n+++ {}\n".format(json.dumps(metadata))
                 else:
                     string += "\n+++\n"
-            string += cell.source
+            string += "\n" + cell.source
             if not cell.source.endswith("\n"):
                 string += "\n"
             last_cell_md = True

--- a/jupytext/myst.py
+++ b/jupytext/myst.py
@@ -4,7 +4,7 @@ myst formatted text documents and notebooks.
 """
 import json
 import logging
-from typing import List, Union
+from typing import List, Optional, Union
 
 import nbformat as nbf
 import yaml
@@ -208,6 +208,7 @@ def notebook_to_myst(
     nb: nbf.NotebookNode,
     code_directive: str = CODE_DIRECTIVE,
     raw_directive: str = RAW_DIRECTIVE,
+    default_lexer: Optional[str] = None
 ):
     string = ""
 
@@ -217,6 +218,8 @@ def notebook_to_myst(
 
     # we add the pygments lexer as a directive argument, for use by syntax highlighters
     pygments_lexer = nb_metadata.get("language_info", {}).get("pygments_lexer", None)
+    if pygments_lexer is None:
+        pygments_lexer = default_lexer
 
     string += "---\n"
     string += yaml.safe_dump(nb_metadata)

--- a/jupytext/myst.py
+++ b/jupytext/myst.py
@@ -67,7 +67,7 @@ def myst_version():
 
 
 def myst_extensions():
-    return [".mystnb"]
+    return [".mystnb", ".mnb"]
 
 
 def from_nbnode(value):

--- a/jupytext/myst.py
+++ b/jupytext/myst.py
@@ -56,11 +56,11 @@ def _fmt_md(text):
 
 
 def myst_to_notebook(
-    text: Union[str, List[str]],
-    code_directive: str = CODE_DIRECTIVE,
-    raw_directive: str = RAW_DIRECTIVE,
+    text,
+    code_directive = CODE_DIRECTIVE,
+    raw_directive = RAW_DIRECTIVE,
     logger=None,
-) -> nbf.NotebookNode:
+):
     """Convert text written in the myst format to a notebook.
 
     :param text: the file text
@@ -118,7 +118,7 @@ def myst_to_notebook(
             if isinstance(item.node, BlockBreak):
                 token = item.node  # type: BlockBreak
                 source = _fmt_md(
-                    "".join(lines.lines[current_line : token.position.line_start - 1])
+                    "".join(lines.lines[current_line:token.position.line_start - 1])
                 )
                 if source:
                     notebook.cells.append(
@@ -163,7 +163,7 @@ def myst_to_notebook(
                 )
 
                 md_source = _fmt_md(
-                    "".join(lines.lines[current_line : token.position.line_start - 1])
+                    "".join(lines.lines[current_line:token.position.line_start - 1])
                 )
                 if md_source:
                     notebook.cells.append(
@@ -205,10 +205,10 @@ def myst_to_notebook(
 
 
 def notebook_to_myst(
-    nb: nbf.NotebookNode,
-    code_directive: str = CODE_DIRECTIVE,
-    raw_directive: str = RAW_DIRECTIVE,
-    default_lexer: Optional[str] = None
+    nb,
+    code_directive = CODE_DIRECTIVE,
+    raw_directive = RAW_DIRECTIVE,
+    default_lexer = None
 ):
     string = ""
 

--- a/jupytext/myst.py
+++ b/jupytext/myst.py
@@ -222,7 +222,7 @@ def notebook_to_myst(
             last_cell_md = True
 
         elif cell.cell_type in ["code", "raw"]:
-            string += "```{{{}}}".format(
+            string += "\n```{{{}}}".format(
                 code_directive if cell.cell_type == "code" else raw_directive
             )
             if pygments_lexer and cell.cell_type == "code":

--- a/jupytext/myst.py
+++ b/jupytext/myst.py
@@ -3,6 +3,7 @@ This module contains round-trip conversion between
 myst formatted text documents and notebooks.
 """
 import json
+import logging
 from typing import List, Union
 
 import nbformat as nbf
@@ -11,6 +12,8 @@ import yaml
 MYST_FORMAT_NAME = "mystnb"
 CODE_DIRECTIVE = "nb-code"
 RAW_DIRECTIVE = "nb-raw"
+
+LOGGER = logging.getLogger(__name__)
 
 
 def is_myst_available():
@@ -56,6 +59,7 @@ def myst_to_notebook(
     text: Union[str, List[str]],
     code_directive: str = CODE_DIRECTIVE,
     raw_directive: str = RAW_DIRECTIVE,
+    logger=None,
 ) -> nbf.NotebookNode:
     """Convert text written in the myst format to a notebook.
 
@@ -79,6 +83,7 @@ def myst_to_notebook(
 
     code_directive = "{{{0}}}".format(code_directive)
     raw_directive = "{{{0}}}".format(raw_directive)
+    logger = logger or LOGGER
 
     original_context = get_parse_context()
     parse_context = ParseContext(
@@ -125,10 +130,18 @@ def myst_to_notebook(
                     try:
                         md_metadata = json.loads(token.content.strip())
                     except Exception:
-                        # TODO log warning if content can't be parsed as json
+                        logger.warning(
+                            "markdown cell metadata could not be read: {}".format(
+                                token.position
+                            )
+                        )
                         md_metadata = {}
                     if not isinstance(md_metadata, dict):
-                        # TODO log warning if content isn't a dict
+                        logger.warning(
+                            "markdown cell metadata is not a dict: {}".format(
+                                token.position
+                            )
+                        )
                         md_metadata = {}
                 else:
                     md_metadata = {}

--- a/jupytext/myst.py
+++ b/jupytext/myst.py
@@ -130,7 +130,7 @@ def myst_to_notebook(
                         md_metadata = json.loads(token.content.strip())
                     except Exception as err:
                         raise MystMetadataParsingError(
-                            "markdown cell {1} at {1} could not be read: {2}".format(
+                            "markdown cell {0} at {1} could not be read: {2}".format(
                                 len(notebook.cells) + 1, token.position, err
                             )
                         )

--- a/jupytext/myst.py
+++ b/jupytext/myst.py
@@ -99,7 +99,7 @@ def myst_to_notebook(
         try:
             metadata_nb = doc.front_matter.get_data() if doc.front_matter else {}
         except (yaml.parser.ParserError, yaml.scanner.ScannerError) as error:
-            raise MystMetadataParsingError("Notebook metadata:".format(error))
+            raise MystMetadataParsingError("Notebook metadata: {}".format(error))
         nbformat = metadata_nb.pop("nbformat", None)
         nbformat_minor = metadata_nb.pop("nbformat_minor", None)
         kwargs = {"metadata": nbf.from_dict(metadata_nb)}

--- a/jupytext/myst.py
+++ b/jupytext/myst.py
@@ -4,7 +4,6 @@ myst formatted text documents and notebooks.
 """
 import json
 import logging
-from typing import List, Optional, Union
 
 import nbformat as nbf
 import yaml
@@ -56,10 +55,7 @@ def _fmt_md(text):
 
 
 def myst_to_notebook(
-    text,
-    code_directive = CODE_DIRECTIVE,
-    raw_directive = RAW_DIRECTIVE,
-    logger=None,
+    text, code_directive=CODE_DIRECTIVE, raw_directive=RAW_DIRECTIVE, logger=None,
 ):
     """Convert text written in the myst format to a notebook.
 
@@ -205,10 +201,7 @@ def myst_to_notebook(
 
 
 def notebook_to_myst(
-    nb,
-    code_directive = CODE_DIRECTIVE,
-    raw_directive = RAW_DIRECTIVE,
-    default_lexer = None
+    nb, code_directive=CODE_DIRECTIVE, raw_directive=RAW_DIRECTIVE, default_lexer=None
 ):
     string = ""
 

--- a/jupytext/myst.py
+++ b/jupytext/myst.py
@@ -1,0 +1,247 @@
+"""
+This module contains round-trip conversion between
+myst formatted text documents and notebooks.
+"""
+import json
+from typing import List, Union
+
+import nbformat as nbf
+import yaml
+
+MYST_FORMAT_NAME = "mystnb"
+CODE_DIRECTIVE = "nb-code"
+RAW_DIRECTIVE = "nb-raw"
+
+
+def is_myst_available():
+    try:
+        import myst_parser  # noqa
+    except ImportError:
+        return False
+    return True
+
+
+def myst_version():
+    from myst_parser import __version__
+
+    return __version__
+
+
+def myst_extensions():
+    return [".mystnb"]
+
+
+def from_nbnode(value):
+    """Recursively convert NotebookNode to dict."""
+    if isinstance(value, nbf.NotebookNode):
+        return {k: from_nbnode(v) for k, v in value.items()}
+    return value
+
+
+class MockDirective:
+    option_spec = {"options": True}
+    required_arguments = 0
+    optional_arguments = 1
+    has_content = True
+
+
+def _fmt_md(text):
+    return text.rstrip()
+
+
+def myst_to_notebook(
+    text: Union[str, List[str]],
+    code_directive: str = CODE_DIRECTIVE,
+    raw_directive: str = RAW_DIRECTIVE,
+) -> nbf.NotebookNode:
+    """Convert text written in the myst format to a notebook.
+
+    :param text: the file text
+    :directive: the name of the directive to search for.
+
+    NOTE: we assume here that all of these directives are at the top-level,
+    i.e. not nested in other directives.
+    """
+    from mistletoe.base_elements import SourceLines
+    from mistletoe.parse_context import (
+        ParseContext,
+        get_parse_context,
+        set_parse_context,
+    )
+    from mistletoe.block_tokens import Document, CodeFence
+
+    from myst_parser.block_tokens import BlockBreak
+    from myst_parser.parse_directives import parse_directive_text
+    from myst_parser.docutils_renderer import DocutilsRenderer
+
+    code_directive = "{{{0}}}".format(code_directive)
+    raw_directive = "{{{0}}}".format(raw_directive)
+
+    original_context = get_parse_context()
+    parse_context = ParseContext(
+        find_blocks=DocutilsRenderer.default_block_tokens,
+        find_spans=DocutilsRenderer.default_span_tokens,
+    )
+
+    if isinstance(text, SourceLines):
+        lines = text
+    else:
+        lines = SourceLines(text, standardize_ends=True)
+
+    try:
+        set_parse_context(parse_context)
+        doc = Document.read(lines, front_matter=True)
+
+        metadata_nb = doc.front_matter.get_data() if doc.front_matter else {}
+        nbformat = metadata_nb.pop("nbformat", None)
+        nbformat_minor = metadata_nb.pop("nbformat_minor", None)
+        kwargs = {"metadata": nbf.from_dict(metadata_nb)}
+        if nbformat is not None:
+            kwargs["nbformat"] = nbformat
+        if nbformat_minor is not None:
+            kwargs["nbformat_minor"] = nbformat_minor
+
+        notebook = nbf.v4.new_notebook(**kwargs)
+
+        current_line = 0 if not doc.front_matter else doc.front_matter.position.line_end
+        md_metadata = {}
+
+        for item in doc.walk(["CodeFence", "BlockBreak"]):
+            if isinstance(item.node, BlockBreak):
+                token = item.node  # type: BlockBreak
+                source = _fmt_md(
+                    "".join(lines.lines[current_line : token.position.line_start - 1])
+                )
+                if source:
+                    notebook.cells.append(
+                        nbf.v4.new_markdown_cell(
+                            source=source, metadata=nbf.from_dict(md_metadata),
+                        )
+                    )
+                if token.content:
+                    try:
+                        md_metadata = json.loads(token.content.strip())
+                    except Exception:
+                        # TODO log warning if content can't be parsed as json
+                        md_metadata = {}
+                    if not isinstance(md_metadata, dict):
+                        # TODO log warning if content isn't a dict
+                        md_metadata = {}
+                else:
+                    md_metadata = {}
+                current_line = token.position.line_start
+            if isinstance(item.node, CodeFence) and item.node.language in [
+                code_directive,
+                raw_directive,
+            ]:
+                token = item.node  # type: CodeFence
+                # Note: we ignore anything after the directive on the first line
+                # this is reserved for the optional lexer name
+                # TODO: could log warning about if token.arguments != lexer name
+
+                _, options, body_lines = parse_directive_text(
+                    directive_class=MockDirective,
+                    argument_str="",
+                    content=token.children[0].content,
+                    validate_options=False,
+                )
+
+                md_source = _fmt_md(
+                    "".join(lines.lines[current_line : token.position.line_start - 1])
+                )
+                if md_source:
+                    notebook.cells.append(
+                        nbf.v4.new_markdown_cell(
+                            source=md_source, metadata=nbf.from_dict(md_metadata),
+                        )
+                    )
+                current_line = token.position.line_end
+                md_metadata = {}
+
+                if item.node.language == code_directive:
+                    notebook.cells.append(
+                        nbf.v4.new_code_cell(
+                            source="\n".join(body_lines),
+                            metadata=nbf.from_dict(options),
+                        )
+                    )
+                if item.node.language == raw_directive:
+                    notebook.cells.append(
+                        nbf.v4.new_raw_cell(
+                            source="\n".join(body_lines),
+                            metadata=nbf.from_dict(options),
+                        )
+                    )
+
+        # add the final markdown cell (if present)
+        if lines.lines[current_line:]:
+            notebook.cells.append(
+                nbf.v4.new_markdown_cell(
+                    source=_fmt_md("".join(lines.lines[current_line:])),
+                    metadata=nbf.from_dict(md_metadata),
+                )
+            )
+
+    finally:
+        set_parse_context(original_context)
+
+    return notebook
+
+
+def notebook_to_myst(
+    nb: nbf.NotebookNode,
+    code_directive: str = CODE_DIRECTIVE,
+    raw_directive: str = RAW_DIRECTIVE,
+):
+    string = ""
+
+    nb_metadata = from_nbnode(nb.metadata)
+    nb_metadata["nbformat"] = nb.nbformat
+    nb_metadata["nbformat_minor"] = nb.nbformat_minor
+
+    # we add the pygments lexer as a directive argument, for use by syntax highlighters
+    pygments_lexer = nb_metadata.get("language_info", {}).get("pygments_lexer", None)
+
+    string += "---\n"
+    string += yaml.safe_dump(nb_metadata)
+    string += "---\n"
+
+    last_cell_md = False
+    for i, cell in enumerate(nb.cells):
+
+        if cell.cell_type == "markdown":
+            metadata = from_nbnode(cell.metadata)
+            if metadata or last_cell_md:
+                if metadata:
+                    string += "\n+++ {}\n".format(json.dumps(metadata))
+                else:
+                    string += "\n+++\n"
+            string += cell.source
+            if not cell.source.endswith("\n"):
+                string += "\n"
+            last_cell_md = True
+
+        elif cell.cell_type in ["code", "raw"]:
+            string += "```{{{}}}".format(
+                code_directive if cell.cell_type == "code" else raw_directive
+            )
+            if pygments_lexer and cell.cell_type == "code":
+                string += " {}".format(pygments_lexer)
+            string += "\n"
+            metadata = from_nbnode(cell.metadata)
+            if metadata:
+                string += "---\n"
+                string += yaml.safe_dump(metadata)
+                string += "---\n"
+            elif cell.source.startswith("---") or cell.source.startswith(":"):
+                string += "\n"
+            string += cell.source
+            if not cell.source.endswith("\n"):
+                string += "\n"
+            string += "```\n"
+            last_cell_md = False
+
+        else:
+            raise NotImplementedError("cell {}, type: {}".format(i, cell.cell_type))
+
+    return string.rstrip() + "\n"

--- a/jupytext/nbextension/index.js
+++ b/jupytext/nbextension/index.js
@@ -36,7 +36,7 @@ define([
         }
 
         var notebook_extension = Jupyter.notebook.notebook_path.split('.').pop();
-        notebook_extension = ['ipynb', 'md', 'Rmd'].indexOf(notebook_extension) == -1 ? 'auto' : notebook_extension;
+        notebook_extension = ['ipynb', 'md', 'Rmd', 'mnb'].indexOf(notebook_extension) == -1 ? 'auto' : notebook_extension;
         for (var i in formats) {
             var ext = formats[i].split(':')[0];
             if (ext==notebook_extension)
@@ -44,7 +44,7 @@ define([
         }
 
         // the notebook extension was not found among the formats
-        if (['ipynb', 'md', 'Rmd'].indexOf(notebook_extension)!=-1)
+        if (['ipynb', 'md', 'Rmd', 'mnb'].indexOf(notebook_extension)!=-1)
             formats.push(notebook_extension);
         else {
             var format_name = Jupyter.notebook.metadata.jupytext && Jupyter.notebook.metadata.jupytext.text_representation
@@ -66,7 +66,7 @@ define([
             $('#jupytext_pair_' + fmt.replace(':', '_') + ' > .fa').toggleClass('fa-check', true);
 
             // any custom format?
-            if (['ipynb', 'auto:light', 'auto:percent', 'auto:hydrogen', 'auto:nomarker', 'md', 'Rmd'].indexOf(fmt)==-1)
+            if (['ipynb', 'auto:light', 'auto:percent', 'auto:hydrogen', 'auto:nomarker', 'md', 'Rmd', 'mnb'].indexOf(fmt)==-1)
                 $('#jupytext_pair_custom' + ' > .fa').toggleClass('fa-check', true);
         }
 
@@ -108,7 +108,7 @@ define([
         }
         var formats = getSelectedJupytextFormats();
         var notebook_extension = Jupyter.notebook.notebook_path.split('.').pop();
-        notebook_extension = ['ipynb', 'md', 'Rmd'].indexOf(notebook_extension) == -1 ? 'auto' : notebook_extension;
+        notebook_extension = ['ipynb', 'md', 'Rmd', 'mnb'].indexOf(notebook_extension) == -1 ? 'auto' : notebook_extension;
 
         // Toggle the selected format
         var index = formats.indexOf(format);
@@ -297,6 +297,7 @@ define([
             JupytextActions.append(jupytext_pair('auto:nomarker', 'Pair Notebook with nomarker Script'));
             JupytextActions.append(jupytext_pair('md', 'Pair Notebook with Markdown', notebook_extension!=='md'));
             JupytextActions.append(jupytext_pair('Rmd', 'Pair Notebook with R Markdown', notebook_extension!=='Rmd'));
+            JupytextActions.append(jupytext_pair('mnb', 'Pair Notebook with MyST-NB', notebook_extension!=='mnb'));
             JupytextActions.append(jupytext_pair('custom', 'Custom pairing'));
             JupytextActions.append($('<li/>').addClass('divider'));
             JupytextActions.append(toggle_metadata);

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ pytest-cov
 codecov
 notebook
 jupyter_client
-myst-parser~=0.7.1
+myst-parser>=0.7.1,<0.8; python_version >= '3.6'
 nbconvert
 sphinx-gallery
 setuptools

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,6 @@ pytest-cov
 codecov
 notebook
 jupyter_client
-myst-parser>=0.7.1,<0.8; python_version >= '3.6'
 nbconvert
 sphinx-gallery
 setuptools

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ pytest-cov
 codecov
 notebook
 jupyter_client
+myst-parser~=0.7.1
 nbconvert
 sphinx-gallery
 setuptools

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     entry_points={'console_scripts': ['jupytext = jupytext.cli:jupytext']},
     tests_require=['pytest'],
     install_requires=['nbformat>=4.0.0', 'pyyaml', 'mock;python_version<"3"'],
+    extras_require={"myst": ["myst-parser~=0.7.1"]},
     license='MIT',
     classifiers=['Development Status :: 5 - Production/Stable',
                  'License :: OSI Approved :: MIT License',

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     entry_points={'console_scripts': ['jupytext = jupytext.cli:jupytext']},
     tests_require=['pytest'],
     install_requires=['nbformat>=4.0.0', 'pyyaml', 'mock;python_version<"3"'],
-    extras_require={"myst": ["myst-parser~=0.7.1"]},
+    extras_require={"myst": ["myst-parser~=0.7.1; python_version >= '3.6'"]},
     license='MIT',
     classifiers=['Development Status :: 5 - Production/Stable',
                  'License :: OSI Approved :: MIT License',

--- a/tests/notebooks/mirror/ipynb_to_myst/Line_breaks_in_LateX_305.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/Line_breaks_in_LateX_305.mystnb
@@ -6,6 +6,7 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 This cell uses no particular cell marker
 
 $$
@@ -17,6 +18,7 @@ $$
 $$
 
 +++
+
 This cell uses no particular cell marker, and a single slash in the $\LaTeX$ equation
 
 $$
@@ -28,6 +30,7 @@ $$
 $$
 
 +++
+
 This cell uses the triple quote cell markers introduced at https://github.com/mwouts/jupytext/issues/305
 
 $$

--- a/tests/notebooks/mirror/ipynb_to_myst/Line_breaks_in_LateX_305.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/Line_breaks_in_LateX_305.mystnb
@@ -1,0 +1,39 @@
+---
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+nbformat: 4
+nbformat_minor: 2
+---
+This cell uses no particular cell marker
+
+$$
+\begin{align}
+\dot{x} & = \sigma(y-x)\\
+\dot{y} & = \rho x - y - xz \\
+\dot{z} & = -\beta z + xy
+\end{align}
+$$
+
++++
+This cell uses no particular cell marker, and a single slash in the $\LaTeX$ equation
+
+$$
+\begin{align}
+\dot{x} & = \sigma(y-x) \
+\dot{y} & = \rho x - y - xz \
+\dot{z} & = -\beta z + xy
+\end{align}
+$$
+
++++
+This cell uses the triple quote cell markers introduced at https://github.com/mwouts/jupytext/issues/305
+
+$$
+\begin{align}
+\dot{x} & = \sigma(y-x)\\
+\dot{y} & = \rho x - y - xz \\
+\dot{z} & = -\beta z + xy
+\end{align}
+$$

--- a/tests/notebooks/mirror/ipynb_to_myst/Notebook with function and cell metadata 164.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/Notebook with function and cell metadata 164.mystnb
@@ -6,11 +6,13 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 ```{nb-code}
 1 + 1
 ```
 A markdown cell
 And below, the cell for function f has non trivial cell metadata. And the next cell as well.
+
 ```{nb-code}
 ---
 attributes:
@@ -21,6 +23,7 @@ attributes:
 def f(x):
     return x
 ```
+
 ```{nb-code}
 ---
 attributes:
@@ -31,6 +34,7 @@ attributes:
 f(5)
 ```
 More text
+
 ```{nb-code}
 2 + 2
 ```

--- a/tests/notebooks/mirror/ipynb_to_myst/Notebook with function and cell metadata 164.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/Notebook with function and cell metadata 164.mystnb
@@ -7,14 +7,14 @@ nbformat: 4
 nbformat_minor: 2
 ---
 
-```{nb-code}
+```{nb-code} ipython3
 1 + 1
 ```
 
 A markdown cell
 And below, the cell for function f has non trivial cell metadata. And the next cell as well.
 
-```{nb-code}
+```{nb-code} ipython3
 ---
 attributes:
   classes: []
@@ -25,7 +25,7 @@ def f(x):
     return x
 ```
 
-```{nb-code}
+```{nb-code} ipython3
 ---
 attributes:
   classes: []
@@ -37,6 +37,6 @@ f(5)
 
 More text
 
-```{nb-code}
+```{nb-code} ipython3
 2 + 2
 ```

--- a/tests/notebooks/mirror/ipynb_to_myst/Notebook with function and cell metadata 164.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/Notebook with function and cell metadata 164.mystnb
@@ -1,0 +1,36 @@
+---
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+nbformat: 4
+nbformat_minor: 2
+---
+```{nb-code}
+1 + 1
+```
+A markdown cell
+And below, the cell for function f has non trivial cell metadata. And the next cell as well.
+```{nb-code}
+---
+attributes:
+  classes: []
+  id: ''
+  n: '10'
+---
+def f(x):
+    return x
+```
+```{nb-code}
+---
+attributes:
+  classes: []
+  id: ''
+  n: '10'
+---
+f(5)
+```
+More text
+```{nb-code}
+2 + 2
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/Notebook with function and cell metadata 164.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/Notebook with function and cell metadata 164.mystnb
@@ -10,6 +10,7 @@ nbformat_minor: 2
 ```{nb-code}
 1 + 1
 ```
+
 A markdown cell
 And below, the cell for function f has non trivial cell metadata. And the next cell as well.
 
@@ -33,6 +34,7 @@ attributes:
 ---
 f(5)
 ```
+
 More text
 
 ```{nb-code}

--- a/tests/notebooks/mirror/ipynb_to_myst/Notebook with html and latex cells.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/Notebook with html and latex cells.mystnb
@@ -6,22 +6,27 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 ```{nb-code}
 %%html
 <p><a href="https://github.com/mwouts/jupytext", style="color: rgb(0,0,255)">Jupytext</a> on GitHub</p>
 ```
+
 ```{nb-code}
 %%latex
 $\frac{\pi}{2}$
 ```
+
 ```{nb-code}
 %load_ext rpy2.ipython
 ```
+
 ```{nb-code}
 %%R
 library(ggplot2)
 ggplot(data=data.frame(x=c('A', 'B'), y=c(5, 2)), aes(x,weight=y)) + geom_bar()
 ```
+
 ```{nb-code}
 %matplotlib inline
 import pandas as pd

--- a/tests/notebooks/mirror/ipynb_to_myst/Notebook with html and latex cells.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/Notebook with html and latex cells.mystnb
@@ -1,0 +1,29 @@
+---
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+nbformat: 4
+nbformat_minor: 2
+---
+```{nb-code}
+%%html
+<p><a href="https://github.com/mwouts/jupytext", style="color: rgb(0,0,255)">Jupytext</a> on GitHub</p>
+```
+```{nb-code}
+%%latex
+$\frac{\pi}{2}$
+```
+```{nb-code}
+%load_ext rpy2.ipython
+```
+```{nb-code}
+%%R
+library(ggplot2)
+ggplot(data=data.frame(x=c('A', 'B'), y=c(5, 2)), aes(x,weight=y)) + geom_bar()
+```
+```{nb-code}
+%matplotlib inline
+import pandas as pd
+pd.Series({'A':5, 'B':2}).plot(figsize=(3,2), kind='bar')
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/Notebook with html and latex cells.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/Notebook with html and latex cells.mystnb
@@ -7,27 +7,27 @@ nbformat: 4
 nbformat_minor: 2
 ---
 
-```{nb-code}
+```{nb-code} ipython3
 %%html
 <p><a href="https://github.com/mwouts/jupytext", style="color: rgb(0,0,255)">Jupytext</a> on GitHub</p>
 ```
 
-```{nb-code}
+```{nb-code} ipython3
 %%latex
 $\frac{\pi}{2}$
 ```
 
-```{nb-code}
+```{nb-code} ipython3
 %load_ext rpy2.ipython
 ```
 
-```{nb-code}
+```{nb-code} ipython3
 %%R
 library(ggplot2)
 ggplot(data=data.frame(x=c('A', 'B'), y=c(5, 2)), aes(x,weight=y)) + geom_bar()
 ```
 
-```{nb-code}
+```{nb-code} ipython3
 %matplotlib inline
 import pandas as pd
 pd.Series({'A':5, 'B':2}).plot(figsize=(3,2), kind='bar')

--- a/tests/notebooks/mirror/ipynb_to_myst/Notebook with many hash signs.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/Notebook with many hash signs.mystnb
@@ -10,6 +10,7 @@ nbformat_minor: 2
 This is a notebook that contains many hash signs.
 Hopefully its python representation is not recognized as a Sphinx Gallery script...
 ##################################################################
+
 ```{nb-code}
 some = 1
 code = 2

--- a/tests/notebooks/mirror/ipynb_to_myst/Notebook with many hash signs.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/Notebook with many hash signs.mystnb
@@ -1,0 +1,26 @@
+---
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+nbformat: 4
+nbformat_minor: 2
+---
+##################################################################
+This is a notebook that contains many hash signs.
+Hopefully its python representation is not recognized as a Sphinx Gallery script...
+##################################################################
+```{nb-code}
+some = 1
+code = 2
+some+code
+
+##################################################################
+# A comment
+##################################################################
+# Another comment
+```
+##################################################################
+This is a notebook that contains many hash signs.
+Hopefully its python representation is not recognized as a Sphinx Gallery script...
+##################################################################

--- a/tests/notebooks/mirror/ipynb_to_myst/Notebook with many hash signs.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/Notebook with many hash signs.mystnb
@@ -12,7 +12,7 @@ This is a notebook that contains many hash signs.
 Hopefully its python representation is not recognized as a Sphinx Gallery script...
 ##################################################################
 
-```{nb-code}
+```{nb-code} ipython3
 some = 1
 code = 2
 some+code

--- a/tests/notebooks/mirror/ipynb_to_myst/Notebook with many hash signs.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/Notebook with many hash signs.mystnb
@@ -6,6 +6,7 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 ##################################################################
 This is a notebook that contains many hash signs.
 Hopefully its python representation is not recognized as a Sphinx Gallery script...
@@ -21,6 +22,7 @@ some+code
 ##################################################################
 # Another comment
 ```
+
 ##################################################################
 This is a notebook that contains many hash signs.
 Hopefully its python representation is not recognized as a Sphinx Gallery script...

--- a/tests/notebooks/mirror/ipynb_to_myst/Notebook with metadata and long cells.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/Notebook with metadata and long cells.mystnb
@@ -6,15 +6,18 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 # Part one - various cells
 
 +++
+
 Here we have a markdown cell
 
 
 with two blank lines
 
 +++
+
 Now we have a markdown cell
 with a code block inside it
 
@@ -30,6 +33,7 @@ After that cell we'll have a code cell
 
 3 + 3
 ```
+
 Followed by a raw cell
 
 ```{nb-raw}
@@ -37,9 +41,11 @@ This is
 the content
 of the raw cell
 ```
+
 # Part two - cell metadata
 
 +++ {"key": "value"}
+
 This is a markdown cell with cell metadata `{"key": "value"}`
 
 ```{nb-code}

--- a/tests/notebooks/mirror/ipynb_to_myst/Notebook with metadata and long cells.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/Notebook with metadata and long cells.mystnb
@@ -51,15 +51,13 @@ This is a markdown cell with cell metadata `{"key": "value"}`
 ```{nb-code} ipython3
 ---
 .class: null
-tags:
-- parameters
+tags: [parameters]
 ---
 """This is a code cell with metadata `{"tags":["parameters"], ".class":null}`"""
 ```
 
 ```{nb-raw}
----
-key: value
----
+:key: value
+
 This is a raw cell with cell metadata `{"key": "value"}`
 ```

--- a/tests/notebooks/mirror/ipynb_to_myst/Notebook with metadata and long cells.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/Notebook with metadata and long cells.mystnb
@@ -1,0 +1,55 @@
+---
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+nbformat: 4
+nbformat_minor: 2
+---
+# Part one - various cells
+
++++
+Here we have a markdown cell
+
+
+with two blank lines
+
++++
+Now we have a markdown cell
+with a code block inside it
+
+```python
+1 + 1
+```
+
+After that cell we'll have a code cell
+```{nb-code}
+2 + 2
+
+
+3 + 3
+```
+Followed by a raw cell
+```{nb-raw}
+This is 
+the content
+of the raw cell
+```
+# Part two - cell metadata
+
++++ {"key": "value"}
+This is a markdown cell with cell metadata `{"key": "value"}`
+```{nb-code}
+---
+.class: null
+tags:
+- parameters
+---
+"""This is a code cell with metadata `{"tags":["parameters"], ".class":null}`"""
+```
+```{nb-raw}
+---
+key: value
+---
+This is a raw cell with cell metadata `{"key": "value"}`
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/Notebook with metadata and long cells.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/Notebook with metadata and long cells.mystnb
@@ -27,7 +27,7 @@ with a code block inside it
 
 After that cell we'll have a code cell
 
-```{nb-code}
+```{nb-code} ipython3
 2 + 2
 
 
@@ -48,7 +48,7 @@ of the raw cell
 
 This is a markdown cell with cell metadata `{"key": "value"}`
 
-```{nb-code}
+```{nb-code} ipython3
 ---
 .class: null
 tags:

--- a/tests/notebooks/mirror/ipynb_to_myst/Notebook with metadata and long cells.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/Notebook with metadata and long cells.mystnb
@@ -23,6 +23,7 @@ with a code block inside it
 ```
 
 After that cell we'll have a code cell
+
 ```{nb-code}
 2 + 2
 
@@ -30,6 +31,7 @@ After that cell we'll have a code cell
 3 + 3
 ```
 Followed by a raw cell
+
 ```{nb-raw}
 This is 
 the content
@@ -39,6 +41,7 @@ of the raw cell
 
 +++ {"key": "value"}
 This is a markdown cell with cell metadata `{"key": "value"}`
+
 ```{nb-code}
 ---
 .class: null
@@ -47,6 +50,7 @@ tags:
 ---
 """This is a code cell with metadata `{"tags":["parameters"], ".class":null}`"""
 ```
+
 ```{nb-raw}
 ---
 key: value

--- a/tests/notebooks/mirror/ipynb_to_myst/Notebook_with_R_magic.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/Notebook_with_R_magic.mystnb
@@ -1,0 +1,27 @@
+---
+kernelspec:
+  display_name: Python 2
+  language: python
+  name: python2
+nbformat: 4
+nbformat_minor: 2
+---
+# A notebook with R cells
+
+This notebook shows the use of R cells to generate plots
+```{nb-code}
+%load_ext rpy2.ipython
+```
+```{nb-code}
+%%R
+suppressMessages(require(tidyverse))
+```
+```{nb-code}
+%%R
+ggplot(iris, aes(x = Sepal.Length, y = Petal.Length, color=Species)) + geom_point()
+```
+The default plot dimensions are not good for us, so we use the -w and -h parameters in %%R magic to set the plot size
+```{nb-code}
+%%R -w 400 -h 240
+ggplot(iris, aes(x = Sepal.Length, y = Petal.Length, color=Species)) + geom_point()
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/Notebook_with_R_magic.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/Notebook_with_R_magic.mystnb
@@ -6,6 +6,7 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 # A notebook with R cells
 
 This notebook shows the use of R cells to generate plots
@@ -23,6 +24,7 @@ suppressMessages(require(tidyverse))
 %%R
 ggplot(iris, aes(x = Sepal.Length, y = Petal.Length, color=Species)) + geom_point()
 ```
+
 The default plot dimensions are not good for us, so we use the -w and -h parameters in %%R magic to set the plot size
 
 ```{nb-code}

--- a/tests/notebooks/mirror/ipynb_to_myst/Notebook_with_R_magic.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/Notebook_with_R_magic.mystnb
@@ -11,23 +11,23 @@ nbformat_minor: 2
 
 This notebook shows the use of R cells to generate plots
 
-```{nb-code}
+```{nb-code} ipython2
 %load_ext rpy2.ipython
 ```
 
-```{nb-code}
+```{nb-code} ipython2
 %%R
 suppressMessages(require(tidyverse))
 ```
 
-```{nb-code}
+```{nb-code} ipython2
 %%R
 ggplot(iris, aes(x = Sepal.Length, y = Petal.Length, color=Species)) + geom_point()
 ```
 
 The default plot dimensions are not good for us, so we use the -w and -h parameters in %%R magic to set the plot size
 
-```{nb-code}
+```{nb-code} ipython2
 %%R -w 400 -h 240
 ggplot(iris, aes(x = Sepal.Length, y = Petal.Length, color=Species)) + geom_point()
 ```

--- a/tests/notebooks/mirror/ipynb_to_myst/Notebook_with_R_magic.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/Notebook_with_R_magic.mystnb
@@ -9,18 +9,22 @@ nbformat_minor: 2
 # A notebook with R cells
 
 This notebook shows the use of R cells to generate plots
+
 ```{nb-code}
 %load_ext rpy2.ipython
 ```
+
 ```{nb-code}
 %%R
 suppressMessages(require(tidyverse))
 ```
+
 ```{nb-code}
 %%R
 ggplot(iris, aes(x = Sepal.Length, y = Petal.Length, color=Species)) + geom_point()
 ```
 The default plot dimensions are not good for us, so we use the -w and -h parameters in %%R magic to set the plot size
+
 ```{nb-code}
 %%R -w 400 -h 240
 ggplot(iris, aes(x = Sepal.Length, y = Petal.Length, color=Species)) + geom_point()

--- a/tests/notebooks/mirror/ipynb_to_myst/Notebook_with_more_R_magic_111.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/Notebook_with_more_R_magic_111.mystnb
@@ -7,7 +7,7 @@ nbformat: 4
 nbformat_minor: 2
 ---
 
-```{nb-code}
+```{nb-code} ipython3
 %load_ext rpy2.ipython
 import pandas as pd
 
@@ -21,7 +21,7 @@ df = pd.DataFrame(
 )
 ```
 
-```{nb-code}
+```{nb-code} ipython3
 %%R -i df
 library("ggplot2")
 ggplot(data = df) + geom_point(aes(x = X, y = Y, color = Letter, size = Z))

--- a/tests/notebooks/mirror/ipynb_to_myst/Notebook_with_more_R_magic_111.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/Notebook_with_more_R_magic_111.mystnb
@@ -6,6 +6,7 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 ```{nb-code}
 %load_ext rpy2.ipython
 import pandas as pd
@@ -19,6 +20,7 @@ df = pd.DataFrame(
     }
 )
 ```
+
 ```{nb-code}
 %%R -i df
 library("ggplot2")

--- a/tests/notebooks/mirror/ipynb_to_myst/Notebook_with_more_R_magic_111.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/Notebook_with_more_R_magic_111.mystnb
@@ -1,0 +1,26 @@
+---
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+nbformat: 4
+nbformat_minor: 2
+---
+```{nb-code}
+%load_ext rpy2.ipython
+import pandas as pd
+
+df = pd.DataFrame(
+    {
+        "Letter": ["a", "a", "a", "b", "b", "b", "c", "c", "c"],
+        "X": [4, 3, 5, 2, 1, 7, 7, 5, 9],
+        "Y": [0, 4, 3, 6, 7, 10, 11, 9, 13],
+        "Z": [1, 2, 3, 1, 2, 3, 1, 2, 3],
+    }
+)
+```
+```{nb-code}
+%%R -i df
+library("ggplot2")
+ggplot(data = df) + geom_point(aes(x = X, y = Y, color = Letter, size = Z))
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/R notebook with invalid cell keys.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/R notebook with invalid cell keys.mystnb
@@ -7,6 +7,7 @@ nbformat: 4
 nbformat_minor: 2
 ---
 This notebook was created with IRKernel 0.8.12, and is not completely valid, as the code cell below contains an unexpected 'source' entry. This did cause https://github.com/mwouts/jupytext/issues/234. Note that the problem is solved when one upgrades to IRKernel 1.0.0.
+
 ```{nb-code}
 library("ggplot2")
 ggplot(mtcars, aes(mpg)) + stat_ecdf()

--- a/tests/notebooks/mirror/ipynb_to_myst/R notebook with invalid cell keys.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/R notebook with invalid cell keys.mystnb
@@ -1,0 +1,13 @@
+---
+kernelspec:
+  display_name: R
+  language: R
+  name: ir
+nbformat: 4
+nbformat_minor: 2
+---
+This notebook was created with IRKernel 0.8.12, and is not completely valid, as the code cell below contains an unexpected 'source' entry. This did cause https://github.com/mwouts/jupytext/issues/234. Note that the problem is solved when one upgrades to IRKernel 1.0.0.
+```{nb-code}
+library("ggplot2")
+ggplot(mtcars, aes(mpg)) + stat_ecdf()
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/R notebook with invalid cell keys.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/R notebook with invalid cell keys.mystnb
@@ -6,6 +6,7 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 This notebook was created with IRKernel 0.8.12, and is not completely valid, as the code cell below contains an unexpected 'source' entry. This did cause https://github.com/mwouts/jupytext/issues/234. Note that the problem is solved when one upgrades to IRKernel 1.0.0.
 
 ```{nb-code}

--- a/tests/notebooks/mirror/ipynb_to_myst/R notebook with invalid cell keys.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/R notebook with invalid cell keys.mystnb
@@ -9,7 +9,7 @@ nbformat_minor: 2
 
 This notebook was created with IRKernel 0.8.12, and is not completely valid, as the code cell below contains an unexpected 'source' entry. This did cause https://github.com/mwouts/jupytext/issues/234. Note that the problem is solved when one upgrades to IRKernel 1.0.0.
 
-```{nb-code}
+```{nb-code} r
 library("ggplot2")
 ggplot(mtcars, aes(mpg)) + stat_ecdf()
 ```

--- a/tests/notebooks/mirror/ipynb_to_myst/Reference Guide for Calysto Scheme.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/Reference Guide for Calysto Scheme.mystnb
@@ -83,37 +83,47 @@ Calysto Scheme may not implement all of those. Some useful and suggestive ones:
 * \Pi - Π
 * \Sigma - Σ
 * \_i - subscript i, such as vectorᵢ
+
 ```{nb-code}
 (define α 67)
 ```
+
 ```{nb-code}
 α
 ```
+
 ```{nb-code}
 (define i 2)
 (define vectorᵢ (vector-ref (vector 0 6 3 2) i))
 vectorᵢ
 ```
 ### Rich media
+
 ```{nb-code}
 (import "calysto.display")
 ```
+
 ```{nb-code}
 (calysto.display.HTML "This is <b>bold</b>, <i>italics</i>, <u>underlined</u>.")
 ```
+
 ```{nb-code}
 (import "calysto.graphics")
 ```
+
 ```{nb-code}
 (define canvas (calysto.graphics.Canvas))
 ```
+
 ```{nb-code}
 (define ball (calysto.graphics.Circle '(150 150) 100))
 ```
+
 ```{nb-code}
 (ball.draw canvas)
 ```
 ### Shell commands
+
 ```{nb-code}
 ! ls /tmp
 ```
@@ -141,9 +151,11 @@ It has breakpoints (click in left margin). You must press Stop to exit the debug
 You can import and use any Python library in Calysto Scheme.
 
 In addition, if you wish, you can execute expressions and statements in a Python environment:
+
 ```{nb-code}
 (python-eval "1 + 2")
 ```
+
 ```{nb-code}
 (python-exec 
 "
@@ -152,13 +164,16 @@ def mypyfunc(a, b):
 ")
 ```
 This is a shared environment with Scheme:
+
 ```{nb-code}
 (mypyfunc 4 5)
 ```
 You can use `func` to turn a Scheme procedure into a Python function, and `define!` to put it into the shared enviornment with Python:
+
 ```{nb-code}
 (define! mypyfunc2 (func (lambda (n) n)))
 ```
+
 ```{nb-code}
 (python-eval "mypyfunc2(34)")
 ```
@@ -185,6 +200,7 @@ You can use `func` to turn a Scheme procedure into a Python function, and `defin
 ### Stack Trace
 
 Calysto Scheme acts as if it has a call stack, for easier debugging. For example:
+
 ```{nb-code}
 (define fact
     (lambda (n)
@@ -192,6 +208,7 @@ Calysto Scheme acts as if it has a call stack, for easier debugging. For example
            q
            (* n (fact (- n 1))))))
 ```
+
 ```{nb-code}
 (fact 5)
 ```
@@ -207,18 +224,22 @@ That will allow infinite recursive loops without keeping track of the "stack".
 
 ## SCHEMEPATH
 SCHEMEPATH is a list of search directories used with (load NAME). This is a reference, so you should append to it rather than attempting to redefine it.
+
 ```{nb-code}
 SCHEMEPATH
 ```
+
 ```{nb-code}
 (set-cdr! (cdr SCHEMEPATH) (list "/var/modules"))
 ```
+
 ```{nb-code}
 SCHEMEPATH
 ```
 ## Getting Started
 
 Note that you can use the word `lambda` or \lambda and then press [TAB]
+
 ```{nb-code}
 (define factorial
   (λ (n)
@@ -226,20 +247,24 @@ Note that you can use the word `lambda` or \lambda and then press [TAB]
       ((zero? n) 1)
       (else (* n (factorial (- n 1)))))))
 ```
+
 ```{nb-code}
 (factorial 5)
 ```
 ## define-syntax
 (define-syntax NAME RULES): a method for creating macros
+
 ```{nb-code}
 (define-syntax time 
   [(time ?exp) (let ((start (current-time)))
                  ?exp
                  (- (current-time) start))])
 ```
+
 ```{nb-code}
 (time (car '(1 2 3 4)))
 ```
+
 ```{nb-code}
 ;;---------------------------------------------------------------------
 ;; collect is like list comprehension in Python
@@ -258,15 +283,19 @@ Note that you can use the word `lambda` or \lambda and then press [TAB]
           (cons (f (car values)) (filter-map f pred? (cdr values)))
           (filter-map f pred? (cdr values))))))
 ```
+
 ```{nb-code}
 (collect (* n n) for n in (range 10))
 ```
+
 ```{nb-code}
 (collect (* n n) for n in (range 5 20 3))
 ```
+
 ```{nb-code}
 (collect (* n n) for n in (range 10) if (> n 5))
 ```
+
 ```{nb-code}
 ;;---------------------------------------------------------------------
 ;; for loops
@@ -306,6 +335,7 @@ Note that you can use the word `lambda` or \lambda and then press [TAB]
         (f (car values) i)
         (for-iterate2 (+ i 1) (cdr values) f)))))
 ```
+
 ```{nb-code}
 (define matrix2d
   '((10 20)
@@ -319,6 +349,7 @@ Note that you can use the word `lambda` or \lambda and then press [TAB]
     ((130 140 150) (160 170 180))
     ((190 200 210) (220 230 240))))
 ```
+
 ```{nb-code}
 (begin 
  (define hello 0)
@@ -326,18 +357,23 @@ Note that you can use the word `lambda` or \lambda and then press [TAB]
  hello
  )
 ```
+
 ```{nb-code}
 (for sym in '(a b c d) do (define x 1) (set! x sym) (print x))
 ```
+
 ```{nb-code}
 (for n in (range 10 20 2) do (print n))
 ```
+
 ```{nb-code}
 (for n at (i j) in matrix2d do (print (list n 'coords: i j)))
 ```
+
 ```{nb-code}
 (for n at (i j k) in matrix3d do (print (list n 'coords: i j k)))
 ```
+
 ```{nb-code}
 (define-syntax scons
   [(scons ?x ?y) (cons ?x (lambda () ?y))])
@@ -380,25 +416,31 @@ Note that you can use the word `lambda` or \lambda and then press [TAB]
 
 (define ! (lambda (n) (nth n facts)))
 ```
+
 ```{nb-code}
 (! 5)
 ```
+
 ```{nb-code}
 (nth 10 facts)
 ```
+
 ```{nb-code}
 (nth 20 fibs)
 ```
+
 ```{nb-code}
 (first 30 fibs)
 ```
 ## for-each
 (for-each PROCEDURE LIST): apply PROCEDURE to each item in LIST; like `map` but don't return results
+
 ```{nb-code}
 (for-each (lambda (n) (print n)) '(3 4 5))
 ```
 ## format
 (format STRING ITEM ...): format the string with ITEMS as arguments
+
 ```{nb-code}
 (format "This uses formatting ~a ~s ~%" 'apple 'apple)
 ```
@@ -407,6 +449,7 @@ Note that you can use the word `lambda` or \lambda and then press [TAB]
 Turns a lambda into a Python function.
 
 (func (lambda ...))
+
 ```{nb-code}
 (func (lambda (n) n))
 ```

--- a/tests/notebooks/mirror/ipynb_to_myst/Reference Guide for Calysto Scheme.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/Reference Guide for Calysto Scheme.mystnb
@@ -6,6 +6,7 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 <img src="images/logo-64x64.png"/>
 <h1>Reference Guide for Calysto Scheme</h1>
 
@@ -59,6 +60,7 @@ When you run Calysto Scheme in Jupyter (console, notebook, qtconsole, etc.) you 
 * Python integration
 
 +++
+
 ### LaTeX-style variables
 
 Calysto Scheme allows you to use LaTeX-style variables in code. For example, if you type:
@@ -97,6 +99,7 @@ Calysto Scheme may not implement all of those. Some useful and suggestive ones:
 (define vectorᵢ (vector-ref (vector 0 6 3 2) i))
 vectorᵢ
 ```
+
 ### Rich media
 
 ```{nb-code}
@@ -122,11 +125,13 @@ vectorᵢ
 ```{nb-code}
 (ball.draw canvas)
 ```
+
 ### Shell commands
 
 ```{nb-code}
 ! ls /tmp
 ```
+
 ### Stepper/Debugger
 
 Here is what the debugger looks like:
@@ -136,6 +141,7 @@ Here is what the debugger looks like:
 It has breakpoints (click in left margin). You must press Stop to exit the debugger.
 
 +++
+
 ```scheme
 %%debug
 
@@ -146,6 +152,7 @@ It has breakpoints (click in left margin). You must press Stop to exit the debug
 ```
 
 +++
+
 ### Python Integration
 
 You can import and use any Python library in Calysto Scheme.
@@ -163,11 +170,13 @@ def mypyfunc(a, b):
     return a * b
 ")
 ```
+
 This is a shared environment with Scheme:
 
 ```{nb-code}
 (mypyfunc 4 5)
 ```
+
 You can use `func` to turn a Scheme procedure into a Python function, and `define!` to put it into the shared enviornment with Python:
 
 ```{nb-code}
@@ -177,6 +186,7 @@ You can use `func` to turn a Scheme procedure into a Python function, and `defin
 ```{nb-code}
 (python-eval "mypyfunc2(34)")
 ```
+
 # Differences Between Languages
 
 ## Major differences between Scheme and Python
@@ -212,6 +222,7 @@ Calysto Scheme acts as if it has a call stack, for easier debugging. For example
 ```{nb-code}
 (fact 5)
 ```
+
 To turn off the stack trace on error:
 
 ```scheme
@@ -220,6 +231,7 @@ To turn off the stack trace on error:
 That will allow infinite recursive loops without keeping track of the "stack".
 
 +++
+
 # Calysto Scheme Variables
 
 ## SCHEMEPATH
@@ -236,6 +248,7 @@ SCHEMEPATH
 ```{nb-code}
 SCHEMEPATH
 ```
+
 ## Getting Started
 
 Note that you can use the word `lambda` or \lambda and then press [TAB]
@@ -251,6 +264,7 @@ Note that you can use the word `lambda` or \lambda and then press [TAB]
 ```{nb-code}
 (factorial 5)
 ```
+
 ## define-syntax
 (define-syntax NAME RULES): a method for creating macros
 
@@ -432,18 +446,21 @@ Note that you can use the word `lambda` or \lambda and then press [TAB]
 ```{nb-code}
 (first 30 fibs)
 ```
+
 ## for-each
 (for-each PROCEDURE LIST): apply PROCEDURE to each item in LIST; like `map` but don't return results
 
 ```{nb-code}
 (for-each (lambda (n) (print n)) '(3 4 5))
 ```
+
 ## format
 (format STRING ITEM ...): format the string with ITEMS as arguments
 
 ```{nb-code}
 (format "This uses formatting ~a ~s ~%" 'apple 'apple)
 ```
+
 ## func
 
 Turns a lambda into a Python function.
@@ -453,6 +470,7 @@ Turns a lambda into a Python function.
 ```{nb-code}
 (func (lambda (n) n))
 ```
+
 ## There's more!
 
 Please see [Calysto Scheme Language](Calysto%20Scheme%20Language.ipynb) for more details on the Calysto Scheme language.

--- a/tests/notebooks/mirror/ipynb_to_myst/Reference Guide for Calysto Scheme.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/Reference Guide for Calysto Scheme.mystnb
@@ -1,0 +1,415 @@
+---
+kernelspec:
+  display_name: Calysto Scheme (Python)
+  language: scheme
+  name: calysto_scheme
+nbformat: 4
+nbformat_minor: 2
+---
+<img src="images/logo-64x64.png"/>
+<h1>Reference Guide for Calysto Scheme</h1>
+
+[Calysto Scheme](https://github.com/Calysto/calysto_scheme) is a real Scheme programming language, with full support for continuations, including call/cc. It can also use all Python libraries. Also has some extensions that make it more useful (stepper-debugger, choose/fail, stack traces), or make it better integrated with Python.
+
+In Jupyter notebooks, because Calysto Scheme uses [MetaKernel](https://github.com/Calysto/metakernel/blob/master/README.rst), it has a fully-supported set of "magics"---meta-commands for additional functionality. This includes running Scheme in parallel. See all of the [MetaKernel Magics](https://github.com/Calysto/metakernel/blob/master/metakernel/magics/README.md).
+
+Calysto Scheme is written in Scheme, and then translated into Python (and other backends). The entire functionality lies in a single Python file: https://github.com/Calysto/calysto_scheme/blob/master/calysto_scheme/scheme.py However, you can easily install it (see below).
+
+Please see [Calysto Scheme Language](Calysto%20Scheme%20Language.ipynb) for more details on the Calysto Scheme language.
+
+## Installation
+
+You can install Calysto Scheme with Python3:
+
+```
+pip3 install --upgrade calysto-scheme --user -U
+python3 -m calysto_kernel install --user
+```
+
+or in the system kernel folder with:
+
+```
+sudo pip3 install --upgrade calysto-scheme -U
+sudo python3 -m calysto_kernel install
+```
+
+Change pip3/python3 to use a different pip or Python. The version of Python used will determine how Calysto Scheme is run.
+
+Use it in the console, qtconsole, or notebook with IPython 3:
+
+```
+ipython console --kernel calysto_scheme
+ipython qtconsole --kernel calysto_scheme
+ipython notebook --kernel calysto_scheme
+```
+
+In addition to all of the following items, Calysto Scheme also has access to all of Python's builtin functions, and all of Python's libraries. For example, you can use `(complex 3 2)` to create a complex number by calling Python's complex function.
+
+## Jupyter Enhancements
+
+When you run Calysto Scheme in Jupyter (console, notebook, qtconsole, etc.) you get:
+
+* TAB completions of Scheme functions and variable names
+* display of rich media
+* stepper/debugger
+* magics (% macros)
+* shell commands (! command)
+* LaTeX equations
+* LaTeX-style variables
+* Python integration
+
++++
+### LaTeX-style variables
+
+Calysto Scheme allows you to use LaTeX-style variables in code. For example, if you type:
+
+```
+\beta
+```
+
+with the cursor right after the 'a' in beta, and then press TAB, it will turn into the unicode character:
+
+```
+β
+```
+
+There are nearly 1300 different symbols defined (thanks to the Julia language) and documented here:
+
+http://docs.julialang.org/en/release-0.4/manual/unicode-input/#man-unicode-input
+
+Calysto Scheme may not implement all of those. Some useful and suggestive ones:
+
+* \pi - π
+* \Pi - Π
+* \Sigma - Σ
+* \_i - subscript i, such as vectorᵢ
+```{nb-code}
+(define α 67)
+```
+```{nb-code}
+α
+```
+```{nb-code}
+(define i 2)
+(define vectorᵢ (vector-ref (vector 0 6 3 2) i))
+vectorᵢ
+```
+### Rich media
+```{nb-code}
+(import "calysto.display")
+```
+```{nb-code}
+(calysto.display.HTML "This is <b>bold</b>, <i>italics</i>, <u>underlined</u>.")
+```
+```{nb-code}
+(import "calysto.graphics")
+```
+```{nb-code}
+(define canvas (calysto.graphics.Canvas))
+```
+```{nb-code}
+(define ball (calysto.graphics.Circle '(150 150) 100))
+```
+```{nb-code}
+(ball.draw canvas)
+```
+### Shell commands
+```{nb-code}
+! ls /tmp
+```
+### Stepper/Debugger
+
+Here is what the debugger looks like:
+
+<img src="images/stepper_debugger.png">
+
+It has breakpoints (click in left margin). You must press Stop to exit the debugger.
+
++++
+```scheme
+%%debug
+
+(begin
+ (define x 1)
+ (set! x 2)
+)
+```
+
++++
+### Python Integration
+
+You can import and use any Python library in Calysto Scheme.
+
+In addition, if you wish, you can execute expressions and statements in a Python environment:
+```{nb-code}
+(python-eval "1 + 2")
+```
+```{nb-code}
+(python-exec 
+"
+def mypyfunc(a, b):
+    return a * b
+")
+```
+This is a shared environment with Scheme:
+```{nb-code}
+(mypyfunc 4 5)
+```
+You can use `func` to turn a Scheme procedure into a Python function, and `define!` to put it into the shared enviornment with Python:
+```{nb-code}
+(define! mypyfunc2 (func (lambda (n) n)))
+```
+```{nb-code}
+(python-eval "mypyfunc2(34)")
+```
+# Differences Between Languages
+
+## Major differences between Scheme and Python
+
+1. In Scheme, double quotes are used for strings and may contain newlines
+1. In Scheme, a single quote is short for (quote ...) and means "literal"
+1. In Scheme, everything is an expression and has a return value
+1. Python does not support macros (e.g., extending syntax)
+1. In Python, "if X" is false if X is None, False, [], (,) or 0. In Scheme, "if X" is only false if X is #f or 0
+1. Calysto Scheme uses continuations, not the call stack. However, for debugging there is a pseudo-stack when an error is raised. You can trun that off with (use-stack-trace #f)
+1. Scheme procedures are not Python functions, but there are means to use one as the other.
+
+## Major Differences Between Calysto Scheme and other Schemes
+
+1. define-syntax works slightly differently
+1. In Calysto Scheme, #(...) is short for '#(...)
+1. Calysto Scheme is missing many standard functions (see list at bottom)
+1. Calysto Scheme has a built-in amb operator called `choose`
+1. For debugging there is a pseudo-stack when errors are raised in Calysto Scheme. You can trun that off with (use-stack-trace #f)
+
+### Stack Trace
+
+Calysto Scheme acts as if it has a call stack, for easier debugging. For example:
+```{nb-code}
+(define fact
+    (lambda (n)
+      (if (= n 1)
+           q
+           (* n (fact (- n 1))))))
+```
+```{nb-code}
+(fact 5)
+```
+To turn off the stack trace on error:
+
+```scheme
+(use-stack-trace #f)
+```
+That will allow infinite recursive loops without keeping track of the "stack".
+
++++
+# Calysto Scheme Variables
+
+## SCHEMEPATH
+SCHEMEPATH is a list of search directories used with (load NAME). This is a reference, so you should append to it rather than attempting to redefine it.
+```{nb-code}
+SCHEMEPATH
+```
+```{nb-code}
+(set-cdr! (cdr SCHEMEPATH) (list "/var/modules"))
+```
+```{nb-code}
+SCHEMEPATH
+```
+## Getting Started
+
+Note that you can use the word `lambda` or \lambda and then press [TAB]
+```{nb-code}
+(define factorial
+  (λ (n)
+     (cond
+      ((zero? n) 1)
+      (else (* n (factorial (- n 1)))))))
+```
+```{nb-code}
+(factorial 5)
+```
+## define-syntax
+(define-syntax NAME RULES): a method for creating macros
+```{nb-code}
+(define-syntax time 
+  [(time ?exp) (let ((start (current-time)))
+                 ?exp
+                 (- (current-time) start))])
+```
+```{nb-code}
+(time (car '(1 2 3 4)))
+```
+```{nb-code}
+;;---------------------------------------------------------------------
+;; collect is like list comprehension in Python
+
+(define-syntax collect
+  [(collect ?exp for ?var in ?list)
+   (filter-map (lambda (?var) ?exp) (lambda (?var) #t) ?list)]
+  [(collect ?exp for ?var in ?list if ?condition)
+   (filter-map (lambda (?var) ?exp) (lambda (?var) ?condition) ?list)])
+
+(define filter-map
+  (lambda (f pred? values)
+    (if (null? values)
+      '()
+      (if (pred? (car values))
+          (cons (f (car values)) (filter-map f pred? (cdr values)))
+          (filter-map f pred? (cdr values))))))
+```
+```{nb-code}
+(collect (* n n) for n in (range 10))
+```
+```{nb-code}
+(collect (* n n) for n in (range 5 20 3))
+```
+```{nb-code}
+(collect (* n n) for n in (range 10) if (> n 5))
+```
+```{nb-code}
+;;---------------------------------------------------------------------
+;; for loops
+
+(define-syntax for
+  [(for ?exp times do . ?bodies)
+   (for-repeat ?exp (lambda () . ?bodies))]
+  [(for ?var in ?exp do . ?bodies)
+   (for-iterate1 ?exp (lambda (?var) . ?bodies))]
+  [(for ?var at (?i) in ?exp do . ?bodies)
+   (for-iterate2 0 ?exp (lambda (?var ?i) . ?bodies))]
+  [(for ?var at (?i ?j . ?rest) in ?exp do . ?bodies)
+   (for ?var at (?i) in ?exp do
+     (for ?var at (?j . ?rest) in ?var do . ?bodies))])
+
+(define for-repeat
+  (lambda (n f)
+    (if (< n 1)
+      'done
+      (begin
+        (f)
+        (for-repeat (- n 1) f)))))
+
+(define for-iterate1
+  (lambda (values f)
+    (if (null? values)
+      'done
+      (begin
+        (f (car values))
+        (for-iterate1 (cdr values) f)))))
+
+(define for-iterate2
+  (lambda (i values f)
+    (if (null? values)
+      'done
+      (begin
+        (f (car values) i)
+        (for-iterate2 (+ i 1) (cdr values) f)))))
+```
+```{nb-code}
+(define matrix2d
+  '((10 20)
+    (30 40)
+    (50 60)
+    (70 80)))
+
+(define matrix3d
+  '(((10 20 30) (40 50 60))
+    ((70 80 90) (100 110 120))
+    ((130 140 150) (160 170 180))
+    ((190 200 210) (220 230 240))))
+```
+```{nb-code}
+(begin 
+ (define hello 0)
+ (for 5 times do (set! hello (+ hello 1)))
+ hello
+ )
+```
+```{nb-code}
+(for sym in '(a b c d) do (define x 1) (set! x sym) (print x))
+```
+```{nb-code}
+(for n in (range 10 20 2) do (print n))
+```
+```{nb-code}
+(for n at (i j) in matrix2d do (print (list n 'coords: i j)))
+```
+```{nb-code}
+(for n at (i j k) in matrix3d do (print (list n 'coords: i j k)))
+```
+```{nb-code}
+(define-syntax scons
+  [(scons ?x ?y) (cons ?x (lambda () ?y))])
+
+(define scar car)
+
+(define scdr
+  (lambda (s)
+    (let ((result ((cdr s))))
+      (set-cdr! s (lambda () result))
+      result)))
+
+(define first
+  (lambda (n s)
+    (if (= n 0)
+      '()
+      (cons (scar s) (first (- n 1) (scdr s))))))
+
+(define nth
+  (lambda (n s)
+    (if (= n 0)
+      (scar s)
+      (nth (- n 1) (scdr s)))))
+
+(define smap
+  (lambda (f s)
+    (scons (f (scar s)) (smap f (scdr s)))))
+
+(define ones (scons 1 ones))
+
+(define nats (scons 0 (combine nats + ones)))
+
+(define combine
+  (lambda (s1 op s2)
+    (scons (op (scar s1) (scar s2)) (combine (scdr s1) op (scdr s2)))))
+
+(define fibs (scons 1 (scons 1 (combine fibs + (scdr fibs)))))
+
+(define facts (scons 1 (combine facts * (scdr nats))))
+
+(define ! (lambda (n) (nth n facts)))
+```
+```{nb-code}
+(! 5)
+```
+```{nb-code}
+(nth 10 facts)
+```
+```{nb-code}
+(nth 20 fibs)
+```
+```{nb-code}
+(first 30 fibs)
+```
+## for-each
+(for-each PROCEDURE LIST): apply PROCEDURE to each item in LIST; like `map` but don't return results
+```{nb-code}
+(for-each (lambda (n) (print n)) '(3 4 5))
+```
+## format
+(format STRING ITEM ...): format the string with ITEMS as arguments
+```{nb-code}
+(format "This uses formatting ~a ~s ~%" 'apple 'apple)
+```
+## func
+
+Turns a lambda into a Python function.
+
+(func (lambda ...))
+```{nb-code}
+(func (lambda (n) n))
+```
+## There's more!
+
+Please see [Calysto Scheme Language](Calysto%20Scheme%20Language.ipynb) for more details on the Calysto Scheme language.

--- a/tests/notebooks/mirror/ipynb_to_myst/Reference Guide for Calysto Scheme.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/Reference Guide for Calysto Scheme.mystnb
@@ -86,15 +86,15 @@ Calysto Scheme may not implement all of those. Some useful and suggestive ones:
 * \Sigma - Σ
 * \_i - subscript i, such as vectorᵢ
 
-```{nb-code}
+```{nb-code} scheme
 (define α 67)
 ```
 
-```{nb-code}
+```{nb-code} scheme
 α
 ```
 
-```{nb-code}
+```{nb-code} scheme
 (define i 2)
 (define vectorᵢ (vector-ref (vector 0 6 3 2) i))
 vectorᵢ
@@ -102,33 +102,33 @@ vectorᵢ
 
 ### Rich media
 
-```{nb-code}
+```{nb-code} scheme
 (import "calysto.display")
 ```
 
-```{nb-code}
+```{nb-code} scheme
 (calysto.display.HTML "This is <b>bold</b>, <i>italics</i>, <u>underlined</u>.")
 ```
 
-```{nb-code}
+```{nb-code} scheme
 (import "calysto.graphics")
 ```
 
-```{nb-code}
+```{nb-code} scheme
 (define canvas (calysto.graphics.Canvas))
 ```
 
-```{nb-code}
+```{nb-code} scheme
 (define ball (calysto.graphics.Circle '(150 150) 100))
 ```
 
-```{nb-code}
+```{nb-code} scheme
 (ball.draw canvas)
 ```
 
 ### Shell commands
 
-```{nb-code}
+```{nb-code} scheme
 ! ls /tmp
 ```
 
@@ -159,11 +159,11 @@ You can import and use any Python library in Calysto Scheme.
 
 In addition, if you wish, you can execute expressions and statements in a Python environment:
 
-```{nb-code}
+```{nb-code} scheme
 (python-eval "1 + 2")
 ```
 
-```{nb-code}
+```{nb-code} scheme
 (python-exec 
 "
 def mypyfunc(a, b):
@@ -173,17 +173,17 @@ def mypyfunc(a, b):
 
 This is a shared environment with Scheme:
 
-```{nb-code}
+```{nb-code} scheme
 (mypyfunc 4 5)
 ```
 
 You can use `func` to turn a Scheme procedure into a Python function, and `define!` to put it into the shared enviornment with Python:
 
-```{nb-code}
+```{nb-code} scheme
 (define! mypyfunc2 (func (lambda (n) n)))
 ```
 
-```{nb-code}
+```{nb-code} scheme
 (python-eval "mypyfunc2(34)")
 ```
 
@@ -211,7 +211,7 @@ You can use `func` to turn a Scheme procedure into a Python function, and `defin
 
 Calysto Scheme acts as if it has a call stack, for easier debugging. For example:
 
-```{nb-code}
+```{nb-code} scheme
 (define fact
     (lambda (n)
       (if (= n 1)
@@ -219,7 +219,7 @@ Calysto Scheme acts as if it has a call stack, for easier debugging. For example
            (* n (fact (- n 1))))))
 ```
 
-```{nb-code}
+```{nb-code} scheme
 (fact 5)
 ```
 
@@ -237,15 +237,15 @@ That will allow infinite recursive loops without keeping track of the "stack".
 ## SCHEMEPATH
 SCHEMEPATH is a list of search directories used with (load NAME). This is a reference, so you should append to it rather than attempting to redefine it.
 
-```{nb-code}
+```{nb-code} scheme
 SCHEMEPATH
 ```
 
-```{nb-code}
+```{nb-code} scheme
 (set-cdr! (cdr SCHEMEPATH) (list "/var/modules"))
 ```
 
-```{nb-code}
+```{nb-code} scheme
 SCHEMEPATH
 ```
 
@@ -253,7 +253,7 @@ SCHEMEPATH
 
 Note that you can use the word `lambda` or \lambda and then press [TAB]
 
-```{nb-code}
+```{nb-code} scheme
 (define factorial
   (λ (n)
      (cond
@@ -261,25 +261,25 @@ Note that you can use the word `lambda` or \lambda and then press [TAB]
       (else (* n (factorial (- n 1)))))))
 ```
 
-```{nb-code}
+```{nb-code} scheme
 (factorial 5)
 ```
 
 ## define-syntax
 (define-syntax NAME RULES): a method for creating macros
 
-```{nb-code}
+```{nb-code} scheme
 (define-syntax time 
   [(time ?exp) (let ((start (current-time)))
                  ?exp
                  (- (current-time) start))])
 ```
 
-```{nb-code}
+```{nb-code} scheme
 (time (car '(1 2 3 4)))
 ```
 
-```{nb-code}
+```{nb-code} scheme
 ;;---------------------------------------------------------------------
 ;; collect is like list comprehension in Python
 
@@ -298,19 +298,19 @@ Note that you can use the word `lambda` or \lambda and then press [TAB]
           (filter-map f pred? (cdr values))))))
 ```
 
-```{nb-code}
+```{nb-code} scheme
 (collect (* n n) for n in (range 10))
 ```
 
-```{nb-code}
+```{nb-code} scheme
 (collect (* n n) for n in (range 5 20 3))
 ```
 
-```{nb-code}
+```{nb-code} scheme
 (collect (* n n) for n in (range 10) if (> n 5))
 ```
 
-```{nb-code}
+```{nb-code} scheme
 ;;---------------------------------------------------------------------
 ;; for loops
 
@@ -350,7 +350,7 @@ Note that you can use the word `lambda` or \lambda and then press [TAB]
         (for-iterate2 (+ i 1) (cdr values) f)))))
 ```
 
-```{nb-code}
+```{nb-code} scheme
 (define matrix2d
   '((10 20)
     (30 40)
@@ -364,7 +364,7 @@ Note that you can use the word `lambda` or \lambda and then press [TAB]
     ((190 200 210) (220 230 240))))
 ```
 
-```{nb-code}
+```{nb-code} scheme
 (begin 
  (define hello 0)
  (for 5 times do (set! hello (+ hello 1)))
@@ -372,23 +372,23 @@ Note that you can use the word `lambda` or \lambda and then press [TAB]
  )
 ```
 
-```{nb-code}
+```{nb-code} scheme
 (for sym in '(a b c d) do (define x 1) (set! x sym) (print x))
 ```
 
-```{nb-code}
+```{nb-code} scheme
 (for n in (range 10 20 2) do (print n))
 ```
 
-```{nb-code}
+```{nb-code} scheme
 (for n at (i j) in matrix2d do (print (list n 'coords: i j)))
 ```
 
-```{nb-code}
+```{nb-code} scheme
 (for n at (i j k) in matrix3d do (print (list n 'coords: i j k)))
 ```
 
-```{nb-code}
+```{nb-code} scheme
 (define-syntax scons
   [(scons ?x ?y) (cons ?x (lambda () ?y))])
 
@@ -431,33 +431,33 @@ Note that you can use the word `lambda` or \lambda and then press [TAB]
 (define ! (lambda (n) (nth n facts)))
 ```
 
-```{nb-code}
+```{nb-code} scheme
 (! 5)
 ```
 
-```{nb-code}
+```{nb-code} scheme
 (nth 10 facts)
 ```
 
-```{nb-code}
+```{nb-code} scheme
 (nth 20 fibs)
 ```
 
-```{nb-code}
+```{nb-code} scheme
 (first 30 fibs)
 ```
 
 ## for-each
 (for-each PROCEDURE LIST): apply PROCEDURE to each item in LIST; like `map` but don't return results
 
-```{nb-code}
+```{nb-code} scheme
 (for-each (lambda (n) (print n)) '(3 4 5))
 ```
 
 ## format
 (format STRING ITEM ...): format the string with ITEMS as arguments
 
-```{nb-code}
+```{nb-code} scheme
 (format "This uses formatting ~a ~s ~%" 'apple 'apple)
 ```
 
@@ -467,7 +467,7 @@ Turns a lambda into a Python function.
 
 (func (lambda ...))
 
-```{nb-code}
+```{nb-code} scheme
 (func (lambda (n) n))
 ```
 

--- a/tests/notebooks/mirror/ipynb_to_myst/The flavors of raw cells.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/The flavors of raw cells.mystnb
@@ -1,0 +1,41 @@
+---
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+nbformat: 4
+nbformat_minor: 2
+---
+```{nb-raw}
+---
+raw_mimetype: text/latex
+---
+$1+1$
+```
+```{nb-raw}
+---
+raw_mimetype: text/restructuredtext
+---
+:math:`1+1`
+```
+```{nb-raw}
+---
+raw_mimetype: text/html
+---
+<b>Bold text<b>
+```
+```{nb-raw}
+---
+raw_mimetype: text/markdown
+---
+**Bold text**
+```
+```{nb-raw}
+---
+raw_mimetype: text/x-python
+---
+1 + 1
+```
+```{nb-raw}
+Not formatted
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/The flavors of raw cells.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/The flavors of raw cells.mystnb
@@ -8,37 +8,32 @@ nbformat_minor: 2
 ---
 
 ```{nb-raw}
----
-raw_mimetype: text/latex
----
+:raw_mimetype: text/latex
+
 $1+1$
 ```
 
 ```{nb-raw}
----
-raw_mimetype: text/restructuredtext
----
+:raw_mimetype: text/restructuredtext
+
 :math:`1+1`
 ```
 
 ```{nb-raw}
----
-raw_mimetype: text/html
----
+:raw_mimetype: text/html
+
 <b>Bold text<b>
 ```
 
 ```{nb-raw}
----
-raw_mimetype: text/markdown
----
+:raw_mimetype: text/markdown
+
 **Bold text**
 ```
 
 ```{nb-raw}
----
-raw_mimetype: text/x-python
----
+:raw_mimetype: text/x-python
+
 1 + 1
 ```
 

--- a/tests/notebooks/mirror/ipynb_to_myst/The flavors of raw cells.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/The flavors of raw cells.mystnb
@@ -6,36 +6,42 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 ```{nb-raw}
 ---
 raw_mimetype: text/latex
 ---
 $1+1$
 ```
+
 ```{nb-raw}
 ---
 raw_mimetype: text/restructuredtext
 ---
 :math:`1+1`
 ```
+
 ```{nb-raw}
 ---
 raw_mimetype: text/html
 ---
 <b>Bold text<b>
 ```
+
 ```{nb-raw}
 ---
 raw_mimetype: text/markdown
 ---
 **Bold text**
 ```
+
 ```{nb-raw}
 ---
 raw_mimetype: text/x-python
 ---
 1 + 1
 ```
+
 ```{nb-raw}
 Not formatted
 ```

--- a/tests/notebooks/mirror/ipynb_to_myst/World population.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/World population.mystnb
@@ -1,0 +1,93 @@
+---
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+nbformat: 4
+nbformat_minor: 2
+---
+# A quick insight at world population
+
+## Collecting population data
+
+In the below we retrieve population data from the
+[World Bank](http://www.worldbank.org/)
+using the [wbdata](https://github.com/OliverSherouse/wbdata) python package
+```{nb-code}
+import pandas as pd
+import wbdata as wb
+
+pd.options.display.max_rows = 6
+pd.options.display.max_columns = 20
+```
+Corresponding indicator is found using search method - or, directly,
+the World Bank site.
+```{nb-code}
+wb.search_indicators('Population, total')  # SP.POP.TOTL
+# wb.search_indicators('area')
+# => https://data.worldbank.org/indicator is easier to use
+```
+Now we download the population data
+```{nb-code}
+indicators = {'SP.POP.TOTL': 'Population, total',
+              'AG.SRF.TOTL.K2': 'Surface area (sq. km)',
+              'AG.LND.TOTL.K2': 'Land area (sq. km)',
+              'AG.LND.ARBL.ZS': 'Arable land (% of land area)'}
+data = wb.get_dataframe(indicators, convert_date=True).sort_index()
+data
+```
+World is one of the countries
+```{nb-code}
+data.loc['World']
+```
+Can we classify over continents?
+```{nb-code}
+data.loc[(slice(None), '2017-01-01'), :]['Population, total'].dropna(
+).sort_values().tail(60).index.get_level_values('country')
+```
+Extract zones manually (in order of increasing population)
+```{nb-code}
+zones = ['North America', 'Middle East & North Africa',
+         'Latin America & Caribbean', 'Europe & Central Asia',
+         'Sub-Saharan Africa', 'South Asia',
+         'East Asia & Pacific'][::-1]
+```
+And extract population information (and check total is right)
+```{nb-code}
+population = data.loc[zones]['Population, total'].swaplevel().unstack()
+population = population[zones]
+assert all(data.loc['World']['Population, total'] == population.sum(axis=1))
+```
+## Stacked area plot with matplotlib
+```{nb-code}
+import matplotlib.pyplot as plt
+```
+```{nb-code}
+plt.clf()
+plt.figure(figsize=(10, 5), dpi=100)
+plt.stackplot(population.index, population.values.T / 1e9)
+plt.legend(population.columns, loc='upper left')
+plt.ylabel('Population count (B)')
+plt.show()
+```
+## Stacked bar plot with plotly
+
++++
+Stacked area plots (with cumulated values computed depending on
+selected legends) are
+[on their way](https://github.com/plotly/plotly.js/pull/2960) at Plotly. For
+now we just do a stacked bar plot.
+```{nb-code}
+import plotly.offline as offline
+import plotly.graph_objs as go
+
+offline.init_notebook_mode()
+```
+```{nb-code}
+bars = [go.Bar(x=population.index, y=population[zone], name=zone)
+        for zone in zones]
+fig = go.Figure(data=bars,
+                layout=go.Layout(title='World population',
+                                 barmode='stack'))
+offline.iplot(fig)
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/World population.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/World population.mystnb
@@ -13,6 +13,7 @@ nbformat_minor: 2
 In the below we retrieve population data from the
 [World Bank](http://www.worldbank.org/)
 using the [wbdata](https://github.com/OliverSherouse/wbdata) python package
+
 ```{nb-code}
 import pandas as pd
 import wbdata as wb
@@ -22,12 +23,14 @@ pd.options.display.max_columns = 20
 ```
 Corresponding indicator is found using search method - or, directly,
 the World Bank site.
+
 ```{nb-code}
 wb.search_indicators('Population, total')  # SP.POP.TOTL
 # wb.search_indicators('area')
 # => https://data.worldbank.org/indicator is easier to use
 ```
 Now we download the population data
+
 ```{nb-code}
 indicators = {'SP.POP.TOTL': 'Population, total',
               'AG.SRF.TOTL.K2': 'Surface area (sq. km)',
@@ -37,15 +40,18 @@ data = wb.get_dataframe(indicators, convert_date=True).sort_index()
 data
 ```
 World is one of the countries
+
 ```{nb-code}
 data.loc['World']
 ```
 Can we classify over continents?
+
 ```{nb-code}
 data.loc[(slice(None), '2017-01-01'), :]['Population, total'].dropna(
 ).sort_values().tail(60).index.get_level_values('country')
 ```
 Extract zones manually (in order of increasing population)
+
 ```{nb-code}
 zones = ['North America', 'Middle East & North Africa',
          'Latin America & Caribbean', 'Europe & Central Asia',
@@ -53,15 +59,18 @@ zones = ['North America', 'Middle East & North Africa',
          'East Asia & Pacific'][::-1]
 ```
 And extract population information (and check total is right)
+
 ```{nb-code}
 population = data.loc[zones]['Population, total'].swaplevel().unstack()
 population = population[zones]
 assert all(data.loc['World']['Population, total'] == population.sum(axis=1))
 ```
 ## Stacked area plot with matplotlib
+
 ```{nb-code}
 import matplotlib.pyplot as plt
 ```
+
 ```{nb-code}
 plt.clf()
 plt.figure(figsize=(10, 5), dpi=100)
@@ -77,12 +86,14 @@ Stacked area plots (with cumulated values computed depending on
 selected legends) are
 [on their way](https://github.com/plotly/plotly.js/pull/2960) at Plotly. For
 now we just do a stacked bar plot.
+
 ```{nb-code}
 import plotly.offline as offline
 import plotly.graph_objs as go
 
 offline.init_notebook_mode()
 ```
+
 ```{nb-code}
 bars = [go.Bar(x=population.index, y=population[zone], name=zone)
         for zone in zones]

--- a/tests/notebooks/mirror/ipynb_to_myst/World population.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/World population.mystnb
@@ -15,7 +15,7 @@ In the below we retrieve population data from the
 [World Bank](http://www.worldbank.org/)
 using the [wbdata](https://github.com/OliverSherouse/wbdata) python package
 
-```{nb-code}
+```{nb-code} ipython3
 import pandas as pd
 import wbdata as wb
 
@@ -26,7 +26,7 @@ pd.options.display.max_columns = 20
 Corresponding indicator is found using search method - or, directly,
 the World Bank site.
 
-```{nb-code}
+```{nb-code} ipython3
 wb.search_indicators('Population, total')  # SP.POP.TOTL
 # wb.search_indicators('area')
 # => https://data.worldbank.org/indicator is easier to use
@@ -34,7 +34,7 @@ wb.search_indicators('Population, total')  # SP.POP.TOTL
 
 Now we download the population data
 
-```{nb-code}
+```{nb-code} ipython3
 indicators = {'SP.POP.TOTL': 'Population, total',
               'AG.SRF.TOTL.K2': 'Surface area (sq. km)',
               'AG.LND.TOTL.K2': 'Land area (sq. km)',
@@ -45,20 +45,20 @@ data
 
 World is one of the countries
 
-```{nb-code}
+```{nb-code} ipython3
 data.loc['World']
 ```
 
 Can we classify over continents?
 
-```{nb-code}
+```{nb-code} ipython3
 data.loc[(slice(None), '2017-01-01'), :]['Population, total'].dropna(
 ).sort_values().tail(60).index.get_level_values('country')
 ```
 
 Extract zones manually (in order of increasing population)
 
-```{nb-code}
+```{nb-code} ipython3
 zones = ['North America', 'Middle East & North Africa',
          'Latin America & Caribbean', 'Europe & Central Asia',
          'Sub-Saharan Africa', 'South Asia',
@@ -67,7 +67,7 @@ zones = ['North America', 'Middle East & North Africa',
 
 And extract population information (and check total is right)
 
-```{nb-code}
+```{nb-code} ipython3
 population = data.loc[zones]['Population, total'].swaplevel().unstack()
 population = population[zones]
 assert all(data.loc['World']['Population, total'] == population.sum(axis=1))
@@ -75,11 +75,11 @@ assert all(data.loc['World']['Population, total'] == population.sum(axis=1))
 
 ## Stacked area plot with matplotlib
 
-```{nb-code}
+```{nb-code} ipython3
 import matplotlib.pyplot as plt
 ```
 
-```{nb-code}
+```{nb-code} ipython3
 plt.clf()
 plt.figure(figsize=(10, 5), dpi=100)
 plt.stackplot(population.index, population.values.T / 1e9)
@@ -97,14 +97,14 @@ selected legends) are
 [on their way](https://github.com/plotly/plotly.js/pull/2960) at Plotly. For
 now we just do a stacked bar plot.
 
-```{nb-code}
+```{nb-code} ipython3
 import plotly.offline as offline
 import plotly.graph_objs as go
 
 offline.init_notebook_mode()
 ```
 
-```{nb-code}
+```{nb-code} ipython3
 bars = [go.Bar(x=population.index, y=population[zone], name=zone)
         for zone in zones]
 fig = go.Figure(data=bars,

--- a/tests/notebooks/mirror/ipynb_to_myst/World population.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/World population.mystnb
@@ -6,6 +6,7 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 # A quick insight at world population
 
 ## Collecting population data
@@ -21,6 +22,7 @@ import wbdata as wb
 pd.options.display.max_rows = 6
 pd.options.display.max_columns = 20
 ```
+
 Corresponding indicator is found using search method - or, directly,
 the World Bank site.
 
@@ -29,6 +31,7 @@ wb.search_indicators('Population, total')  # SP.POP.TOTL
 # wb.search_indicators('area')
 # => https://data.worldbank.org/indicator is easier to use
 ```
+
 Now we download the population data
 
 ```{nb-code}
@@ -39,17 +42,20 @@ indicators = {'SP.POP.TOTL': 'Population, total',
 data = wb.get_dataframe(indicators, convert_date=True).sort_index()
 data
 ```
+
 World is one of the countries
 
 ```{nb-code}
 data.loc['World']
 ```
+
 Can we classify over continents?
 
 ```{nb-code}
 data.loc[(slice(None), '2017-01-01'), :]['Population, total'].dropna(
 ).sort_values().tail(60).index.get_level_values('country')
 ```
+
 Extract zones manually (in order of increasing population)
 
 ```{nb-code}
@@ -58,6 +64,7 @@ zones = ['North America', 'Middle East & North Africa',
          'Sub-Saharan Africa', 'South Asia',
          'East Asia & Pacific'][::-1]
 ```
+
 And extract population information (and check total is right)
 
 ```{nb-code}
@@ -65,6 +72,7 @@ population = data.loc[zones]['Population, total'].swaplevel().unstack()
 population = population[zones]
 assert all(data.loc['World']['Population, total'] == population.sum(axis=1))
 ```
+
 ## Stacked area plot with matplotlib
 
 ```{nb-code}
@@ -79,9 +87,11 @@ plt.legend(population.columns, loc='upper left')
 plt.ylabel('Population count (B)')
 plt.show()
 ```
+
 ## Stacked bar plot with plotly
 
 +++
+
 Stacked area plots (with cumulated values computed depending on
 selected legends) are
 [on their way](https://github.com/plotly/plotly.js/pull/2960) at Plotly. For

--- a/tests/notebooks/mirror/ipynb_to_myst/cat_variable.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/cat_variable.mystnb
@@ -6,6 +6,7 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 ```{nb-code}
 cat = 42
 ```

--- a/tests/notebooks/mirror/ipynb_to_myst/cat_variable.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/cat_variable.mystnb
@@ -7,6 +7,6 @@ nbformat: 4
 nbformat_minor: 2
 ---
 
-```{nb-code}
+```{nb-code} ipython3
 cat = 42
 ```

--- a/tests/notebooks/mirror/ipynb_to_myst/cat_variable.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/cat_variable.mystnb
@@ -1,0 +1,11 @@
+---
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+nbformat: 4
+nbformat_minor: 2
+---
+```{nb-code}
+cat = 42
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/convert_to_py_then_test_with_update83.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/convert_to_py_then_test_with_update83.mystnb
@@ -1,0 +1,17 @@
+---
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+nbformat: 4
+nbformat_minor: 2
+---
+```{nb-code}
+%%time
+
+print('asdf')
+```
+Thanks for jupytext!
+```{nb-code}
+
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/convert_to_py_then_test_with_update83.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/convert_to_py_then_test_with_update83.mystnb
@@ -6,12 +6,14 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 ```{nb-code}
 %%time
 
 print('asdf')
 ```
 Thanks for jupytext!
+
 ```{nb-code}
 
 ```

--- a/tests/notebooks/mirror/ipynb_to_myst/convert_to_py_then_test_with_update83.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/convert_to_py_then_test_with_update83.mystnb
@@ -7,7 +7,7 @@ nbformat: 4
 nbformat_minor: 2
 ---
 
-```{nb-code}
+```{nb-code} ipython3
 %%time
 
 print('asdf')
@@ -15,6 +15,6 @@ print('asdf')
 
 Thanks for jupytext!
 
-```{nb-code}
+```{nb-code} ipython3
 
 ```

--- a/tests/notebooks/mirror/ipynb_to_myst/convert_to_py_then_test_with_update83.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/convert_to_py_then_test_with_update83.mystnb
@@ -12,6 +12,7 @@ nbformat_minor: 2
 
 print('asdf')
 ```
+
 Thanks for jupytext!
 
 ```{nb-code}

--- a/tests/notebooks/mirror/ipynb_to_myst/csharp.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/csharp.mystnb
@@ -6,11 +6,13 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 1
 ---
+
 We start with...
 
 ```{nb-code}
 Console.WriteLine("Hello World!");
 ```
+
 Then we do a plot with Plotly, following the [Plotting with XPlot](https://github.com/dotnet/interactive/blob/master/NotebookExamples/csharp/Docs/Plotting%20with%20Xplot.ipynb) example from `dotnet/interactive`:
 
 ```{nb-code}
@@ -27,6 +29,7 @@ var chart = Chart.Plot(new[] {bar});
 chart.WithTitle("A bar plot");
 display(chart);
 ```
+
 We also test the math outputs as in the [Math and Latex](https://github.com/dotnet/interactive/blob/master/NotebookExamples/csharp/Docs/Math%20and%20LaTeX.ipynb) example:
 
 ```{nb-code}

--- a/tests/notebooks/mirror/ipynb_to_myst/csharp.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/csharp.mystnb
@@ -7,10 +7,12 @@ nbformat: 4
 nbformat_minor: 1
 ---
 We start with...
+
 ```{nb-code}
 Console.WriteLine("Hello World!");
 ```
 Then we do a plot with Plotly, following the [Plotting with XPlot](https://github.com/dotnet/interactive/blob/master/NotebookExamples/csharp/Docs/Plotting%20with%20Xplot.ipynb) example from `dotnet/interactive`:
+
 ```{nb-code}
 using XPlot.Plotly;
 
@@ -26,9 +28,11 @@ chart.WithTitle("A bar plot");
 display(chart);
 ```
 We also test the math outputs as in the [Math and Latex](https://github.com/dotnet/interactive/blob/master/NotebookExamples/csharp/Docs/Math%20and%20LaTeX.ipynb) example:
+
 ```{nb-code}
 (LaTeXString)@"\begin{align} e^{i \pi} = -1\end{align}"
 ```
+
 ```{nb-code}
 (MathString)@"e^{i \pi} = -1"
 ```

--- a/tests/notebooks/mirror/ipynb_to_myst/csharp.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/csharp.mystnb
@@ -1,0 +1,34 @@
+---
+kernelspec:
+  display_name: .NET (C#)
+  language: C#
+  name: .net-csharp
+nbformat: 4
+nbformat_minor: 1
+---
+We start with...
+```{nb-code}
+Console.WriteLine("Hello World!");
+```
+Then we do a plot with Plotly, following the [Plotting with XPlot](https://github.com/dotnet/interactive/blob/master/NotebookExamples/csharp/Docs/Plotting%20with%20Xplot.ipynb) example from `dotnet/interactive`:
+```{nb-code}
+using XPlot.Plotly;
+
+var bar = new Graph.Bar
+{
+    name = "Bar",
+    x = new[] {'A', 'B', 'C'},
+    y = new[] {1, 3, 2}
+};
+
+var chart = Chart.Plot(new[] {bar});
+chart.WithTitle("A bar plot");
+display(chart);
+```
+We also test the math outputs as in the [Math and Latex](https://github.com/dotnet/interactive/blob/master/NotebookExamples/csharp/Docs/Math%20and%20LaTeX.ipynb) example:
+```{nb-code}
+(LaTeXString)@"\begin{align} e^{i \pi} = -1\end{align}"
+```
+```{nb-code}
+(MathString)@"e^{i \pi} = -1"
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/csharp.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/csharp.mystnb
@@ -9,13 +9,13 @@ nbformat_minor: 1
 
 We start with...
 
-```{nb-code}
+```{nb-code} csharp
 Console.WriteLine("Hello World!");
 ```
 
 Then we do a plot with Plotly, following the [Plotting with XPlot](https://github.com/dotnet/interactive/blob/master/NotebookExamples/csharp/Docs/Plotting%20with%20Xplot.ipynb) example from `dotnet/interactive`:
 
-```{nb-code}
+```{nb-code} csharp
 using XPlot.Plotly;
 
 var bar = new Graph.Bar
@@ -32,10 +32,10 @@ display(chart);
 
 We also test the math outputs as in the [Math and Latex](https://github.com/dotnet/interactive/blob/master/NotebookExamples/csharp/Docs/Math%20and%20LaTeX.ipynb) example:
 
-```{nb-code}
+```{nb-code} csharp
 (LaTeXString)@"\begin{align} e^{i \pi} = -1\end{align}"
 ```
 
-```{nb-code}
+```{nb-code} csharp
 (MathString)@"e^{i \pi} = -1"
 ```

--- a/tests/notebooks/mirror/ipynb_to_myst/demo_gdl_fbp.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/demo_gdl_fbp.mystnb
@@ -6,9 +6,11 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 ## GDL demo notebook
 
 +++
+
 Demonstration of GDL [(gnudatalanguage)](https://github.com/gnudatalanguage/gdl)
 
 This notebook creates a Shepp-Logan phantom, projects it and then performs an FBP reconstruction.
@@ -69,6 +71,7 @@ phantom = shepplogan()
 window, 0, xsize=256, ysize=256
 tvscl, phantom > 0.95
 ```
+
 Now we define simple forward and backprojection functions:
 
 ```{nb-code}
@@ -106,6 +109,7 @@ function back, sino, angle
 
 end
 ```
+
 This allows us to create a sinogram:
 
 ```{nb-code}
@@ -114,6 +118,7 @@ sino = proj(phantom, angles)
 window, 0, xsize=256, ysize=360
 tvscl, sino
 ```
+
 On this we can apply a simple FBP reconstruction:
 
 ```{nb-code}
@@ -156,4 +161,5 @@ window, 0, xsize=512, ysize=256
 
 tvscl, [phantom, reconstruction] > 0.8
 ```
+
 ### The end

--- a/tests/notebooks/mirror/ipynb_to_myst/demo_gdl_fbp.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/demo_gdl_fbp.mystnb
@@ -12,6 +12,7 @@ nbformat_minor: 2
 Demonstration of GDL [(gnudatalanguage)](https://github.com/gnudatalanguage/gdl)
 
 This notebook creates a Shepp-Logan phantom, projects it and then performs an FBP reconstruction.
+
 ```{nb-code}
 ;; L.A. Shepp and B.F. Logan, “The Fourier reconstruction of a head section,”
 ;; IEEE Trans. Nucl. Sci. 21(3), 21–43 (1974).
@@ -57,16 +58,19 @@ function shepplogan, size = size
   
 end
 ```
+
 ```{nb-code}
 ;; Enable inline plotting
 !inline=1
 ```
+
 ```{nb-code}
 phantom = shepplogan()
 window, 0, xsize=256, ysize=256
 tvscl, phantom > 0.95
 ```
 Now we define simple forward and backprojection functions:
+
 ```{nb-code}
 function proj, image, angle
 
@@ -85,6 +89,7 @@ function proj, image, angle
     
 end
 ```
+
 ```{nb-code}
 function back, sino, angle
 
@@ -102,6 +107,7 @@ function back, sino, angle
 end
 ```
 This allows us to create a sinogram:
+
 ```{nb-code}
 angles = findgen(360)
 sino = proj(phantom, angles)
@@ -109,6 +115,7 @@ window, 0, xsize=256, ysize=360
 tvscl, sino
 ```
 On this we can apply a simple FBP reconstruction:
+
 ```{nb-code}
 ;; G.L. Zeng, “Revisit of the Ramp Filter,”
 ;; IEEE Trans. Nucl. Sci. 62(1), 131–136 (2015).
@@ -142,6 +149,7 @@ function fbp, sino, angles
 
 end
 ```
+
 ```{nb-code}
 reconstruction = fbp(sino, angles)
 window, 0, xsize=512, ysize=256

--- a/tests/notebooks/mirror/ipynb_to_myst/demo_gdl_fbp.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/demo_gdl_fbp.mystnb
@@ -1,0 +1,151 @@
+---
+kernelspec:
+  display_name: IDL [conda env:gdl] *
+  language: IDL
+  name: conda-env-gdl-idl
+nbformat: 4
+nbformat_minor: 2
+---
+## GDL demo notebook
+
++++
+Demonstration of GDL [(gnudatalanguage)](https://github.com/gnudatalanguage/gdl)
+
+This notebook creates a Shepp-Logan phantom, projects it and then performs an FBP reconstruction.
+```{nb-code}
+;; L.A. Shepp and B.F. Logan, “The Fourier reconstruction of a head section,”
+;; IEEE Trans. Nucl. Sci. 21(3), 21–43 (1974).
+function shepplogan, size = size
+
+  if NOT keyword_set(size) then size = 256
+
+  phantom = fltarr(size,size)
+
+  tmp  = (findgen(size)-((size-1)/2.0)) / (size/2.0)
+  xcor = rebin(tmp,size,size)
+  ycor = rebin(transpose(tmp),size,size)
+  tmp  = fltarr(size,size)
+  
+  aa={cx: 0.0,  cy: 0.0,    maj:0.69,   min:0.92,  theta:  0.0, val: 2.0 }
+  bb={cx: 0.0,  cy:-0.0184, maj:0.6624, min:0.874, theta:  0.0, val:-0.98}
+  cc={cx: 0.22, cy: 0.0,    maj:0.11,   min:0.31,  theta:-18.0, val:-0.02}
+  dd={cx:-0.22, cy: 0.0,    maj:0.16,   min:0.41,  theta: 18.0, val:-0.02}
+  ee={cx: 0.0,  cy: 0.35,   maj:0.21,   min:0.25,  theta:  0.0, val:-0.01}
+  ff={cx: 0.0,  cy: 0.1,    maj:0.046,  min:0.046, theta:  0.0, val:-0.01}
+  gg={cx: 0.0,  cy:-0.1,    maj:0.046,  min:0.046, theta:  0.0, val:-0.01}
+  hh={cx:-0.08, cy:-0.605,  maj:0.046,  min:0.023, theta:  0.0, val:-0.01}
+  ii={cx: 0.0,  cy:-0.605,  maj:0.023,  min:0.023, theta:  0.0, val:-0.01}
+  jj={cx: 0.06, cy:-0.605,  maj:0.023,  min:0.046, theta:  0.0, val:-0.01}
+
+  list = [aa,bb,cc,dd,ee,ff,gg,hh,ii,jj]
+  for n = 0, n_elements(list)-1 do begin
+
+     tmp = ((xcor-list[n].cx) / list[n].maj)^2 $
+           + ((ycor-list[n].cy) / list[n].min)^2
+     
+     if list[n].theta NE 0 then begin
+        nx = (size-1) * (list[n].cx + 1) / 2
+        ny = (size-1) * (list[n].cy + 1) / 2
+        tmp = rot(tmp, -list[n].theta, 1, nx, ny, /interp, /pivot)
+     endif
+     
+     phantom[where(tmp LE 1.0)] += list[n].val
+     
+  endfor
+  
+  return, phantom < 1.1
+  
+end
+```
+```{nb-code}
+;; Enable inline plotting
+!inline=1
+```
+```{nb-code}
+phantom = shepplogan()
+window, 0, xsize=256, ysize=256
+tvscl, phantom > 0.95
+```
+Now we define simple forward and backprojection functions:
+```{nb-code}
+function proj, image, angle
+
+    sino_size_x = max(size(image,/dim))
+    sino_size_y = n_elements(angle)
+
+    sino = fltarr(sino_size_x, sino_size_y)
+    
+    for aa=0, n_elements(angle)-1 do begin
+    
+        sino[*,aa] = total(rot(image, angle[aa], /interp), 2)
+    
+    endfor
+
+    return, sino
+    
+end
+```
+```{nb-code}
+function back, sino, angle
+
+    image_size = n_elements(sino[*,0])
+    image = fltarr(image_size,image_size)
+
+    for aa=0, n_elements(angle)-1 do begin
+    
+        image += rot(rebin(sino[*,aa],[image_size,image_size]), -angle[aa], /interp)
+    
+    endfor
+
+    return, image / n_elements(angle)
+
+end
+```
+This allows us to create a sinogram:
+```{nb-code}
+angles = findgen(360)
+sino = proj(phantom, angles)
+window, 0, xsize=256, ysize=360
+tvscl, sino
+```
+On this we can apply a simple FBP reconstruction:
+```{nb-code}
+;; G.L. Zeng, “Revisit of the Ramp Filter,”
+;; IEEE Trans. Nucl. Sci. 62(1), 131–136 (2015).
+function fbp, sino, angles
+  
+  ntot = n_elements(sino[*,0])
+  nang = n_elements(sino[0,*])
+  npos = ntot / 2 + 1           ; integer division needed !
+  nneg = ntot - npos
+
+  freq = findgen(ntot)
+  freq[npos:ntot-1] = REVERSE(freq[1:nneg])
+  freq[0] = 1
+
+  filter = -1 / (!pi * freq)^2
+  filter[where(freq mod 2 EQ 0)] *= -0.0
+  filter[0] = 0.25
+
+  filter = abs(fft(filter)) * ntot
+  filter[ntot/4:ntot/4+ntot/2-1] *= 0.0
+  filter = rebin(filter,ntot,nang)
+
+  ;; apply filter to the sinogram
+  fsino  = fft(sino,  dim=1)
+  fsino *= filter
+  fsino  = fft(fsino, dim=1, /overwrite, /inverse)
+  fsino  = !pi * real_part(fsino)
+
+  ;; backproject the filtered sinogram
+  return, back(fsino, angles)
+
+end
+```
+```{nb-code}
+reconstruction = fbp(sino, angles)
+window, 0, xsize=512, ysize=256
+
+tvscl, [phantom, reconstruction] > 0.8
+```
+### The end

--- a/tests/notebooks/mirror/ipynb_to_myst/evcxr_jupyter_tour.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/evcxr_jupyter_tour.mystnb
@@ -1,0 +1,156 @@
+---
+kernelspec:
+  display_name: Rust
+  language: rust
+  name: rust
+nbformat: 4
+nbformat_minor: 2
+---
+# Tour of the EvCxR Jupyter Kernel
+For those not already familiar with Jupyter notebook, it lets you write code into "cells" like the box below. Cells can alternatively contain markdown, like this text here. Each code cell is compiled and executed separately, but variables, defined functions etc persist between cells.
+
+## Printing to outputs and evaluating expressions
+Lets print something to stdout and stderr then return a final expression to see how that's presented. Note that stdout and stderr are separate streams, so may not appear in the same order is their respective print statements.
+```{nb-code}
+println!("Hello world");
+eprintln!("Hello error");
+format!("Hello {}", "world")
+```
+## Assigning and making use of variables
+We define a variable `message`, then in the subsequent cell, modify the string and finally print it out. We could also do all this in the one cell if we wanted.
+```{nb-code}
+let mut message = "Hello ".to_owned();
+```
+```{nb-code}
+message.push_str("world!");
+```
+```{nb-code}
+message
+```
+## Defining and redefining functions
+Next we'll define a function
+```{nb-code}
+pub fn fib(x: i32) -> i32 {
+    if x <= 2 {0} else {fib(x - 2) + fib(x - 1)}
+}
+```
+```{nb-code}
+(1..13).map(fib).collect::<Vec<i32>>()
+```
+Hmm, that doesn't look right. Lets redefine the function. In practice, we'd go back and edit the function above and reevalute it, but here, lets redefine it in a separate cell.
+```{nb-code}
+pub fn fib(x: i32) -> i32 {
+    if x <= 2 {2} else {fib(x - 2) + fib(x - 1)}
+}
+```
+```{nb-code}
+let values = (1..13).map(fib).collect::<Vec<i32>>();
+values
+```
+## Spawning a separate thread and communicating with it
+We can spawn a thread to do stuff in the background, then continue executing code in other cells.
+```{nb-code}
+use std::sync::{Mutex, Arc};
+let counter = Arc::new(Mutex::new(0i32));
+std::thread::spawn({
+    let counter = Arc::clone(&counter);
+    move || {
+        for i in 1..300 {
+            *counter.lock().unwrap() += 1;
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+}});
+```
+```{nb-code}
+*counter.lock().unwrap()
+```
+```{nb-code}
+*counter.lock().unwrap()
+```
+## Loading external crates
+We can load external crates. This one takes a while to compile, but once it's compiled, subsequent cells shouldn't need to recompile it, so it should be much quicker.
+```{nb-code}
+
+:dep base64 = "0.10.1"
+base64::encode(&vec![1, 2, 3, 4])
+```
+## Customizing how types are displayed
+We can also customize how our types are displayed, including presenting them as HTML. Here's an example where we define a custom display function for a type `Matrix`.
+```{nb-code}
+use std::fmt::Debug;
+pub struct Matrix<T> {pub values: Vec<T>, pub row_size: usize}
+impl<T: Debug> Matrix<T> {
+    pub fn evcxr_display(&self) {
+        let mut html = String::new();
+        html.push_str("<table>");
+        for r in 0..(self.values.len() / self.row_size) {
+            html.push_str("<tr>");
+            for c in 0..self.row_size {
+                html.push_str("<td>");
+                html.push_str(&format!("{:?}", self.values[r * self.row_size + c]));
+                html.push_str("</td>");
+            }
+            html.push_str("</tr>");            
+        }
+        html.push_str("</table>");
+        println!("EVCXR_BEGIN_CONTENT text/html\n{}\nEVCXR_END_CONTENT", html);
+    }
+}
+```
+```{nb-code}
+let m = Matrix {values: vec![1,2,3,4,5,6,7,8,9], row_size: 3};
+m
+```
+We can also return images, we just need to base64 encode them. First, we set up code for displaying RGB and grayscale images.
+```{nb-code}
+extern crate image;
+extern crate base64;
+pub trait EvcxrResult {fn evcxr_display(&self);}
+impl EvcxrResult for image::RgbImage {
+    fn evcxr_display(&self) {
+        let mut buffer = Vec::new();
+        image::png::PNGEncoder::new(&mut buffer).encode(&**self, self.width(), self.height(),
+            image::ColorType::RGB(8)).unwrap();
+        let img = base64::encode(&buffer);
+        println!("EVCXR_BEGIN_CONTENT image/png\n{}\nEVCXR_END_CONTENT", img);        
+    }
+}
+impl EvcxrResult for image::GrayImage {
+    fn evcxr_display(&self) {
+        let mut buffer = Vec::new();
+        image::png::PNGEncoder::new(&mut buffer).encode(&**self, self.width(), self.height(),
+            image::ColorType::Gray(8)).unwrap();
+        let img = base64::encode(&buffer);
+        println!("EVCXR_BEGIN_CONTENT image/png\n{}\nEVCXR_END_CONTENT", img);        
+    }
+}
+```
+```{nb-code}
+image::ImageBuffer::from_fn(256, 256, |x, y| {
+    if (x as i32 - y as i32).abs() < 3 {
+        image::Rgb([0, 0, 255])
+    } else {
+        image::Rgb([0, 0, 0])
+    }
+})
+```
+## Display of compilation errors
+Here's how compilation errors are presented. Here we forgot an & and passed a String instead of an &str.
+```{nb-code}
+let mut s = String::new();
+s.push_str(format!("foo {}", 42));
+```
+## Seeing what variables have been defined
+We can print a table of defined variables and their types with the :vars command.
+```{nb-code}
+
+:vars
+```
+Other built-in commands can be found via :help
+```{nb-code}
+
+:help
+```
+```{nb-code}
+
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/evcxr_jupyter_tour.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/evcxr_jupyter_tour.mystnb
@@ -11,6 +11,7 @@ For those not already familiar with Jupyter notebook, it lets you write code int
 
 ## Printing to outputs and evaluating expressions
 Lets print something to stdout and stderr then return a final expression to see how that's presented. Note that stdout and stderr are separate streams, so may not appear in the same order is their respective print statements.
+
 ```{nb-code}
 println!("Hello world");
 eprintln!("Hello error");
@@ -18,37 +19,45 @@ format!("Hello {}", "world")
 ```
 ## Assigning and making use of variables
 We define a variable `message`, then in the subsequent cell, modify the string and finally print it out. We could also do all this in the one cell if we wanted.
+
 ```{nb-code}
 let mut message = "Hello ".to_owned();
 ```
+
 ```{nb-code}
 message.push_str("world!");
 ```
+
 ```{nb-code}
 message
 ```
 ## Defining and redefining functions
 Next we'll define a function
+
 ```{nb-code}
 pub fn fib(x: i32) -> i32 {
     if x <= 2 {0} else {fib(x - 2) + fib(x - 1)}
 }
 ```
+
 ```{nb-code}
 (1..13).map(fib).collect::<Vec<i32>>()
 ```
 Hmm, that doesn't look right. Lets redefine the function. In practice, we'd go back and edit the function above and reevalute it, but here, lets redefine it in a separate cell.
+
 ```{nb-code}
 pub fn fib(x: i32) -> i32 {
     if x <= 2 {2} else {fib(x - 2) + fib(x - 1)}
 }
 ```
+
 ```{nb-code}
 let values = (1..13).map(fib).collect::<Vec<i32>>();
 values
 ```
 ## Spawning a separate thread and communicating with it
 We can spawn a thread to do stuff in the background, then continue executing code in other cells.
+
 ```{nb-code}
 use std::sync::{Mutex, Arc};
 let counter = Arc::new(Mutex::new(0i32));
@@ -61,14 +70,17 @@ std::thread::spawn({
         }
 }});
 ```
+
 ```{nb-code}
 *counter.lock().unwrap()
 ```
+
 ```{nb-code}
 *counter.lock().unwrap()
 ```
 ## Loading external crates
 We can load external crates. This one takes a while to compile, but once it's compiled, subsequent cells shouldn't need to recompile it, so it should be much quicker.
+
 ```{nb-code}
 
 :dep base64 = "0.10.1"
@@ -76,6 +88,7 @@ base64::encode(&vec![1, 2, 3, 4])
 ```
 ## Customizing how types are displayed
 We can also customize how our types are displayed, including presenting them as HTML. Here's an example where we define a custom display function for a type `Matrix`.
+
 ```{nb-code}
 use std::fmt::Debug;
 pub struct Matrix<T> {pub values: Vec<T>, pub row_size: usize}
@@ -97,11 +110,13 @@ impl<T: Debug> Matrix<T> {
     }
 }
 ```
+
 ```{nb-code}
 let m = Matrix {values: vec![1,2,3,4,5,6,7,8,9], row_size: 3};
 m
 ```
 We can also return images, we just need to base64 encode them. First, we set up code for displaying RGB and grayscale images.
+
 ```{nb-code}
 extern crate image;
 extern crate base64;
@@ -125,6 +140,7 @@ impl EvcxrResult for image::GrayImage {
     }
 }
 ```
+
 ```{nb-code}
 image::ImageBuffer::from_fn(256, 256, |x, y| {
     if (x as i32 - y as i32).abs() < 3 {
@@ -136,21 +152,25 @@ image::ImageBuffer::from_fn(256, 256, |x, y| {
 ```
 ## Display of compilation errors
 Here's how compilation errors are presented. Here we forgot an & and passed a String instead of an &str.
+
 ```{nb-code}
 let mut s = String::new();
 s.push_str(format!("foo {}", 42));
 ```
 ## Seeing what variables have been defined
 We can print a table of defined variables and their types with the :vars command.
+
 ```{nb-code}
 
 :vars
 ```
 Other built-in commands can be found via :help
+
 ```{nb-code}
 
 :help
 ```
+
 ```{nb-code}
 
 ```

--- a/tests/notebooks/mirror/ipynb_to_myst/evcxr_jupyter_tour.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/evcxr_jupyter_tour.mystnb
@@ -6,6 +6,7 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 # Tour of the EvCxR Jupyter Kernel
 For those not already familiar with Jupyter notebook, it lets you write code into "cells" like the box below. Cells can alternatively contain markdown, like this text here. Each code cell is compiled and executed separately, but variables, defined functions etc persist between cells.
 
@@ -17,6 +18,7 @@ println!("Hello world");
 eprintln!("Hello error");
 format!("Hello {}", "world")
 ```
+
 ## Assigning and making use of variables
 We define a variable `message`, then in the subsequent cell, modify the string and finally print it out. We could also do all this in the one cell if we wanted.
 
@@ -31,6 +33,7 @@ message.push_str("world!");
 ```{nb-code}
 message
 ```
+
 ## Defining and redefining functions
 Next we'll define a function
 
@@ -43,6 +46,7 @@ pub fn fib(x: i32) -> i32 {
 ```{nb-code}
 (1..13).map(fib).collect::<Vec<i32>>()
 ```
+
 Hmm, that doesn't look right. Lets redefine the function. In practice, we'd go back and edit the function above and reevalute it, but here, lets redefine it in a separate cell.
 
 ```{nb-code}
@@ -55,6 +59,7 @@ pub fn fib(x: i32) -> i32 {
 let values = (1..13).map(fib).collect::<Vec<i32>>();
 values
 ```
+
 ## Spawning a separate thread and communicating with it
 We can spawn a thread to do stuff in the background, then continue executing code in other cells.
 
@@ -78,6 +83,7 @@ std::thread::spawn({
 ```{nb-code}
 *counter.lock().unwrap()
 ```
+
 ## Loading external crates
 We can load external crates. This one takes a while to compile, but once it's compiled, subsequent cells shouldn't need to recompile it, so it should be much quicker.
 
@@ -86,6 +92,7 @@ We can load external crates. This one takes a while to compile, but once it's co
 :dep base64 = "0.10.1"
 base64::encode(&vec![1, 2, 3, 4])
 ```
+
 ## Customizing how types are displayed
 We can also customize how our types are displayed, including presenting them as HTML. Here's an example where we define a custom display function for a type `Matrix`.
 
@@ -115,6 +122,7 @@ impl<T: Debug> Matrix<T> {
 let m = Matrix {values: vec![1,2,3,4,5,6,7,8,9], row_size: 3};
 m
 ```
+
 We can also return images, we just need to base64 encode them. First, we set up code for displaying RGB and grayscale images.
 
 ```{nb-code}
@@ -150,6 +158,7 @@ image::ImageBuffer::from_fn(256, 256, |x, y| {
     }
 })
 ```
+
 ## Display of compilation errors
 Here's how compilation errors are presented. Here we forgot an & and passed a String instead of an &str.
 
@@ -157,6 +166,7 @@ Here's how compilation errors are presented. Here we forgot an & and passed a St
 let mut s = String::new();
 s.push_str(format!("foo {}", 42));
 ```
+
 ## Seeing what variables have been defined
 We can print a table of defined variables and their types with the :vars command.
 
@@ -164,6 +174,7 @@ We can print a table of defined variables and their types with the :vars command
 
 :vars
 ```
+
 Other built-in commands can be found via :help
 
 ```{nb-code}

--- a/tests/notebooks/mirror/ipynb_to_myst/frozen_cell.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/frozen_cell.mystnb
@@ -1,0 +1,22 @@
+---
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+nbformat: 4
+nbformat_minor: 2
+---
+```{nb-code}
+# This is an unfrozen cell. Works as usual.
+print("I'm a regular cell so I run and print!")
+```
+```{nb-code}
+---
+deletable: false
+editable: false
+run_control:
+  frozen: true
+---
+# This is an frozen cell
+print("I'm frozen so Im not executed :(")
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/frozen_cell.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/frozen_cell.mystnb
@@ -6,10 +6,12 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 ```{nb-code}
 # This is an unfrozen cell. Works as usual.
 print("I'm a regular cell so I run and print!")
 ```
+
 ```{nb-code}
 ---
 deletable: false

--- a/tests/notebooks/mirror/ipynb_to_myst/frozen_cell.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/frozen_cell.mystnb
@@ -7,12 +7,12 @@ nbformat: 4
 nbformat_minor: 2
 ---
 
-```{nb-code}
+```{nb-code} ipython3
 # This is an unfrozen cell. Works as usual.
 print("I'm a regular cell so I run and print!")
 ```
 
-```{nb-code}
+```{nb-code} ipython3
 ---
 deletable: false
 editable: false

--- a/tests/notebooks/mirror/ipynb_to_myst/fsharp.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/fsharp.mystnb
@@ -9,11 +9,11 @@ nbformat_minor: 2
 
 This notebook was inspired by [Plottting with XPlot](https://github.com/dotnet/interactive/blob/master/NotebookExamples/fsharp/Docs/Plotting%20with%20Xplot.ipynb).
 
-```{nb-code}
+```{nb-code} fsharp
 open XPlot.Plotly
 ```
 
-```{nb-code}
+```{nb-code} fsharp
 let bar =
     Bar(
         name = "Bar 1",

--- a/tests/notebooks/mirror/ipynb_to_myst/fsharp.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/fsharp.mystnb
@@ -1,0 +1,23 @@
+---
+kernelspec:
+  display_name: .NET (F#)
+  language: F#
+  name: .net-fsharp
+nbformat: 4
+nbformat_minor: 2
+---
+This notebook was inspired by [Plottting with XPlot](https://github.com/dotnet/interactive/blob/master/NotebookExamples/fsharp/Docs/Plotting%20with%20Xplot.ipynb).
+```{nb-code}
+open XPlot.Plotly
+```
+```{nb-code}
+let bar =
+    Bar(
+        name = "Bar 1",
+        x = ["A"; "B"; "C"],
+        y = [1; 3; 2])
+
+[bar]
+|> Chart.Plot
+|> Chart.WithTitle "A sample bar plot"
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/fsharp.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/fsharp.mystnb
@@ -7,9 +7,11 @@ nbformat: 4
 nbformat_minor: 2
 ---
 This notebook was inspired by [Plottting with XPlot](https://github.com/dotnet/interactive/blob/master/NotebookExamples/fsharp/Docs/Plotting%20with%20Xplot.ipynb).
+
 ```{nb-code}
 open XPlot.Plotly
 ```
+
 ```{nb-code}
 let bar =
     Bar(

--- a/tests/notebooks/mirror/ipynb_to_myst/fsharp.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/fsharp.mystnb
@@ -6,6 +6,7 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 This notebook was inspired by [Plottting with XPlot](https://github.com/dotnet/interactive/blob/master/NotebookExamples/fsharp/Docs/Plotting%20with%20Xplot.ipynb).
 
 ```{nb-code}

--- a/tests/notebooks/mirror/ipynb_to_myst/html-demo.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/html-demo.mystnb
@@ -1,0 +1,95 @@
+---
+kernelspec:
+  display_name: Clojure
+  language: clojure
+  name: clojure
+nbformat: 4
+nbformat_minor: 2
+---
+
+# Clojupyter Demo
+
+This example notebook is from the [Clojupyter](https://github.com/clojupyter/clojupyter/blob/1637f6b2557f01db1e35bae5389bc38522eefe9a/examples/html-demo.ipynb) project.
+This notebook demonstrates some of the more advanced features of Clojupyter.
+
++++
+
+## Displaying HTML
+
+To display HTML, you'll need to require a clojupyter helper function to change the cell output
+
+```{nb-code}
+(require '[clojupyter.misc.display :as display])
+```
+
+```{nb-code}
+(println ">> should print some text")
+;; displaying html
+(display/hiccup-html 
+    [:ul 
+     [:li "a " [:i "emphatic"] " idea"]
+     [:li "a " [:b "bold"] " idea"]
+     [:li "an " [:span {:style "text-decoration: underline;"} "important"] " idea"]])
+```
+
+We can also use this to render SVG:
+
+```{nb-code}
+(display/hiccup-html
+    [:svg {:height 100 :width 100 :xmlns "http://www.w3.org/2000/svg"}
+            [:circle {:cx 50 :cy 40 :r 40 :fill "red"}]])
+```
+
+## Adding External Clojure Dependencies 
+
+You can fetch external Clojure dependcies using the `clojupyter.misc.helper` namespace. 
+
+```{nb-code}
+(require '[clojupyter.misc.helper :as helper])
+```
+
+```{nb-code}
+(helper/add-dependencies '[org.clojure/data.json "0.2.6"])
+(require '[clojure.data.json :as json])
+```
+
+```{nb-code}
+(json/write-str {:a 1 :b [2, 3] :c "c"})
+```
+
+## Adding External Javascript Dependency
+
+Since you can render arbitrary HTML using `display/hiccup-html`, it's pretty easy to use external Javascript libraries to do things like generate charts. Here's an example using [Highcharts](https://www.highcharts.com/).
+
+First, we use a cell to add javascript to the running notebook:
+
+```{nb-code}
+(helper/add-javascript "https://code.highcharts.com/highcharts.js")
+```
+
+Now we define a function which takes Clojure data and returns hiccup HTML to display:
+
+```{nb-code}
+(defn plot-highchart [highchart-json]
+  (let [id (str (java.util.UUID/randomUUID))
+        code (format "Highcharts.chart('%s', %s );" id, (json/write-str highchart-json))]
+      (display/hiccup-html 
+        [:div [:div {:id id :style {:background-color "red"}}]
+                   [:script code]])))
+```
+
+Now we can make generate interactive plots (try hovering over plot):
+
+```{nb-code}
+(def raw-data (map #(+ (* 22 (+ % (Math/random)) 78)) (range)))
+(def data-1 (take 500 raw-data))
+(def data-2 (take 500 (drop 500 raw-data)))
+
+(plot-highchart {:chart {:type "line"}
+                 :title {:text "Plot of random data"}
+                 :series [{:data data-1} {:data data-2}]})
+```
+
+```{nb-code}
+
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/ijavascript.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/ijavascript.mystnb
@@ -7,28 +7,35 @@ nbformat: 4
 nbformat_minor: 2
 ---
 ## A notebook that uses IJavascript kernel
+
 ```{nb-code}
 let x = 5;
 const y = 6;
 var z = 10;
 ```
+
 ```{nb-code}
 x + y;
 ```
+
 ```{nb-code}
 function add(num1, num2) {
     return num1 + num2
 }
 ```
+
 ```{nb-code}
 add(x, y);
 ```
+
 ```{nb-code}
 const arrowAdd = (num1, num2) => num1 + num2;
 ```
+
 ```{nb-code}
 arrowAdd(x, y);
 ```
+
 ```{nb-code}
 const myCar = {
     color: "blue",
@@ -38,20 +45,25 @@ const myCar = {
     doors: [1,2,3,4]
 }
 ```
+
 ```{nb-code}
 console.log("color:", myCar.color);
 ```
+
 ```{nb-code}
 console.log("start:", myCar.start());
 ```
+
 ```{nb-code}
 for (let door of myCar.doors) {
     console.log("I'm door", door)
 }
 ```
+
 ```{nb-code}
 myCar;
 ```
+
 ```{nb-code}
 class User {
   constructor(name){
@@ -62,6 +74,7 @@ class User {
   }
 }
 ```
+
 ```{nb-code}
 let John = new User("John");
 John.sayHello();

--- a/tests/notebooks/mirror/ipynb_to_myst/ijavascript.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/ijavascript.mystnb
@@ -6,6 +6,7 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 ## A notebook that uses IJavascript kernel
 
 ```{nb-code}

--- a/tests/notebooks/mirror/ipynb_to_myst/ijavascript.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/ijavascript.mystnb
@@ -1,0 +1,68 @@
+---
+kernelspec:
+  display_name: Javascript (Node.js)
+  language: javascript
+  name: javascript
+nbformat: 4
+nbformat_minor: 2
+---
+## A notebook that uses IJavascript kernel
+```{nb-code}
+let x = 5;
+const y = 6;
+var z = 10;
+```
+```{nb-code}
+x + y;
+```
+```{nb-code}
+function add(num1, num2) {
+    return num1 + num2
+}
+```
+```{nb-code}
+add(x, y);
+```
+```{nb-code}
+const arrowAdd = (num1, num2) => num1 + num2;
+```
+```{nb-code}
+arrowAdd(x, y);
+```
+```{nb-code}
+const myCar = {
+    color: "blue",
+    weight: 850,
+    model: "fiat",
+    start: () => "car started!",
+    doors: [1,2,3,4]
+}
+```
+```{nb-code}
+console.log("color:", myCar.color);
+```
+```{nb-code}
+console.log("start:", myCar.start());
+```
+```{nb-code}
+for (let door of myCar.doors) {
+    console.log("I'm door", door)
+}
+```
+```{nb-code}
+myCar;
+```
+```{nb-code}
+class User {
+  constructor(name){
+    this.name = name;
+  }
+  sayHello(){
+    return "Hello, I'm " + this.name;
+  }
+}
+```
+```{nb-code}
+let John = new User("John");
+John.sayHello();
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/ir_notebook.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/ir_notebook.mystnb
@@ -9,14 +9,14 @@ nbformat_minor: 2
 
 This is a jupyter notebook that uses the IR kernel.
 
-```{nb-code}
+```{nb-code} r
 sum(1:10)
 ```
 
-```{nb-code}
+```{nb-code} r
 plot(cars)
 ```
 
-```{nb-code}
+```{nb-code} r
 
 ```

--- a/tests/notebooks/mirror/ipynb_to_myst/ir_notebook.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/ir_notebook.mystnb
@@ -1,0 +1,18 @@
+---
+kernelspec:
+  display_name: R
+  language: R
+  name: ir
+nbformat: 4
+nbformat_minor: 2
+---
+This is a jupyter notebook that uses the IR kernel.
+```{nb-code}
+sum(1:10)
+```
+```{nb-code}
+plot(cars)
+```
+```{nb-code}
+
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/ir_notebook.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/ir_notebook.mystnb
@@ -6,6 +6,7 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 This is a jupyter notebook that uses the IR kernel.
 
 ```{nb-code}

--- a/tests/notebooks/mirror/ipynb_to_myst/ir_notebook.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/ir_notebook.mystnb
@@ -7,12 +7,15 @@ nbformat: 4
 nbformat_minor: 2
 ---
 This is a jupyter notebook that uses the IR kernel.
+
 ```{nb-code}
 sum(1:10)
 ```
+
 ```{nb-code}
 plot(cars)
 ```
+
 ```{nb-code}
 
 ```

--- a/tests/notebooks/mirror/ipynb_to_myst/itypescript.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/itypescript.mystnb
@@ -1,0 +1,38 @@
+---
+kernelspec:
+  display_name: Typescript 3.5
+  language: typescript
+  name: typescript
+nbformat: 4
+nbformat_minor: 2
+---
+```{nb-code}
+let x: number = 5;
+const y: number = 6;
+var z: string = "hi";
+console.log(z);
+x + y;
+```
+```{nb-code}
+function add(num1: number, num2: number): number {
+    return num1 + num2
+}
+add(x, y);
+```
+```{nb-code}
+const arrowAdd = (num1: number, num2: number) => num1 + num2;
+arrowAdd(x, y);
+```
+```{nb-code}
+class User {
+  constructor(private name: string) {
+    this.name = name;
+  }
+  sayHello(): string {
+    return "Hello, I'm " + this.name;
+  }
+}
+let John: User;
+John = new User("John");
+John.sayHello();
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/itypescript.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/itypescript.mystnb
@@ -6,6 +6,7 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 ```{nb-code}
 let x: number = 5;
 const y: number = 6;
@@ -13,16 +14,19 @@ var z: string = "hi";
 console.log(z);
 x + y;
 ```
+
 ```{nb-code}
 function add(num1: number, num2: number): number {
     return num1 + num2
 }
 add(x, y);
 ```
+
 ```{nb-code}
 const arrowAdd = (num1: number, num2: number) => num1 + num2;
 arrowAdd(x, y);
 ```
+
 ```{nb-code}
 class User {
   constructor(private name: string) {

--- a/tests/notebooks/mirror/ipynb_to_myst/julia_benchmark_plotly_barchart.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/julia_benchmark_plotly_barchart.mystnb
@@ -1,0 +1,103 @@
+---
+kernelspec:
+  display_name: Julia 1.1.1
+  language: julia
+  name: julia-1.1
+nbformat: 4
+nbformat_minor: 1
+---
+```{nb-code}
+# IJulia rocks! So does Plotly. Check it out
+
+using Plotly
+api_key = "" # visit https://plot.ly/api to generate an API username and password
+username = ""
+
+Plotly.signin(username, api_key)
+```
+```{nb-code}
+# Following data taken from http://julialang.org/ frontpage 
+benchmarks = ["fib", "parse_int", "quicksort3", "mandel", "pi_sum", "rand_mat_stat", "rand_mat_mul"]
+platforms = ["Fortran", "Julia", "Python", "R", "Matlab", "Mathematica", "Javascript", "Go"]
+
+data = {
+        platforms[1] => [0.26, 5.03, 1.11, 0.86, 0.80, 0.64, 0.96],
+        platforms[2] => [0.91, 1.60, 1.14, 0.85, 1.00, 1.66, 1.01],
+        platforms[3] => [30.37, 13.95, 31.98, 14.19, 16.33, 13.52, 3.41 ],
+        platforms[4] => [411.36, 59.40, 524.29, 106.97, 15.42, 10.84, 3.98  ],
+        platforms[5] => [1992.00, 1463.16, 101.84, 64.58, 1.29, 6.61, 1.10   ],
+        platforms[6] => [64.46, 29.54, 35.74, 6.07, 1.32, 4.52, 1.16 ],
+        platforms[7] => [2.18, 2.43, 3.51, 3.49, 0.84, 3.28, 14.60],
+        platforms[8] => [1.03, 4.79, 1.25, 2.36, 1.41, 8.12, 8.51]
+        }
+
+pdata = [ {"x"=>benchmarks,"y"=>data[k],"bardir"=>"h","type"=>"bar","name"=>k} for k = platforms ]
+
+layout = {
+          "title"=> "Julia benchmark comparison (smaller is better, C performance = 1.0)",
+          "barmode"=> "group",
+          "autosize"=> false,
+          "width"=> 900,
+          "height"=> 900,
+          "titlefont"=>
+          {
+           "family"=> "Open Sans",
+           "size"=> 18,
+           "color"=> "rgb(84, 39, 143)"
+           },
+          "margin"=> {"l"=>160, "pad"=>0},
+          "xaxis"=> {
+                     "title"=> "Benchmark log-time",
+                     "type"=> "log"
+                     },
+          "yaxis"=> {"title"=> "Benchmark Name"}
+          }
+
+response = Plotly.plot(pdata,["layout"=>layout])
+
+# Embed in an iframe within IJulia
+s = string("<iframe height='750' id='igraph' scrolling='no' seamless='seamless' src='",
+            response["url"],
+            "/700/700' width='750'></iframe>")
+display("text/html", s)
+```
+```{nb-code}
+# checkout https://plot.ly/api/ for more Julia examples!
+# But to show off some other Plotly features:
+x = 1:1500
+y1 = sin(2*pi*x/1500.) + rand(1500)-0.5
+y2 = sin(2*pi*x/1500.)
+
+fish = {"x"=>x,"y"=> y1,
+	"type"=>"scatter","mode"=>"markers",
+	"marker"=>{"color"=>"rgb(0, 0, 255)","opacity"=>0.5 } }
+
+fit = {"x"=> x,"y"=> y2,
+	"type"=>"scatter", "mode"=>"markers", "opacity"=>0.8,
+	"marker"=>{"color"=>"rgb(255, 0, 0)"} }
+
+layout = {"autosize"=> false,
+    "width"=> 650, "height"=> 550,
+    "title"=>"Fish School",
+	"xaxis"=>{ "ticks"=> "",
+        "gridcolor"=> "white",
+        "zerolinecolor"=> "white",    
+        "linecolor"=> "white",
+        "autorange"=> false,
+        "range"=>[0,1500] },
+	"yaxis"=>{ "ticks"=> "",
+        "gridcolor"=> "white",
+        "zerolinecolor"=> "white",
+		"linecolor"=> "white",
+        "autorange"=> false,
+        "range"=>[-2.2,2.2] },
+	"plot_bgcolor"=> "rgb(245,245,247)",
+    "showlegend"=> false,
+    "hovermode"=> "closest"}
+
+response = Plotly.plot([fish, fit],["layout"=>layout])
+s = string("<iframe height='750' id='igraph' scrolling='no' seamless='seamless' src='",
+            response["url"],
+            "/700/700' width='750'></iframe>")
+display("text/html", s)
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/julia_benchmark_plotly_barchart.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/julia_benchmark_plotly_barchart.mystnb
@@ -6,6 +6,7 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 1
 ---
+
 ```{nb-code}
 # IJulia rocks! So does Plotly. Check it out
 
@@ -15,6 +16,7 @@ username = ""
 
 Plotly.signin(username, api_key)
 ```
+
 ```{nb-code}
 # Following data taken from http://julialang.org/ frontpage 
 benchmarks = ["fib", "parse_int", "quicksort3", "mandel", "pi_sum", "rand_mat_stat", "rand_mat_mul"]
@@ -61,6 +63,7 @@ s = string("<iframe height='750' id='igraph' scrolling='no' seamless='seamless' 
             "/700/700' width='750'></iframe>")
 display("text/html", s)
 ```
+
 ```{nb-code}
 # checkout https://plot.ly/api/ for more Julia examples!
 # But to show off some other Plotly features:

--- a/tests/notebooks/mirror/ipynb_to_myst/julia_functional_geometry.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/julia_functional_geometry.mystnb
@@ -1,0 +1,135 @@
+---
+kernelspec:
+  display_name: Julia 1.1.1
+  language: julia
+  name: julia-1.1
+nbformat: 4
+nbformat_minor: 1
+---
+
+```{nb-code}
+# This notebook is a semi top-down explanation. This cell needs to be
+# executed first so that the operators and helper functions are defined
+# All of this is explained in the later half of the notebook
+
+using Compose, Interact
+Compose.set_default_graphic_size(2inch, 2inch)
+
+points_f = [
+    (.1, .1),
+    (.9, .1),
+    (.9, .2),
+    (.2, .2),
+    (.2, .4),
+    (.6, .4),
+    (.6, .5),
+    (.2, .5),
+    (.2, .9),
+    (.1, .9),
+    (.1, .1)
+]
+
+f = compose(context(), stroke("black"), line(points_f))
+
+rot(pic) = compose(context(rotation=Rotation(-deg2rad(90))), pic)
+flip(pic) = compose(context(mirror=Mirror(deg2rad(90), 0.5w, 0.5h)), pic)
+above(m, n, p, q) =
+    compose(context(),
+            (context(0, 0, 1, m/(m+n)), p),
+            (context(0, m/(m+n), 1, n/(m+n)), q))
+
+above(p, q) = above(1, 1, p, q)
+
+beside(m, n, p, q) =
+    compose(context(),
+            (context(0, 0, m/(m+n), 1), p),
+            (context(m/(m+n), 0, n/(m+n), 1), q))
+
+beside(p, q) = beside(1, 1, p, q)
+
+over(p, q) = compose(context(),
+                (context(), p), (context(), q))
+
+rot45(pic) =
+    compose(context(0, 0, 1/sqrt(2), 1/sqrt(2),
+        rotation=Rotation(-deg2rad(45), 0w, 0h)), pic)
+
+# Utility function to zoom out and look at the context
+zoomout(pic) = compose(context(),
+                (context(0.2, 0.2, 0.6, 0.6), pic),
+                (context(0.2, 0.2, 0.6, 0.6), fill(nothing), stroke("black"), strokedash([0.5mm, 0.5mm]),
+                    polygon([(0, 0), (1, 0), (1, 1), (0, 1)])))
+
+function read_path(p_str)
+    tokens = [try parsefloat(x) catch symbol(x) end for x in split(p_str, r"[\s,]+")]
+    path(tokens)
+end
+
+fish = compose(context(units=UnitBox(260, 260)), stroke("black"),
+            read_path(strip(readall("fish.path"))))
+
+rotatable(pic) = @manipulate for θ=0:0.001:2π
+    compose(context(rotation=Rotation(θ)), pic)
+end
+
+blank = compose(context())
+
+fliprot45(pic) = rot45(compose(context(mirror=Mirror(deg2rad(-45))),pic))
+
+# Hide this cell.
+display(MIME("text/html"), """<script>
+var cell = \$(".container .cell").eq(0), ia = cell.find(".input_area")
+if (cell.find(".toggle-button").length == 0) {
+ia.after(
+    \$('<button class="toggle-button">Toggle hidden code</button>').click(
+        function (){ ia.toggle() }
+        )
+    )
+ia.hide()
+}
+</script>""")
+```
+
+# Functional Geometry
+*Functional Geometry* is a paper by Peter Henderson ([original (1982)](users.ecs.soton.ac.uk/peter/funcgeo.pdf), [revisited (2002)](https://cs.au.dk/~hosc/local/HOSC-15-4-pp349-365.pdf)) which deconstructs the MC Escher woodcut *Square Limit*
+
+![Square Limit](http://i.imgur.com/LjRzmNM.png)
+
++++
+
+> A picture is an example of a complex object that can be described in terms of its parts.
+Yet a picture needs to be rendered on a printer or a screen by a device that expects to
+be given a sequence of commands. Programming that sequence of commands directly is
+much harder than having an application generate the commands automatically from the
+simpler, denotational description.
+
++++
+
+A `picture` is a *denotation* of something to draw.
+
+e.g. The value of f here denotes the picture of the letter F
+
++++
+
+Original at http://nbviewer.jupyter.org/github/shashi/ijulia-notebooks/blob/master/funcgeo/Functional%20Geometry.ipynb
+
++++
+
+## In conclusion
+
+We described Escher's *Square Limit* from the description of its smaller parts, which in turn were described in terms of their smaller parts.
+
+This seemed simple because we chose to talk in terms of an *algebra* to describe pictures. The primitives `rot`, `flip`, `fliprot45`, `above`, `beside` and `over` fit the job perfectly.
+
+We were able to describe these primitves in terms of `compose` `contexts`, which the Compose library knows how to render.
+
+Denotation can be an easy way to describe a system as well as a practical implementation method.
+
+[Abstraction barriers](https://mitpress.mit.edu/sicp/full-text/sicp/book/node29.html) are useful tools that can reduce the cognitive overhead on the programmer. It entails creating layers consisting of functions which only use functions in the same layer or layers below in their own implementation. The layers in our language were:
+
+    ------------------[ squarelimit ]------------------
+    -------------[ quartet, cycle, nonet ]-------------
+    ---[ rot, flip, fliprot45, above, beside, over ]---
+    -------[ compose, context, line, path,... ]--------
+    
+Drawing this diagram out is a useful way to begin building any library.

--- a/tests/notebooks/mirror/ipynb_to_myst/jupyter.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/jupyter.mystnb
@@ -11,7 +11,7 @@ nbformat_minor: 2
 
 This notebook is a simple jupyter notebook. It only has markdown and code cells. And it does not contain consecutive markdown cells. We start with an addition:
 
-```{nb-code}
+```{nb-code} ipython3
 a = 1
 b = 2
 a + b
@@ -19,11 +19,11 @@ a + b
 
 Now we return a few tuples
 
-```{nb-code}
+```{nb-code} ipython3
 a, b
 ```
 
-```{nb-code}
+```{nb-code} ipython3
 a, b, a+b
 ```
 

--- a/tests/notebooks/mirror/ipynb_to_myst/jupyter.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/jupyter.mystnb
@@ -6,6 +6,7 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 # Jupyter notebook
 
 This notebook is a simple jupyter notebook. It only has markdown and code cells. And it does not contain consecutive markdown cells. We start with an addition:
@@ -15,6 +16,7 @@ a = 1
 b = 2
 a + b
 ```
+
 Now we return a few tuples
 
 ```{nb-code}
@@ -24,4 +26,5 @@ a, b
 ```{nb-code}
 a, b, a+b
 ```
+
 And this is already the end of the notebook

--- a/tests/notebooks/mirror/ipynb_to_myst/jupyter.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/jupyter.mystnb
@@ -1,0 +1,24 @@
+---
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+nbformat: 4
+nbformat_minor: 2
+---
+# Jupyter notebook
+
+This notebook is a simple jupyter notebook. It only has markdown and code cells. And it does not contain consecutive markdown cells. We start with an addition:
+```{nb-code}
+a = 1
+b = 2
+a + b
+```
+Now we return a few tuples
+```{nb-code}
+a, b
+```
+```{nb-code}
+a, b, a+b
+```
+And this is already the end of the notebook

--- a/tests/notebooks/mirror/ipynb_to_myst/jupyter.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/jupyter.mystnb
@@ -9,15 +9,18 @@ nbformat_minor: 2
 # Jupyter notebook
 
 This notebook is a simple jupyter notebook. It only has markdown and code cells. And it does not contain consecutive markdown cells. We start with an addition:
+
 ```{nb-code}
 a = 1
 b = 2
 a + b
 ```
 Now we return a few tuples
+
 ```{nb-code}
 a, b
 ```
+
 ```{nb-code}
 a, b, a+b
 ```

--- a/tests/notebooks/mirror/ipynb_to_myst/jupyter_again.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/jupyter_again.mystnb
@@ -6,6 +6,7 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 ```{nb-code}
 c = '''
 title: "Quick test"
@@ -17,10 +18,12 @@ editor_options:
      chunk_output_type console
 '''
 ```
+
 ```{nb-code}
 import yaml
 print(yaml.dump(yaml.load(c)))
 ```
+
 ```{nb-code}
 ?next
 ```

--- a/tests/notebooks/mirror/ipynb_to_myst/jupyter_again.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/jupyter_again.mystnb
@@ -1,0 +1,26 @@
+---
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+nbformat: 4
+nbformat_minor: 2
+---
+```{nb-code}
+c = '''
+title: "Quick test"
+output:
+  ioslides_presentation:
+    widescreen: true
+    smaller: true
+editor_options:
+     chunk_output_type console
+'''
+```
+```{nb-code}
+import yaml
+print(yaml.dump(yaml.load(c)))
+```
+```{nb-code}
+?next
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/jupyter_again.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/jupyter_again.mystnb
@@ -7,7 +7,7 @@ nbformat: 4
 nbformat_minor: 2
 ---
 
-```{nb-code}
+```{nb-code} ipython3
 c = '''
 title: "Quick test"
 output:
@@ -19,11 +19,11 @@ editor_options:
 '''
 ```
 
-```{nb-code}
+```{nb-code} ipython3
 import yaml
 print(yaml.dump(yaml.load(c)))
 ```
 
-```{nb-code}
+```{nb-code} ipython3
 ?next
 ```

--- a/tests/notebooks/mirror/ipynb_to_myst/jupyter_with_raw_cell_in_body.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/jupyter_with_raw_cell_in_body.mystnb
@@ -14,4 +14,5 @@ nbformat_minor: 2
 ```{nb-raw}
 This is a raw cell
 ```
+
 This is a markdown cell

--- a/tests/notebooks/mirror/ipynb_to_myst/jupyter_with_raw_cell_in_body.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/jupyter_with_raw_cell_in_body.mystnb
@@ -6,9 +6,11 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 ```{nb-code}
 1+2+3
 ```
+
 ```{nb-raw}
 This is a raw cell
 ```

--- a/tests/notebooks/mirror/ipynb_to_myst/jupyter_with_raw_cell_in_body.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/jupyter_with_raw_cell_in_body.mystnb
@@ -1,0 +1,15 @@
+---
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+nbformat: 4
+nbformat_minor: 2
+---
+```{nb-code}
+1+2+3
+```
+```{nb-raw}
+This is a raw cell
+```
+This is a markdown cell

--- a/tests/notebooks/mirror/ipynb_to_myst/jupyter_with_raw_cell_in_body.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/jupyter_with_raw_cell_in_body.mystnb
@@ -7,7 +7,7 @@ nbformat: 4
 nbformat_minor: 2
 ---
 
-```{nb-code}
+```{nb-code} ipython3
 1+2+3
 ```
 

--- a/tests/notebooks/mirror/ipynb_to_myst/jupyter_with_raw_cell_on_top.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/jupyter_with_raw_cell_on_top.mystnb
@@ -6,6 +6,7 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 ```{nb-raw}
 
 ---
@@ -18,9 +19,11 @@ editor_options:
      chunk_output_type console
 ---
 ```
+
 ```{nb-code}
 1+2+3
 ```
+
 ```{nb-code}
 
 ```

--- a/tests/notebooks/mirror/ipynb_to_myst/jupyter_with_raw_cell_on_top.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/jupyter_with_raw_cell_on_top.mystnb
@@ -20,10 +20,10 @@ editor_options:
 ---
 ```
 
-```{nb-code}
+```{nb-code} ipython3
 1+2+3
 ```
 
-```{nb-code}
+```{nb-code} ipython3
 
 ```

--- a/tests/notebooks/mirror/ipynb_to_myst/jupyter_with_raw_cell_on_top.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/jupyter_with_raw_cell_on_top.mystnb
@@ -1,0 +1,26 @@
+---
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+nbformat: 4
+nbformat_minor: 2
+---
+```{nb-raw}
+
+---
+title: "Quick test"
+output:
+  ioslides_presentation:
+    widescreen: true
+    smaller: true
+editor_options:
+     chunk_output_type console
+---
+```
+```{nb-code}
+1+2+3
+```
+```{nb-code}
+
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/kalman_filter_and_visualization.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/kalman_filter_and_visualization.mystnb
@@ -1,0 +1,38 @@
+---
+kernelspec:
+  display_name: Q 3.5
+  language: q
+  name: qpk
+nbformat: 4
+nbformat_minor: 2
+---
+```{nb-code}
+plt: .p.import`matplotlib.pyplot
+```
+```{nb-code}
+filter: {
+    t: ([] x: `float $ x; xh: `float $ x; p: (count x) # R: var x);
+    (first t), iterate[R; R]\[first t; 1 _ t] 
+    }
+
+iterate: {[Q; R; x; y]
+    x[`p]+: Q;
+    k: x[`p] % R + x[`p];
+    `x`xh`p ! (y[`x]; x[`xh] + k * y[`x] - x[`xh]; (1 - k) * x[`p])
+    }
+```
+```{nb-code}
+price: 100 + sums 0.5 - (n:50)?1.
+```
+```{nb-code}
+output:filter price
+```
+```{nb-code}
+plt[`:plot][til n; output`x; `label pykw "price"];
+plt[`:plot][til n; output`xh;`label pykw "forecast"];
+plt[`:legend][];
+plt[`:show][];
+```
+```{nb-code}
+
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/kalman_filter_and_visualization.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/kalman_filter_and_visualization.mystnb
@@ -6,9 +6,11 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 ```{nb-code}
 plt: .p.import`matplotlib.pyplot
 ```
+
 ```{nb-code}
 filter: {
     t: ([] x: `float $ x; xh: `float $ x; p: (count x) # R: var x);
@@ -21,18 +23,22 @@ iterate: {[Q; R; x; y]
     `x`xh`p ! (y[`x]; x[`xh] + k * y[`x] - x[`xh]; (1 - k) * x[`p])
     }
 ```
+
 ```{nb-code}
 price: 100 + sums 0.5 - (n:50)?1.
 ```
+
 ```{nb-code}
 output:filter price
 ```
+
 ```{nb-code}
 plt[`:plot][til n; output`x; `label pykw "price"];
 plt[`:plot][til n; output`xh;`label pykw "forecast"];
 plt[`:legend][];
 plt[`:show][];
 ```
+
 ```{nb-code}
 
 ```

--- a/tests/notebooks/mirror/ipynb_to_myst/notebook_with_complex_metadata.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/notebook_with_complex_metadata.mystnb
@@ -1,0 +1,11 @@
+---
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+nbformat: 4
+nbformat_minor: 2
+---
+```{nb-code}
+
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/notebook_with_complex_metadata.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/notebook_with_complex_metadata.mystnb
@@ -6,6 +6,7 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 ```{nb-code}
 
 ```

--- a/tests/notebooks/mirror/ipynb_to_myst/notebook_with_complex_metadata.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/notebook_with_complex_metadata.mystnb
@@ -7,6 +7,6 @@ nbformat: 4
 nbformat_minor: 2
 ---
 
-```{nb-code}
+```{nb-code} ipython3
 
 ```

--- a/tests/notebooks/mirror/ipynb_to_myst/nteract_with_parameter.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/nteract_with_parameter.mystnb
@@ -10,38 +10,33 @@ nbformat_minor: 2
 ---
 
 ```{nb-code} ipython3
----
-inputHidden: false
-outputHidden: false
-tags:
-- parameters
----
+:inputHidden: false
+:outputHidden: false
+:tags: [parameters]
+
 param = 4
 ```
 
 ```{nb-code} ipython3
----
-inputHidden: false
-outputHidden: false
----
+:inputHidden: false
+:outputHidden: false
+
 import pandas as pd
 ```
 
 ```{nb-code} ipython3
----
-inputHidden: false
-outputHidden: false
----
+:inputHidden: false
+:outputHidden: false
+
 df = pd.DataFrame({'A': [1, 2], 'B': [3 + param, 4]},
                   index=pd.Index(['x0', 'x1'], name='x'))
 df
 ```
 
 ```{nb-code} ipython3
----
-inputHidden: false
-outputHidden: false
----
+:inputHidden: false
+:outputHidden: false
+
 %matplotlib inline
 df.plot(kind='bar')
 ```

--- a/tests/notebooks/mirror/ipynb_to_myst/nteract_with_parameter.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/nteract_with_parameter.mystnb
@@ -1,0 +1,43 @@
+---
+kernel_info:
+  name: python3
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+nbformat: 4
+nbformat_minor: 2
+---
+```{nb-code}
+---
+inputHidden: false
+outputHidden: false
+tags:
+- parameters
+---
+param = 4
+```
+```{nb-code}
+---
+inputHidden: false
+outputHidden: false
+---
+import pandas as pd
+```
+```{nb-code}
+---
+inputHidden: false
+outputHidden: false
+---
+df = pd.DataFrame({'A': [1, 2], 'B': [3 + param, 4]},
+                  index=pd.Index(['x0', 'x1'], name='x'))
+df
+```
+```{nb-code}
+---
+inputHidden: false
+outputHidden: false
+---
+%matplotlib inline
+df.plot(kind='bar')
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/nteract_with_parameter.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/nteract_with_parameter.mystnb
@@ -9,7 +9,7 @@ nbformat: 4
 nbformat_minor: 2
 ---
 
-```{nb-code}
+```{nb-code} ipython3
 ---
 inputHidden: false
 outputHidden: false
@@ -19,7 +19,7 @@ tags:
 param = 4
 ```
 
-```{nb-code}
+```{nb-code} ipython3
 ---
 inputHidden: false
 outputHidden: false
@@ -27,7 +27,7 @@ outputHidden: false
 import pandas as pd
 ```
 
-```{nb-code}
+```{nb-code} ipython3
 ---
 inputHidden: false
 outputHidden: false
@@ -37,7 +37,7 @@ df = pd.DataFrame({'A': [1, 2], 'B': [3 + param, 4]},
 df
 ```
 
-```{nb-code}
+```{nb-code} ipython3
 ---
 inputHidden: false
 outputHidden: false

--- a/tests/notebooks/mirror/ipynb_to_myst/nteract_with_parameter.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/nteract_with_parameter.mystnb
@@ -8,6 +8,7 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 ```{nb-code}
 ---
 inputHidden: false
@@ -17,6 +18,7 @@ tags:
 ---
 param = 4
 ```
+
 ```{nb-code}
 ---
 inputHidden: false
@@ -24,6 +26,7 @@ outputHidden: false
 ---
 import pandas as pd
 ```
+
 ```{nb-code}
 ---
 inputHidden: false
@@ -33,6 +36,7 @@ df = pd.DataFrame({'A': [1, 2], 'B': [3 + param, 4]},
                   index=pd.Index(['x0', 'x1'], name='x'))
 df
 ```
+
 ```{nb-code}
 ---
 inputHidden: false

--- a/tests/notebooks/mirror/ipynb_to_myst/octave_notebook.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/octave_notebook.mystnb
@@ -1,0 +1,36 @@
+---
+kernelspec:
+  display_name: Octave
+  language: octave
+  name: octave
+nbformat: 4
+nbformat_minor: 2
+---
+A markdown cell
+```{nb-code}
+1 + 1
+```
+```{nb-code}
+% a code cell with comments
+2 + 2
+```
+```{nb-code}
+% a simple plot
+x = -10:0.1:10;
+plot (x, sin (x));
+```
+```{nb-code}
+%plot -w 800
+% a simple plot with a magic instruction
+x = -10:0.1:10;
+plot (x, sin (x));
+```
+And to finish with, a Python cell
+```{nb-code}
+%%python
+a = 1
+```
+```{nb-code}
+%%python
+a + 1
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/octave_notebook.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/octave_notebook.mystnb
@@ -7,18 +7,22 @@ nbformat: 4
 nbformat_minor: 2
 ---
 A markdown cell
+
 ```{nb-code}
 1 + 1
 ```
+
 ```{nb-code}
 % a code cell with comments
 2 + 2
 ```
+
 ```{nb-code}
 % a simple plot
 x = -10:0.1:10;
 plot (x, sin (x));
 ```
+
 ```{nb-code}
 %plot -w 800
 % a simple plot with a magic instruction
@@ -26,10 +30,12 @@ x = -10:0.1:10;
 plot (x, sin (x));
 ```
 And to finish with, a Python cell
+
 ```{nb-code}
 %%python
 a = 1
 ```
+
 ```{nb-code}
 %%python
 a + 1

--- a/tests/notebooks/mirror/ipynb_to_myst/octave_notebook.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/octave_notebook.mystnb
@@ -6,6 +6,7 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 A markdown cell
 
 ```{nb-code}
@@ -29,6 +30,7 @@ plot (x, sin (x));
 x = -10:0.1:10;
 plot (x, sin (x));
 ```
+
 And to finish with, a Python cell
 
 ```{nb-code}

--- a/tests/notebooks/mirror/ipynb_to_myst/plotly_graphs.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/plotly_graphs.mystnb
@@ -17,12 +17,12 @@ This notebook contains complex outputs, including plotly javascript graphs.
 
 We use Plotly's connected mode to make the notebook lighter - when connected, the notebook downloads the `plotly.js` library from the web.
 
-```{nb-code}
+```{nb-code} ipython3
 import plotly.offline as offline
 offline.init_notebook_mode(connected=True)
 ```
 
-```{nb-code}
+```{nb-code} ipython3
 import plotly.graph_objects as go
 fig = go.Figure(
     data=[go.Bar(y=[2, 3, 1])],

--- a/tests/notebooks/mirror/ipynb_to_myst/plotly_graphs.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/plotly_graphs.mystnb
@@ -6,12 +6,15 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 This notebook contains complex outputs, including plotly javascript graphs.
 
 +++
+
 # Interactive plots
 
 +++
+
 We use Plotly's connected mode to make the notebook lighter - when connected, the notebook downloads the `plotly.js` library from the web.
 
 ```{nb-code}

--- a/tests/notebooks/mirror/ipynb_to_myst/plotly_graphs.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/plotly_graphs.mystnb
@@ -1,0 +1,28 @@
+---
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+nbformat: 4
+nbformat_minor: 2
+---
+This notebook contains complex outputs, including plotly javascript graphs.
+
++++
+# Interactive plots
+
++++
+We use Plotly's connected mode to make the notebook lighter - when connected, the notebook downloads the `plotly.js` library from the web.
+```{nb-code}
+import plotly.offline as offline
+offline.init_notebook_mode(connected=True)
+```
+```{nb-code}
+import plotly.graph_objects as go
+fig = go.Figure(
+    data=[go.Bar(y=[2, 3, 1])],
+    layout=go.Layout(title="bar plot"))
+fig.show()
+fig.data[0].marker = dict(color='purple')
+fig
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/plotly_graphs.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/plotly_graphs.mystnb
@@ -13,10 +13,12 @@ This notebook contains complex outputs, including plotly javascript graphs.
 
 +++
 We use Plotly's connected mode to make the notebook lighter - when connected, the notebook downloads the `plotly.js` library from the web.
+
 ```{nb-code}
 import plotly.offline as offline
 offline.init_notebook_mode(connected=True)
 ```
+
 ```{nb-code}
 import plotly.graph_objects as go
 fig = go.Figure(

--- a/tests/notebooks/mirror/ipynb_to_myst/powershell.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/powershell.mystnb
@@ -6,6 +6,7 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 This is an extract from
 https://github.com/Jaykul/Jupyter-PowerShell/blob/master/LiterateDevOps.ipynb
 

--- a/tests/notebooks/mirror/ipynb_to_myst/powershell.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/powershell.mystnb
@@ -1,0 +1,18 @@
+---
+kernelspec:
+  display_name: PowerShell
+  language: PowerShell
+  name: powershell
+nbformat: 4
+nbformat_minor: 2
+---
+This is an extract from
+https://github.com/Jaykul/Jupyter-PowerShell/blob/master/LiterateDevOps.ipynb
+```{nb-code}
+$imageUrl = 'https://upload.wikimedia.org/wikipedia/commons/2/2f/PowerShell_5.0_icon.png'
+$ImageData = @{ "png" = (Invoke-WebRequest $imageUrl -UseBasicParsing).RawContentStream.GetBuffer() }
+# $ImageData
+
+Write-Jupyter -InputObject $ImageData -Metadata @{ "image/png" = @{ 'width' = 32 } }
+Write-Jupyter -InputObject $ImageData -Metadata @{ "image/png" = @{ 'width' = 64 } }
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/powershell.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/powershell.mystnb
@@ -10,7 +10,7 @@ nbformat_minor: 2
 This is an extract from
 https://github.com/Jaykul/Jupyter-PowerShell/blob/master/LiterateDevOps.ipynb
 
-```{nb-code}
+```{nb-code} powershell
 $imageUrl = 'https://upload.wikimedia.org/wikipedia/commons/2/2f/PowerShell_5.0_icon.png'
 $ImageData = @{ "png" = (Invoke-WebRequest $imageUrl -UseBasicParsing).RawContentStream.GetBuffer() }
 # $ImageData

--- a/tests/notebooks/mirror/ipynb_to_myst/powershell.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/powershell.mystnb
@@ -8,6 +8,7 @@ nbformat_minor: 2
 ---
 This is an extract from
 https://github.com/Jaykul/Jupyter-PowerShell/blob/master/LiterateDevOps.ipynb
+
 ```{nb-code}
 $imageUrl = 'https://upload.wikimedia.org/wikipedia/commons/2/2f/PowerShell_5.0_icon.png'
 $ImageData = @{ "png" = (Invoke-WebRequest $imageUrl -UseBasicParsing).RawContentStream.GetBuffer() }

--- a/tests/notebooks/mirror/ipynb_to_myst/sample_bash_notebook.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/sample_bash_notebook.mystnb
@@ -1,0 +1,18 @@
+---
+kernelspec:
+  display_name: Bash
+  language: bash
+  name: bash
+nbformat: 4
+nbformat_minor: 2
+---
+```{nb-code}
+ls
+```
+```{nb-code}
+# https://coderwall.com/p/euwpig/a-better-git-log
+git config --global alias.lg "log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit"
+```
+```{nb-code}
+git lg
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/sample_bash_notebook.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/sample_bash_notebook.mystnb
@@ -6,13 +6,16 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 ```{nb-code}
 ls
 ```
+
 ```{nb-code}
 # https://coderwall.com/p/euwpig/a-better-git-log
 git config --global alias.lg "log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit"
 ```
+
 ```{nb-code}
 git lg
 ```

--- a/tests/notebooks/mirror/ipynb_to_myst/sample_rise_notebook_66.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/sample_rise_notebook_66.mystnb
@@ -8,6 +8,7 @@ nbformat_minor: 2
 ---
 
 +++ {"slideshow": {"slide_type": "slide"}}
+
 A markdown cell
 
 ```{nb-code}
@@ -19,4 +20,5 @@ slideshow:
 ```
 
 +++ {"cell_style": "center", "slideshow": {"slide_type": "fragment"}}
+
 Markdown cell two

--- a/tests/notebooks/mirror/ipynb_to_myst/sample_rise_notebook_66.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/sample_rise_notebook_66.mystnb
@@ -1,0 +1,21 @@
+---
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+nbformat: 4
+nbformat_minor: 2
+---
+
++++ {"slideshow": {"slide_type": "slide"}}
+A markdown cell
+```{nb-code}
+---
+slideshow:
+  slide_type: ''
+---
+1+1
+```
+
++++ {"cell_style": "center", "slideshow": {"slide_type": "fragment"}}
+Markdown cell two

--- a/tests/notebooks/mirror/ipynb_to_myst/sample_rise_notebook_66.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/sample_rise_notebook_66.mystnb
@@ -9,6 +9,7 @@ nbformat_minor: 2
 
 +++ {"slideshow": {"slide_type": "slide"}}
 A markdown cell
+
 ```{nb-code}
 ---
 slideshow:

--- a/tests/notebooks/mirror/ipynb_to_myst/sample_rise_notebook_66.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/sample_rise_notebook_66.mystnb
@@ -11,7 +11,7 @@ nbformat_minor: 2
 
 A markdown cell
 
-```{nb-code}
+```{nb-code} ipython3
 ---
 slideshow:
   slide_type: ''

--- a/tests/notebooks/mirror/ipynb_to_myst/simple_robot_notebook.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/simple_robot_notebook.mystnb
@@ -6,11 +6,13 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 ```{nb-code}
 *** Settings ***
 
 Library  Collections
 ```
+
 ```{nb-code}
 *** Keywords ***
 
@@ -19,6 +21,7 @@ Head
     ${value}=  Get from list  ${list}  0
     [Return]  ${value}
 ```
+
 ```{nb-code}
 *** Tasks ***
 

--- a/tests/notebooks/mirror/ipynb_to_myst/simple_robot_notebook.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/simple_robot_notebook.mystnb
@@ -7,13 +7,13 @@ nbformat: 4
 nbformat_minor: 2
 ---
 
-```{nb-code}
+```{nb-code} robotframework
 *** Settings ***
 
 Library  Collections
 ```
 
-```{nb-code}
+```{nb-code} robotframework
 *** Keywords ***
 
 Head
@@ -22,7 +22,7 @@ Head
     [Return]  ${value}
 ```
 
-```{nb-code}
+```{nb-code} robotframework
 *** Tasks ***
 
 Get head

--- a/tests/notebooks/mirror/ipynb_to_myst/simple_robot_notebook.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/simple_robot_notebook.mystnb
@@ -1,0 +1,29 @@
+---
+kernelspec:
+  display_name: Robot Framework
+  language: robotframework
+  name: robotkernel
+nbformat: 4
+nbformat_minor: 2
+---
+```{nb-code}
+*** Settings ***
+
+Library  Collections
+```
+```{nb-code}
+*** Keywords ***
+
+Head
+    [Arguments]  ${list}
+    ${value}=  Get from list  ${list}  0
+    [Return]  ${value}
+```
+```{nb-code}
+*** Tasks ***
+
+Get head
+    ${array}=  Create list  1  2  3  4  5
+    ${head}=  Head  ${array}
+    Should be equal  ${head}  1
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/simple_scala_notebook.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/simple_scala_notebook.mystnb
@@ -1,0 +1,20 @@
+---
+kernelspec:
+  display_name: Apache Toree - Scala
+  language: scala
+  name: apache_toree_scala
+nbformat: 4
+nbformat_minor: 2
+---
+```{nb-code}
+// This is just a simple scala notebook
+
+object SampleObject {
+    def calculation(x: Int, y: Int): Int = x + y
+}
+
+val result = SampleObject.calculation(1, 2)
+```
+```{nb-code}
+println(result * 10)
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/simple_scala_notebook.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/simple_scala_notebook.mystnb
@@ -7,7 +7,7 @@ nbformat: 4
 nbformat_minor: 2
 ---
 
-```{nb-code}
+```{nb-code} scala
 // This is just a simple scala notebook
 
 object SampleObject {
@@ -17,6 +17,6 @@ object SampleObject {
 val result = SampleObject.calculation(1, 2)
 ```
 
-```{nb-code}
+```{nb-code} scala
 println(result * 10)
 ```

--- a/tests/notebooks/mirror/ipynb_to_myst/simple_scala_notebook.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/simple_scala_notebook.mystnb
@@ -6,6 +6,7 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 ```{nb-code}
 // This is just a simple scala notebook
 
@@ -15,6 +16,7 @@ object SampleObject {
 
 val result = SampleObject.calculation(1, 2)
 ```
+
 ```{nb-code}
 println(result * 10)
 ```

--- a/tests/notebooks/mirror/ipynb_to_myst/text_outputs_and_images.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/text_outputs_and_images.mystnb
@@ -12,12 +12,14 @@ This notebook contains outputs of many different types: text, HTML, plots and er
 # Text outputs
 
 Using `print`, `sys.stdout` and `sys.stderr`
+
 ```{nb-code}
 import sys
 print('using print')
 sys.stdout.write('using sys.stdout.write')
 sys.stderr.write('using sys.stderr.write')
 ```
+
 ```{nb-code}
 import logging
 logging.debug('Debug')
@@ -28,19 +30,23 @@ logging.error('Error')
 # HTML outputs
 
 Using `pandas`. Here we find two representations: both text and HTML.
+
 ```{nb-code}
 import pandas as pd
 pd.DataFrame([4])
 ```
+
 ```{nb-code}
 from IPython.display import display
 display(pd.DataFrame([5]))
 display(pd.DataFrame([6]))
 ```
 # Images
+
 ```{nb-code}
 %matplotlib inline
 ```
+
 ```{nb-code}
 # First plot
 from matplotlib import pyplot as plt
@@ -61,6 +67,7 @@ plt.axis('off')
 plt.show()
 ```
 # Errors
+
 ```{nb-code}
 undefined_variable
 ```

--- a/tests/notebooks/mirror/ipynb_to_myst/text_outputs_and_images.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/text_outputs_and_images.mystnb
@@ -15,14 +15,14 @@ This notebook contains outputs of many different types: text, HTML, plots and er
 
 Using `print`, `sys.stdout` and `sys.stderr`
 
-```{nb-code}
+```{nb-code} ipython3
 import sys
 print('using print')
 sys.stdout.write('using sys.stdout.write')
 sys.stderr.write('using sys.stderr.write')
 ```
 
-```{nb-code}
+```{nb-code} ipython3
 import logging
 logging.debug('Debug')
 logging.info('Info')
@@ -34,12 +34,12 @@ logging.error('Error')
 
 Using `pandas`. Here we find two representations: both text and HTML.
 
-```{nb-code}
+```{nb-code} ipython3
 import pandas as pd
 pd.DataFrame([4])
 ```
 
-```{nb-code}
+```{nb-code} ipython3
 from IPython.display import display
 display(pd.DataFrame([5]))
 display(pd.DataFrame([6]))
@@ -47,11 +47,11 @@ display(pd.DataFrame([6]))
 
 # Images
 
-```{nb-code}
+```{nb-code} ipython3
 %matplotlib inline
 ```
 
-```{nb-code}
+```{nb-code} ipython3
 # First plot
 from matplotlib import pyplot as plt
 import numpy as np
@@ -73,6 +73,6 @@ plt.show()
 
 # Errors
 
-```{nb-code}
+```{nb-code} ipython3
 undefined_variable
 ```

--- a/tests/notebooks/mirror/ipynb_to_myst/text_outputs_and_images.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/text_outputs_and_images.mystnb
@@ -6,9 +6,11 @@ kernelspec:
 nbformat: 4
 nbformat_minor: 2
 ---
+
 This notebook contains outputs of many different types: text, HTML, plots and errors.
 
 +++
+
 # Text outputs
 
 Using `print`, `sys.stdout` and `sys.stderr`
@@ -27,6 +29,7 @@ logging.info('Info')
 logging.warning('Warning')
 logging.error('Error')
 ```
+
 # HTML outputs
 
 Using `pandas`. Here we find two representations: both text and HTML.
@@ -41,6 +44,7 @@ from IPython.display import display
 display(pd.DataFrame([5]))
 display(pd.DataFrame([6]))
 ```
+
 # Images
 
 ```{nb-code}
@@ -66,6 +70,7 @@ plt.imshow(data)
 plt.axis('off')
 plt.show()
 ```
+
 # Errors
 
 ```{nb-code}

--- a/tests/notebooks/mirror/ipynb_to_myst/text_outputs_and_images.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/text_outputs_and_images.mystnb
@@ -1,0 +1,66 @@
+---
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+nbformat: 4
+nbformat_minor: 2
+---
+This notebook contains outputs of many different types: text, HTML, plots and errors.
+
++++
+# Text outputs
+
+Using `print`, `sys.stdout` and `sys.stderr`
+```{nb-code}
+import sys
+print('using print')
+sys.stdout.write('using sys.stdout.write')
+sys.stderr.write('using sys.stderr.write')
+```
+```{nb-code}
+import logging
+logging.debug('Debug')
+logging.info('Info')
+logging.warning('Warning')
+logging.error('Error')
+```
+# HTML outputs
+
+Using `pandas`. Here we find two representations: both text and HTML.
+```{nb-code}
+import pandas as pd
+pd.DataFrame([4])
+```
+```{nb-code}
+from IPython.display import display
+display(pd.DataFrame([5]))
+display(pd.DataFrame([6]))
+```
+# Images
+```{nb-code}
+%matplotlib inline
+```
+```{nb-code}
+# First plot
+from matplotlib import pyplot as plt
+import numpy as np
+w, h = 3, 3
+data = np.zeros((h, w, 3), dtype=np.uint8)
+data[0,:] = [0,255,0]
+data[1,:] = [0,0,255]
+data[2,:] = [0,255,0]
+data[1:3,1:3] = [255, 0, 0]
+plt.imshow(data)
+plt.axis('off')
+plt.show()
+# Second plot
+data[1:3,1:3] = [255, 255, 0]
+plt.imshow(data)
+plt.axis('off')
+plt.show()
+```
+# Errors
+```{nb-code}
+undefined_variable
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/xcpp_by_quantstack.mystnb
+++ b/tests/notebooks/mirror/ipynb_to_myst/xcpp_by_quantstack.mystnb
@@ -1,0 +1,469 @@
+---
+kernelspec:
+  display_name: C++14
+  language: C++14
+  name: xeus-cling-cpp14
+nbformat: 4
+nbformat_minor: 2
+---
+
+[![xeus-cling](images/xeus-cling.png)](https://github.com/QuantStack/xeus-cling/)
+
+A Jupyter kernel for C++ based on the `cling` C++ interpreter and the `xeus` native implementation of the Jupyter protocol, xeus.
+
+- GitHub repository: https://github.com/QuantStack/xeus-cling/
+- Online documentation: https://xeus-cling.readthedocs.io/
+
++++
+
+## Usage
+
+<div style="background: #efffed;
+            border: 1px solid grey;
+            margin: 8px 0 8px 0;
+            text-align: center;
+            padding: 8px; ">
+    <i class="fa-play fa" 
+       style="font-size: 40px;
+              line-height: 40px;
+              margin: 8px;
+              color: #444;">
+    </i>
+    <div>
+    To run the selected code cell, hit <pre style="background: #efffed">Shift + Enter</pre>
+    </div>
+</div>
+
++++
+
+## Output and error streams
+
+`std::cout` and `std::cerr` are redirected to the notebook frontend.
+
+```{nb-code}
+#include <iostream>
+
+std::cout << "some output" << std::endl;
+```
+
+```{nb-code}
+std::cerr << "some error" << std::endl;
+```
+
+```{nb-code}
+#include <stdexcept>
+```
+
+```{nb-code}
+throw std::runtime_error("Unknown exception");
+```
+
+Omitting the `;` in the last statement of a cell results in an output being printed
+
+```{nb-code}
+int j = 5;
+```
+
+```{nb-code}
+j
+```
+
+# Interpreting the C++ programming language
+
+`cling` has a broad support of the features of C++. You can define functions, classes, templates, etc ...
+
++++
+
+## Functions
+
+```{nb-code}
+double sqr(double a)
+{
+    return a * a;
+}
+```
+
+```{nb-code}
+double a = 2.5;
+double asqr = sqr(a);
+asqr
+```
+
+## Classes
+
+```{nb-code}
+class Foo
+{
+public:
+
+    virtual ~Foo() {}
+    
+    virtual void print(double value) const
+    {
+        std::cout << "Foo value = " << value << std::endl;
+    }
+};
+```
+
+```{nb-code}
+Foo bar;
+bar.print(1.2);
+```
+
+## Polymorphism
+
+```{nb-code}
+class Bar : public Foo
+{
+public:
+
+    virtual ~Bar() {}
+    
+    virtual void print(double value) const
+    {
+        std::cout << "Bar value = " << 2 * value << std::endl;
+    }
+};
+```
+
+```{nb-code}
+Foo* bar2 = new Bar;
+bar2->print(1.2);
+delete bar2;
+```
+
+## Templates
+
+```{nb-code}
+#include <typeinfo>
+
+template <class T>
+class FooT
+{
+public:
+    
+    explicit FooT(const T& t) : m_t(t) {}
+    
+    void print() const
+    {
+        std::cout << typeid(T).name() << " m_t = " << m_t << std::endl;
+    }
+    
+private:
+    
+    T m_t;
+};
+
+template <>
+class FooT<int>
+{
+public:
+    
+    explicit FooT(const int& t) : m_t(t) {}
+    
+    void print() const
+    {
+        std::cout << "m_t = " << m_t << std::endl;
+    }
+    
+private:
+    
+    int m_t;
+};
+```
+
+```{nb-code}
+FooT<double> foot1(1.2);
+foot1.print();
+```
+
+```{nb-code}
+FooT<int> foot2(4);
+foot2.print();
+```
+
+## C++11 / C++14 support
+
+```{nb-code}
+class Foo11
+{
+public:
+    
+    Foo11() { std::cout << "Foo11 default constructor" << std::endl; }
+    Foo11(const Foo11&) { std::cout << "Foo11 copy constructor" << std::endl; }
+    Foo11(Foo11&&) { std::cout << "Foo11 move constructor" << std::endl; }
+};
+```
+
+```{nb-code}
+Foo11 f1;
+Foo11 f2(f1);
+Foo11 f3(std::move(f1));
+```
+
+```{nb-code}
+#include <vector>
+
+std::vector<int> v = { 1, 2, 3};
+auto iter = ++v.begin();
+v
+```
+
+```{nb-code}
+*iter
+```
+
+... and also lambda, universal references, `decltype`, etc ...
+
++++
+
+## Documentation and completion
+
+ - Documentation for types of the standard library is retrieved on cppreference.com.
+ - The quick-help feature can also be enabled for user-defined types and third-party libraries. More documentation on this feature is available at https://xeus-cling.readthedocs.io/en/latest/inline_help.html.
+
+```{nb-code}
+?std::vector
+```
+
+## Using the `display_data` mechanism
+
++++
+
+For a user-defined type `T`, the rich rendering in the notebook and JupyterLab can be enabled by by implementing the function `xeus::xjson mime_bundle_repr(const T& im)`, which returns the JSON mime bundle for that type.
+
+More documentation on the rich display system of Jupyter and Xeus-cling is available at https://xeus-cling.readthedocs.io/en/latest/rich_display.html
+
++++
+
+### Image example
+
+```{nb-code}
+#include <string>
+#include <fstream>
+
+#include "xtl/xbase64.hpp"
+#include "xeus/xjson.hpp"
+
+namespace im
+{
+    struct image
+    {   
+        inline image(const std::string& filename)
+        {
+            std::ifstream fin(filename, std::ios::binary);   
+            m_buffer << fin.rdbuf();
+        }
+        
+        std::stringstream m_buffer;
+    };
+    
+    xeus::xjson mime_bundle_repr(const image& i)
+    {
+        auto bundle = xeus::xjson::object();
+        bundle["image/png"] = xtl::base64encode(i.m_buffer.str());
+        return bundle;
+    }
+}
+```
+
+```{nb-code}
+im::image marie("images/marie.png");
+marie
+```
+
+### Audio example
+
+```{nb-code}
+#include <string>
+#include <fstream>
+
+#include "xtl/xbase64.hpp"
+#include "xeus/xjson.hpp"
+
+namespace au
+{
+    struct audio
+    {   
+        inline audio(const std::string& filename)
+        {
+            std::ifstream fin(filename, std::ios::binary);   
+            m_buffer << fin.rdbuf();
+        }
+        
+        std::stringstream m_buffer;
+    };
+    
+    xeus::xjson mime_bundle_repr(const audio& a)
+    {
+        auto bundle = xeus::xjson::object();
+        bundle["text/html"] =
+           std::string("<audio controls=\"controls\"><source src=\"data:audio/wav;base64,")
+           + xtl::base64encode(a.m_buffer.str()) +
+            "\" type=\"audio/wav\" /></audio>";
+        return bundle;
+    }
+}
+```
+
+```{nb-code}
+au::audio drums("audio/audio.wav");
+drums
+```
+
+### Display
+
+```{nb-code}
+#include "xcpp/xdisplay.hpp"
+```
+
+```{nb-code}
+xcpp::display(drums);
+```
+
+### Update-display
+
+```{nb-code}
+#include <string>
+#include "xcpp/xdisplay.hpp"
+
+namespace ht
+{
+    struct html
+    {   
+        inline html(const std::string& content)
+        {
+            m_content = content;
+        }
+        std::string m_content;
+    };
+
+    xeus::xjson mime_bundle_repr(const html& a)
+    {
+        auto bundle = xeus::xjson::object();
+        bundle["text/html"] = a.m_content;
+        return bundle;
+    }
+}
+
+// A red rectangle
+ht::html rect(R"(
+<div style='
+    width: 90px;
+    height: 50px;
+    line-height: 50px;
+    background-color: blue;
+    color: white;
+    text-align: center;'>
+Original
+</div>)");
+```
+
+```{nb-code}
+xcpp::display(rect, "some_display_id");
+```
+
+```{nb-code}
+// Update the rectangle to be blue
+rect.m_content = R"(
+<div style='
+    width: 90px;
+    height: 50px;
+    line-height: 50px;
+    background-color: red;
+    color: white;
+    text-align: center;'>
+Updated
+</div>)";
+
+xcpp::display(rect, "some_display_id", true);
+```
+
+## Magics
+
+Magics are special commands for the kernel that are not part of the C++ language.
+
+They are defined with the symbol `%` for a line magic and `%%` for a cell magic.
+
+More documentation for magics is available at https://xeus-cling.readthedocs.io/en/latest/magics.html.
+
+```{nb-code}
+#include <algorithm>
+#include <vector>
+```
+
+```{nb-code}
+std::vector<double> to_shuffle = {1, 2, 3, 4};
+```
+
+```{nb-code}
+%timeit std::random_shuffle(to_shuffle.begin(), to_shuffle.end());
+```
+
+[![xtensor](images/xtensor.png)](https://github.com/QuantStack/xtensor/)
+
+- GitHub repository: https://github.com/QuantStack/xtensor/
+- Online documentation: https://xtensor.readthedocs.io/
+- NumPy to xtensor cheat sheet: http://xtensor.readthedocs.io/en/latest/numpy.html
+
+`xtensor` is a C++ library for manipulating N-D arrays with an API very similar to that of numpy.
+
+```{nb-code}
+#include <iostream>
+
+#include "xtensor/xarray.hpp"
+#include "xtensor/xio.hpp"
+#include "xtensor/xview.hpp"
+
+xt::xarray<double> arr1
+  {{1.0, 2.0, 3.0},
+   {2.0, 5.0, 7.0},
+   {2.0, 5.0, 7.0}};
+
+xt::xarray<double> arr2
+  {5.0, 6.0, 7.0};
+
+xt::view(arr1, 1) + arr2
+```
+
+Together with the C++ Jupyter kernel, `xtensor` offers a similar experience as `NumPy` in the Python Jupyter kernel, including broadcasting and universal functions.
+
+```{nb-code}
+#include <iostream>
+#include "xtensor/xarray.hpp"
+#include "xtensor/xio.hpp"
+```
+
+```{nb-code}
+xt::xarray<int> arr
+  {1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+arr.reshape({3, 3});
+
+std::cout << arr;
+```
+
+```{nb-code}
+#include "xtensor-blas/xlinalg.hpp"
+```
+
+```{nb-code}
+xt::xtensor<double, 2> m = {{1.5, 0.5}, {0.7, 1.0}};
+std::cout << "Matrix rank: " << std::endl << xt::linalg::matrix_rank(m) << std::endl;
+std::cout << "Matrix inverse: " << std::endl << xt::linalg::inv(m) << std::endl;
+std::cout << "Eigen values: " << std::endl << xt::linalg::eigvals(m) << std::endl;
+```
+
+```{nb-code}
+xt::xarray<double> arg1 = xt::arange<double>(9);
+xt::xarray<double> arg2 = xt::arange<double>(18);
+
+arg1.reshape({3, 3});
+arg2.reshape({2, 3, 3});
+
+std::cout << xt::linalg::dot(arg1, arg2) << std::endl;
+```
+
+```{nb-code}
+
+```

--- a/tests/test_ipynb_to_myst.py
+++ b/tests/test_ipynb_to_myst.py
@@ -1,0 +1,57 @@
+from textwrap import dedent
+import pytest
+from jupytext.myst import myst_to_notebook, CODE_DIRECTIVE, MystMetadataParsingError
+
+
+def test_bad_notebook_metadata():
+    """Test exception raised if notebook metadata cannot be parsed."""
+    with pytest.raises(MystMetadataParsingError):
+        myst_to_notebook(
+            dedent(
+                """\
+            ---
+            {{a
+            ---
+            """
+            )
+        )
+
+
+def test_bad_code_metadata():
+    """Test exception raised if cell metadata cannot be parsed."""
+    with pytest.raises(MystMetadataParsingError):
+        myst_to_notebook(
+            dedent(
+                """\
+            ```{{{0}}}
+            ---
+            {{a
+            ---
+            ```
+            """
+            ).format(CODE_DIRECTIVE)
+        )
+
+
+def test_bad_markdown_metadata():
+    """Test exception raised if markdown metadata cannot be parsed."""
+    with pytest.raises(MystMetadataParsingError):
+        myst_to_notebook(
+            dedent(
+                """\
+            +++ {{a
+            """
+            )
+        )
+
+
+def test_bad_markdown_metadata2():
+    """Test exception raised if markdown metadata is not a dict."""
+    with pytest.raises(MystMetadataParsingError):
+        myst_to_notebook(
+            dedent(
+                """\
+            +++ [1, 2]
+            """
+            )
+        )

--- a/tests/test_ipynb_to_myst.py
+++ b/tests/test_ipynb_to_myst.py
@@ -1,8 +1,10 @@
 from textwrap import dedent
 import pytest
 from jupytext.myst import myst_to_notebook, CODE_DIRECTIVE, MystMetadataParsingError
+from .utils import requires_myst
 
 
+@requires_myst
 def test_bad_notebook_metadata():
     """Test exception raised if notebook metadata cannot be parsed."""
     with pytest.raises(MystMetadataParsingError):
@@ -17,6 +19,7 @@ def test_bad_notebook_metadata():
         )
 
 
+@requires_myst
 def test_bad_code_metadata():
     """Test exception raised if cell metadata cannot be parsed."""
     with pytest.raises(MystMetadataParsingError):
@@ -33,6 +36,7 @@ def test_bad_code_metadata():
         )
 
 
+@requires_myst
 def test_bad_markdown_metadata():
     """Test exception raised if markdown metadata cannot be parsed."""
     with pytest.raises(MystMetadataParsingError):
@@ -45,6 +49,7 @@ def test_bad_markdown_metadata():
         )
 
 
+@requires_myst
 def test_bad_markdown_metadata2():
     """Test exception raised if markdown metadata is not a dict."""
     with pytest.raises(MystMetadataParsingError):

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -13,7 +13,13 @@ from jupytext.compare import compare_notebooks, combine_inputs_with_outputs
 from jupytext.formats import long_form_one_format, check_auto_ext, auto_ext_from_metadata
 from jupytext.languages import _SCRIPT_EXTENSIONS
 from jupytext.paired_paths import full_path
-from .utils import list_notebooks, skip_if_dict_is_not_ordered, requires_pandoc, requires_sphinx_gallery
+from .utils import (
+    list_notebooks,
+    skip_if_dict_is_not_ordered,
+    requires_pandoc,
+    requires_sphinx_gallery,
+    requires_myst,
+)
 
 pytestmark = skip_if_dict_is_not_ordered
 
@@ -123,6 +129,13 @@ def test_ipynb_to_Rmd(nb_file, no_jupytext_version_number):
                          list_notebooks('ipynb', skip='(functional|Notebook with|flavors|invalid|305)'))
 def test_ipynb_to_pandoc(nb_file, no_jupytext_version_number):
     assert_conversion_same_as_mirror(nb_file, 'md:pandoc', 'ipynb_to_pandoc')
+
+
+@requires_myst
+@pytest.mark.parametrize('nb_file',
+                         list_notebooks('ipynb_all', skip='html-demo|julia_functional_geometry|xcpp_by_quantstack'))
+def test_ipynb_to_myst(nb_file, no_jupytext_version_number):
+    assert_conversion_same_as_mirror(nb_file, 'mystnb', 'ipynb_to_myst')
 
 
 @requires_sphinx_gallery

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,6 +6,7 @@ from jupytext.cli import system
 from jupytext.cell_reader import rst2md
 from jupytext.pandoc import is_pandoc_available
 from jupytext.kernels import kernelspec_from_language
+from jupytext.myst import is_myst_available
 
 skip_if_dict_is_not_ordered = pytest.mark.skipif(
     sys.version_info < (3, 6),
@@ -29,6 +30,7 @@ requires_nbconvert = pytest.mark.skipif(not tool_version('jupyter nbconvert'), r
 requires_sphinx_gallery = pytest.mark.skipif(not rst2md, reason='sphinx_gallery is not available')
 requires_pandoc = pytest.mark.skipif(not is_pandoc_available(), reason='pandoc>=2.7.2 is not available')
 requires_ir_kernel = pytest.mark.skipif(kernelspec_from_language('R') is None, reason='irkernel is not installed')
+requires_myst = pytest.mark.skipif(not is_myst_available(), reason='myst_parser not founnd')
 
 
 def list_notebooks(path='ipynb', skip='World'):


### PR DESCRIPTION
Heya @mwouts the new format we have discussed for you to look at 😄 

closes #447, originally implemented in ExecutableBookProject/MyST-NB#82

See https://myst-parser.readthedocs.io and https://myst-nb.readthedocs.io for further details on the format. The file extension is still up for discussion. Also, at present, I copy `nbformat` and `nbformat_minor` to the front matter, but that's probably not necessary?

All tests pass, apart from 3 that are skipped due to diffs in newline characters at the end of markdown blocks, which don't actually affect the consistency of the round-trip.

cc'ing @choldgraf @AakashGfude @mmcky @jstac

