### PR TITLE
Update parsing of myst notebooks to new (markdown-it based) parser

### DIFF
--- a/jupytext/formats.py
+++ b/jupytext/formats.py
@@ -232,7 +232,7 @@ def read_format_from_metadata(text, ext):
 
 def guess_format(text, ext):
     """Guess the format and format options of the file, given its extension and content"""
-    if matches_mystnb(text, ext):
+    if is_myst_available() and matches_mystnb(text, ext):
         return MYST_FORMAT_NAME, {}
     lines = text.splitlines()
 

--- a/jupytext/myst.py
+++ b/jupytext/myst.py
@@ -43,7 +43,7 @@ def myst_extensions(no_md=False):
 def matches_mystnb(
     text,
     ext=None,
-    requires_meta=False,
+    requires_meta=True,
     code_directive=CODE_DIRECTIVE,
     raw_directive=RAW_DIRECTIVE,
 ):

--- a/jupytext/myst.py
+++ b/jupytext/myst.py
@@ -209,15 +209,15 @@ def myst_to_notebook(
     text,
     code_directive=CODE_DIRECTIVE,
     raw_directive=RAW_DIRECTIVE,
-    store_line_numbers=False,
+    add_source_map=False,
 ):
     """Convert text written in the myst format to a notebook.
 
     :param text: the file text
     :param code_directive: the name of the directive to search for containing code cells
     :param raw_directive: the name of the directive to search for containing raw cells
-    :param store_line_numbers: add a `_source_lines` key to cell metadata,
-        mapping to the source text.
+    :param add_source_map: add a `source_map` key to the notebook metadata,
+        which is a list of the starting source line number for each cell.
 
     :raises MystMetadataParsingError if the metadata block is not valid JSON/YAML
 
@@ -246,17 +246,17 @@ def myst_to_notebook(
     nbf_version = nbf.v4
     kwargs = {"metadata": nbf.from_dict(metadata_nb)}
     notebook = nbf_version.new_notebook(**kwargs)
+    source_map = []  # this is a list of the starting line number for each cell
 
     def _flush_markdown(start_line, token, md_metadata):
         """When we find a cell we check if there is preceding text.o"""
         endline = token.map[0] if token else len(lines)
         md_source = strip_blank_lines("\n".join(lines[start_line:endline]))
         meta = nbf.from_dict(md_metadata)
-        if store_line_numbers:
-            meta["_source_lines"] = [start_line, endline]
         if md_source:
+            source_map.append(start_line)
             notebook.cells.append(
-                nbf_version.new_markdown_cell(source=md_source, metadata=meta,)
+                nbf_version.new_markdown_cell(source=md_source, metadata=meta)
             )
 
     # iterate through the tokens to identify notebook cells
@@ -275,8 +275,7 @@ def myst_to_notebook(
             _flush_markdown(md_start_line, token, md_metadata)
             options, body_lines = read_fenced_cell(token, len(notebook.cells), "Code")
             meta = nbf.from_dict(options)
-            if store_line_numbers:
-                meta["_source_lines"] = [token.map[0] + 1, token.map[1]]
+            source_map.append(token.map[0] + 1)
             notebook.cells.append(
                 nbf_version.new_code_cell(source="\n".join(body_lines), metadata=meta)
             )
@@ -287,8 +286,7 @@ def myst_to_notebook(
             _flush_markdown(md_start_line, token, md_metadata)
             options, body_lines = read_fenced_cell(token, len(notebook.cells), "Raw")
             meta = nbf.from_dict(options)
-            if store_line_numbers:
-                meta["_source_lines"] = [token.map[0] + 1, token.map[1]]
+            source_map.append(token.map[0] + 1)
             notebook.cells.append(
                 nbf_version.new_raw_cell(source="\n".join(body_lines), metadata=meta)
             )
@@ -302,6 +300,8 @@ def myst_to_notebook(
 
     _flush_markdown(md_start_line, None, md_metadata)
 
+    if add_source_map:
+        notebook.metadata["source_map"] = source_map
     return notebook
 
 

--- a/jupytext/myst.py
+++ b/jupytext/myst.py
@@ -43,7 +43,7 @@ def myst_extensions(no_md=False):
 def matches_mystnb(
     text,
     ext=None,
-    requires_meta=True,
+    requires_meta=False,
     code_directive=CODE_DIRECTIVE,
     raw_directive=RAW_DIRECTIVE,
 ):

--- a/jupytext/myst.py
+++ b/jupytext/myst.py
@@ -73,7 +73,7 @@ def matches_mystnb(
         return False
 
     # Is the format information available in the jupytext text representation?
-    if tokens[0].type == "front_matter":
+    if tokens and tokens[0].type == "front_matter":
         from jupytext.formats import format_name_for_ext
 
         try:

--- a/jupytext/myst.py
+++ b/jupytext/myst.py
@@ -64,9 +64,13 @@ def matches_mystnb(
 
     from myst_parser.main import default_parser
 
-    # parse markdown file up to the block level (i.e. don't worry about inline text)
-    parser = default_parser("html", disable_syntax=["inline"])
-    tokens = parser.parse(text + "\n")
+    try:
+        # parse markdown file up to the block level (i.e. don't worry about inline text)
+        parser = default_parser("html", disable_syntax=["inline"])
+        tokens = parser.parse(text + "\n")
+    except Exception as err:
+        warnings.warn("myst-parse failed unexpectedly: {}".format(err))
+        return False
 
     # Is the format information available in the jupytext text representation?
     if tokens[0].type == "front_matter":

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     entry_points={'console_scripts': ['jupytext = jupytext.cli:jupytext']},
     tests_require=['pytest'],
     install_requires=['nbformat>=4.0.0', 'pyyaml', 'mock;python_version<"3"'],
-    extras_require={"myst": ["myst-parser==0.8.0a3; python_version >= '3.6'"]},
+    extras_require={"myst": ["myst-parser~=0.8; python_version >= '3.6'"]},
     license='MIT',
     classifiers=['Development Status :: 5 - Production/Stable',
                  'License :: OSI Approved :: MIT License',

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     entry_points={'console_scripts': ['jupytext = jupytext.cli:jupytext']},
     tests_require=['pytest'],
     install_requires=['nbformat>=4.0.0', 'pyyaml', 'mock;python_version<"3"'],
-    extras_require={"myst": ["myst-parser~=0.7.1; python_version >= '3.6'"]},
+    extras_require={"myst": ["myst-parser==0.8.0a3; python_version >= '3.6'"]},
     license='MIT',
     classifiers=['Development Status :: 5 - Production/Stable',
                  'License :: OSI Approved :: MIT License',

--- a/tests/test_ipynb_to_myst.py
+++ b/tests/test_ipynb_to_myst.py
@@ -124,7 +124,7 @@ def test_not_installed():
 
 
 @requires_myst
-def test_store_line_numbers():
+def test_add_source_map():
     notebook = myst_to_notebook(
         dedent(
             """\
@@ -143,36 +143,6 @@ def test_store_line_numbers():
             xyz
             """
         ).format(CODE_DIRECTIVE),
-        store_line_numbers=True,
+        add_source_map=True,
     )
-    expected = {
-        "nbformat": 4,
-        "nbformat_minor": 4,
-        "metadata": {"a": 1},
-        "cells": [
-            {
-                "cell_type": "markdown",
-                "source": "abc",
-                "metadata": {"_source_lines": [3, 4]},
-            },
-            {
-                "cell_type": "markdown",
-                "source": "def",
-                "metadata": {"_source_lines": [5, 6]},
-            },
-            {
-                "cell_type": "code",
-                "metadata": {"b": 2, "_source_lines": [7, 12]},
-                "execution_count": None,
-                "source": "c = 3",
-                "outputs": [],
-            },
-            {
-                "cell_type": "markdown",
-                "source": "xyz",
-                "metadata": {"_source_lines": [12, 13]},
-            },
-        ],
-    }
-    notebook.nbformat_minor = 4
-    compare_notebooks(notebook, from_dict(expected))
+    assert notebook.metadata.source_map == [3, 5, 7, 12]

--- a/tests/test_ipynb_to_myst.py
+++ b/tests/test_ipynb_to_myst.py
@@ -40,7 +40,7 @@ def test_bad_code_metadata():
         myst_to_notebook(
             dedent(
                 """\
-            ```{{{0}}}
+            ```{0}
             ---
             {{a
             ---
@@ -105,6 +105,16 @@ def test_matches_mystnb():
         """
     )
     assert matches_mystnb(text) is True
+    text = dedent(
+        """\
+        ---
+        a: 1
+        ---
+        > ```{code-cell}
+          ```
+        """
+    )
+    assert matches_mystnb(text) is True
 
 
 def test_not_installed():
@@ -115,7 +125,7 @@ def test_not_installed():
 
 @requires_myst
 def test_store_line_numbers():
-    notebook = matches_mystnb(
+    notebook = myst_to_notebook(
         dedent(
             """\
             ---
@@ -124,7 +134,7 @@ def test_store_line_numbers():
             abc
             +++
             def
-            ```{{{0}}}
+            ```{0}
             ---
             b: 2
             ---
@@ -134,7 +144,6 @@ def test_store_line_numbers():
             """
         ).format(CODE_DIRECTIVE),
         store_line_numbers=True,
-        return_nb=True
     )
     expected = {
         "nbformat": 4,

--- a/tests/test_ipynb_to_myst.py
+++ b/tests/test_ipynb_to_myst.py
@@ -4,9 +4,7 @@ except ImportError:
     import mock
 from textwrap import dedent
 import pytest
-from nbformat import from_dict
 
-from jupytext.compare import compare_notebooks
 from jupytext.formats import get_format_implementation, JupytextFormatError
 from jupytext.myst import (
     myst_to_notebook,


### PR DESCRIPTION
Hey @mwouts, first just to clarify this should not be merged just yet. It is an update to use the (currently) pre-release ExecutableBookProject/MyST-Parser#123, which utilises [markdown-it-py](https://github.com/ExecutableBookProject/markdown-it-py), my shiny new markdown parser 😁 

As you can see, it does not affect any of the tests, and thus shouldn't be noticeable on the front-end.