### PR TITLE
New rules for combining inputs with outputs

### DIFF
--- a/jupytext/combine.py
+++ b/jupytext/combine.py
@@ -94,15 +94,15 @@ def map_outputs_to_inputs(cells_inputs, cells_outputs):
     n_out = len(cells_outputs)
     outputs_map = [None] * n_in
 
-    # First rule: match based on cell type, content, in increasing order
-    current_j = 0
+    # First rule: match based on cell type, content, in increasing order, for each cell type
+    first_unmatched_output_per_cell_type = {}
     for i in range(n_in):
         cell_input = cells_inputs[i]
-        for j in range(current_j, n_out):
+        for j in range(first_unmatched_output_per_cell_type.get(cell_input.cell_type, 0), n_out):
             cell_output = cells_outputs[j]
             if cell_input.cell_type == cell_output.cell_type and same_content(cell_input.source, cell_output.source):
                 outputs_map[i] = j
-                current_j = j + 1
+                first_unmatched_output_per_cell_type[cell_input.cell_type] = j + 1
                 break
 
     # Second rule: match unused outputs based on cell type and content
@@ -124,7 +124,7 @@ def map_outputs_to_inputs(cells_inputs, cells_outputs):
                     unused_ouputs.remove(j)
                     break
 
-    # Fourth rule: match based on increasing index, for non-empty cells
+    # Fourth rule: match based on increasing index (and cell type) for non-empty cells
     if not unused_ouputs:
         return outputs_map
 
@@ -140,7 +140,7 @@ def map_outputs_to_inputs(cells_inputs, cells_outputs):
 
         cell_input = cells_inputs[i]
         cell_output = cells_outputs[j]
-        if cell_input.cell_type == cell_output.cell_type and cell_input.source:
+        if cell_input.cell_type == cell_output.cell_type and cell_input.source.strip() != '':
             outputs_map[i] = j
             unused_ouputs.remove(j)
             prev_j = j

--- a/jupytext/combine.py
+++ b/jupytext/combine.py
@@ -21,9 +21,12 @@ def black_invariant(text, chars=None):
 
 def same_content(ref, test, endswith=False):
     """Is the content of two cells the same, up to reformating by black"""
-    if endswith:
-        return black_invariant(ref).endswith(black_invariant(test))
-    return black_invariant(ref) == black_invariant(test)
+    ref = black_invariant(ref)
+    test = black_invariant(test)
+
+    if endswith and test:
+        return ref.endswith(test)
+    return ref == test
 
 
 def combine_inputs_with_outputs(nb_source, nb_outputs, fmt=None):


### PR DESCRIPTION
This PR implements new rules for combining the outputs from the `.ipynb` notebook, with the inputs from the text notebook.

The matching rules are implemented at [`jupytext.combine.map_outputs_to_inputs`](https://github.com/mwouts/jupytext/blob/3a7bf840e57a96145792cf90bc969862c6582dca/jupytext/combine.py#L88), are at tested in [`test_combine.py`](https://github.com/mwouts/jupytext/blob/3a7bf840e57a96145792cf90bc969862c6582dca/tests/test_combine.py).

I have tested that
- an unchanged notebook does not see any change in its outputs
- an notebook with reordered cells has its outputs reordered
- a notebook in which cells are splitted sees the outputs going to the last chunck of the splitted cell
- and a notebook refactored has the outputs attributed according to the cell index.

This closes #464 