### PR TITLE
Improve the string parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 **Fixed**
 - Fixed the CLI example for not commenting out magic commands: `--opt comment_magics=false`. In addition, most of the `jupytext` commands in `using-cli.md` are now tested! (#465)
 - `jupytext.read` and `jupytext.write` now give more meaningful errors when the format information is incorrect (#462)
+- Multiline comments starting with quadruple quotes should not cause issues anymore (#460)
 
 1.4.1 (2020-03-19)
 ------------------

--- a/jupytext/stringparser.py
+++ b/jupytext/stringparser.py
@@ -8,6 +8,7 @@ class StringParser:
     is quoted or not"""
     single = None
     triple = None
+    triple_start = None
 
     def __init__(self, language):
         self.ignore = language is None
@@ -29,6 +30,8 @@ class StringParser:
         if not self.is_quoted() and self.comment is not None and line.startswith(self.comment):
             return
 
+        self.triple_start = -1
+
         for i, char in enumerate(line):
             if char not in ['"', "'"]:
                 continue
@@ -46,13 +49,14 @@ class StringParser:
                 continue
 
             if self.triple == char:
-                if line[i - 2:i + 1] == 3 * char:
+                if line[i - 2:i + 1] == 3 * char and i >= self.triple_start + 3:
                     self.triple = None
                     continue
             if self.triple is not None:
                 continue
             if line[i - 2:i + 1] == 3 * char:
                 self.triple = char
+                self.triple_start = i
                 continue
             self.single = char
 

--- a/tests/test_read_simple_percent.py
+++ b/tests/test_read_simple_percent.py
@@ -405,3 +405,21 @@ def test_single_triple_quote_works(no_jupytext_version_number, text='''# ---
 print("hello")
 ''', notebook=new_notebook(cells=[new_code_cell('print("hello")')])):
     compare_notebooks(jupytext.reads(text, 'py'), notebook)
+
+
+def test_docstring_with_quadruple_quote(nb=new_notebook(cells=[
+    new_code_cell('''def fun_1(df):
+  """"
+  docstring starting with 4 double quotes and ending with 3
+  """
+  return df'''),
+    new_code_cell('''def fun_2(df):
+  """
+  docstring
+  """
+  return df''')
+])):
+    """Reproduces https://github.com/mwouts/jupytext/issues/460"""
+    py = jupytext.writes(nb, 'py:percent')
+    nb2 = jupytext.reads(py, 'py')
+    compare_notebooks(nb2, nb)

--- a/tests/test_stringparser.py
+++ b/tests/test_stringparser.py
@@ -37,3 +37,19 @@ def test_single_chars(text="""'This is a single line comment'''
     for line in text.splitlines():
         assert not sp.is_quoted()
         sp.read_line(line)
+
+
+def test_long_string_with_four_quotes(text="""''''This is a multiline
+comment that starts with four quotes
+'''
+
+1 + 1
+"""):
+    quoted = []
+    sp = StringParser('python')
+    for i, line in enumerate(text.splitlines()):
+        if sp.is_quoted():
+            quoted.append(i)
+        sp.read_line(line)
+
+    assert quoted == [1, 2]


### PR DESCRIPTION
Four consecutive quotes are a correct way to open multiline strings.
This fixes #460.