### PR TITLE
Check format in jupytext.read and jupytext.write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 **Fixed**
 - Fixed the CLI example for not commenting out magic commands: `--opt comment_magics=false`. In addition, most of the `jupytext` commands in `using-cli.md` are now tested! (#465)
+- `jupytext.read` and `jupytext.write` now give more meaningful errors when the format information is incorrect (#462)
 
 1.4.1 (2020-03-19)
 ------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -165,7 +165,7 @@ def tmp_py(tmpdir):
 
 
 def test_error_not_notebook_ext_to(tmp_ipynb):
-    with pytest.raises(JupytextFormatError, match="Extension '.ext' is not a notebook extension. Please use one of"):
+    with pytest.raises(JupytextFormatError, match="'ext' is not a notebook extension"):
         jupytext([tmp_ipynb, '--to', 'ext'])
 
 

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -5,7 +5,7 @@ import jupytext
 from jupytext.formats import guess_format, divine_format, read_format_from_metadata, rearrange_jupytext_metadata
 from jupytext.formats import long_form_multiple_formats, short_form_multiple_formats, update_jupytext_formats_metadata
 from jupytext.formats import get_format_implementation, validate_one_format, JupytextFormatError
-from .utils import list_notebooks
+from .utils import list_notebooks, requires_myst
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('python'))
@@ -230,3 +230,26 @@ def test_pandoc_format_is_preserved():
     formats_new = short_form_multiple_formats(long)
 
     compare(formats_new, formats_org)
+
+
+@requires_myst
+def test_write_as_myst(tmpdir):
+    """Inspired by https://github.com/mwouts/jupytext/issues/462"""
+    nb = new_notebook()
+    tmp_md = str(tmpdir.join('notebook.md'))
+
+    jupytext.write(nb, tmp_md, fmt='myst')
+
+    with open(tmp_md) as fp:
+        md = fp.read()
+
+    assert 'myst' in md
+
+
+def test_write_raises_when_fmt_does_not_exists(tmpdir):
+    """Inspired by https://github.com/mwouts/jupytext/issues/462"""
+    nb = new_notebook()
+    tmp_md = str(tmpdir.join('notebook.md'))
+
+    with pytest.raises(JupytextFormatError):
+        jupytext.write(nb, tmp_md, fmt='unknown_format')

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -5,7 +5,7 @@ import jupytext
 from jupytext.formats import guess_format, divine_format, read_format_from_metadata, rearrange_jupytext_metadata
 from jupytext.formats import long_form_multiple_formats, short_form_multiple_formats, update_jupytext_formats_metadata
 from jupytext.formats import get_format_implementation, validate_one_format, JupytextFormatError
-from .utils import list_notebooks, requires_myst
+from .utils import list_notebooks, requires_myst, requires_pandoc
 
 
 @pytest.mark.parametrize('nb_file', list_notebooks('python'))
@@ -224,6 +224,7 @@ def test_set_auto_ext():
         long_form_multiple_formats('ipynb,auto:percent', {})
 
 
+@requires_pandoc
 def test_pandoc_format_is_preserved():
     formats_org = 'ipynb,md,.pandoc.md:pandoc,py:light'
     long = long_form_multiple_formats(formats_org)


### PR DESCRIPTION
`jupytext.read` and `jupytext.write` now give more meaningful errors when the format information is incorrect.

This closes #462.