### PR TITLE
Use os.path.samefile rather than os.path.normpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 1.4.2 (2020-03-??)
 ------------------
 
+**Changed**
+- Use `os.path.samefile` when searching for the kernel that corresponds to the current environment (`--set-kernel -`)
+
 **Fixed**
 - Fixed the CLI example for not commenting out magic commands: `--opt comment_magics=false`. In addition, most of the `jupytext` commands in `using-cli.md` are now tested! (#465)
 

--- a/jupytext/kernels.py
+++ b/jupytext/kernels.py
@@ -1,5 +1,6 @@
 """Find kernel specifications for a given language"""
 
+import os
 import sys
 from .reraise import reraise
 from .languages import same_language
@@ -29,7 +30,8 @@ def kernelspec_from_language(language):
             # Return the kernel that matches the current Python executable
             for name in find_kernel_specs():
                 kernel_specs = get_kernel_spec(name)
-                if kernel_specs.language == 'python' and kernel_specs.argv[0] == sys.executable:
+                cmd = kernel_specs.argv[0]
+                if kernel_specs.language == 'python' and os.path.isfile(cmd) and os.path.samefile(cmd, sys.executable):
                     return {'name': name, 'language': language, 'display_name': kernel_specs.display_name}
 
             # If none was found, return the first kernel that has 'python' as argv[0]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -643,10 +643,6 @@ def test_update_metadata(py_file, tmpdir, capsys):
     assert 'invalid' in err
 
 
-def normpath(path):
-    return os.path.normpath(path).lower()
-
-
 @pytest.mark.parametrize('py_file', list_notebooks('python'))
 def test_set_kernel_inplace(py_file, tmpdir):
     tmp_py = str(tmpdir.join('notebook.py'))
@@ -657,7 +653,8 @@ def test_set_kernel_inplace(py_file, tmpdir):
 
     nb = read(tmp_py)
     kernel_name = nb.metadata['kernelspec']['name']
-    assert normpath(get_kernel_spec(kernel_name).argv[0]) in ['python', normpath(sys.executable)]
+    cmd = get_kernel_spec(kernel_name).argv[0]
+    assert cmd == 'python' or os.path.samefile(cmd, sys.executable)
 
 
 @pytest.mark.parametrize('py_file', list_notebooks('python'))
@@ -671,7 +668,8 @@ def test_set_kernel_auto(py_file, tmpdir):
 
     nb = read(tmp_ipynb)
     kernel_name = nb.metadata['kernelspec']['name']
-    assert normpath(get_kernel_spec(kernel_name).argv[0]) in ['python', normpath(sys.executable)]
+    cmd = get_kernel_spec(kernel_name).argv[0]
+    assert cmd == 'python' or os.path.samefile(cmd, sys.executable)
 
 
 @pytest.mark.parametrize('py_file', list_notebooks('python'))


### PR DESCRIPTION
We now use os.path.samefile to determine if a given kernel matches the current python environment. This fixes a few tests when running `pytest` on Windows.