### PR TITLE
Increase pylint score to 9.78

### DIFF
--- a/jupytext/cli.py
+++ b/jupytext/cli.py
@@ -77,30 +77,30 @@ def parse_jupytext_args(args=None):
                              'on the notebooks found in the git index, which have an\n'
                              'extension that matches the (optional) --from argument.\n')
     # Destination format & act on metadata
-    parser.add_argument('--to',
-                        help="Destination format: either 'notebook' (extension .ipynb),\n"
-                             "'markdown' (.md), 'rmarkdown' (.Rmd), 'script', a supported\n"
-                             "extension, or an explicit extension/format description\n"
-                             "[prefix_path//][suffix.]ext[:format_name], where\n" +
-                             "- ext is one of {}, or auto\n"
-                        .format(', '.join(ext[1:] for ext in NOTEBOOK_EXTENSIONS)) +
-                             "- format_name is optional, and can be {} for Markdown\nfiles, and ".format(
-                                 ' or '.join(
-                                     set(fmt.format_name for fmt in JUPYTEXT_FORMATS if fmt.extension == '.md'))) +
-                             "{} for scripts.\n".format(
-                                 ', '.join(set(fmt.format_name for fmt in JUPYTEXT_FORMATS if fmt.extension == '.py')))
-                             +
-                             "The default format for scripts is the 'light' format,\n"
-                             "which uses few cell markers (none when possible).\n"
-                             "Alternatively, a format compatible with many editors is the\n"
-                             "'percent' format, which uses '# %%%%' as cell markers\n"
-                             "The main formats (markdown, light, percent) preserve\n"
-                             "notebooks and text documents in a roundtrip. Use the\n"
-                             "--test and and --test-strict commands to test the roundtrip\n"
-                             "on your files.\n"
-                             "Read more about the available formats at\n"
-                             "https://jupytext.readthedocs.io/en/latest/formats.html\n"
-                        )
+    parser.add_argument(
+        '--to',
+        help=("Destination format: either 'notebook' (extension .ipynb),\n"
+              "'markdown' (.md), 'rmarkdown' (.Rmd), 'script', a supported\n"
+              "extension, or an explicit extension/format description\n"
+              "[prefix_path//][suffix.]ext[:format_name], where\n" +
+              "- ext is one of {}, or auto\n".format(', '.join(ext[1:] for ext in NOTEBOOK_EXTENSIONS)) +
+              "- format_name is optional, and can be {} for Markdown\nfiles, and ".format(
+                  ' or '.join(
+                      set(fmt.format_name for fmt in JUPYTEXT_FORMATS if fmt.extension == '.md'))) +
+              "{} for scripts.\n".format(
+                  ', '.join(set(fmt.format_name for fmt in JUPYTEXT_FORMATS if fmt.extension == '.py')))
+              +
+              "The default format for scripts is the 'light' format,\n"
+              "which uses few cell markers (none when possible).\n"
+              "Alternatively, a format compatible with many editors is the\n"
+              "'percent' format, which uses '# %%%%' as cell markers\n"
+              "The main formats (markdown, light, percent) preserve\n"
+              "notebooks and text documents in a roundtrip. Use the\n"
+              "--test and and --test-strict commands to test the roundtrip\n"
+              "on your files.\n"
+              "Read more about the available formats at\n"
+              "https://jupytext.readthedocs.io/en/latest/formats.html\n")
+    )
     parser.add_argument('--format-options', '--opt',
                         action='append',
                         help='Set format options with e.g.\n'
@@ -446,7 +446,7 @@ def jupytext_single_file(nb_file, args, log):
                     # white spaces between the comment char and the YAML delimiters are allowed
                     if comment:
                         comment = comment + r'\s*'
-                    yaml_header = re.compile(r'^{}---\s*\n.*\n{}---\s*\n'.format(comment, comment),
+                    yaml_header = re.compile(r'^{comment}---\s*\n.*\n{comment}---\s*\n'.format(comment=comment),
                                              re.MULTILINE | re.DOTALL)
                     compare(re.sub(yaml_header, '', text),
                             re.sub(yaml_header, '', org_text))

--- a/jupytext/formats.py
+++ b/jupytext/formats.py
@@ -232,14 +232,15 @@ def read_format_from_metadata(text, ext):
 
 def guess_format(text, ext):
     """Guess the format and format options of the file, given its extension and content"""
-    if is_myst_available() and matches_mystnb(text, ext):
-        return MYST_FORMAT_NAME, {}
-    lines = text.splitlines()
-
     metadata = read_metadata(text, ext)
 
     if 'text_representation' in metadata.get('jupytext', {}):
         return format_name_for_ext(metadata, ext), {}
+
+    if is_myst_available() and matches_mystnb(text, ext):
+        return MYST_FORMAT_NAME, {}
+
+    lines = text.splitlines()
 
     # Is this a Hydrogen-like script?
     # Or a Sphinx-gallery script?

--- a/jupytext/jupytext.py
+++ b/jupytext/jupytext.py
@@ -140,11 +140,12 @@ class TextNotebookConverter(NotebookReader, NotebookWriter):
                     cells.append(new_code_cell(source=cell.source, metadata=cell_metadata))
                 else:
                     cells.append(NotebookNode(source=cell.source, metadata=cell_metadata, cell_type=cell.cell_type))
-            return notebook_to_myst(NotebookNode(
-                nbformat=nb.nbformat,
-                nbformat_minor=nb.nbformat_minor,
-                metadata=metadata,
-                cells=cells),
+            return notebook_to_myst(
+                NotebookNode(
+                    nbformat=nb.nbformat,
+                    nbformat_minor=nb.nbformat_minor,
+                    metadata=metadata,
+                    cells=cells),
                 default_lexer=pygments_lexer)
 
         # Copy the notebook, in order to be sure we do not modify the original notebook

--- a/jupytext/myst.py
+++ b/jupytext/myst.py
@@ -41,11 +41,11 @@ def myst_extensions(no_md=False):
 
 
 def matches_mystnb(
-    text,
-    ext=None,
-    requires_meta=True,
-    code_directive=CODE_DIRECTIVE,
-    raw_directive=RAW_DIRECTIVE,
+        text,
+        ext=None,
+        requires_meta=True,
+        code_directive=CODE_DIRECTIVE,
+        raw_directive=RAW_DIRECTIVE,
 ):
     """Attempt to distinguish a file as myst, only given its extension and content.
 
@@ -92,8 +92,8 @@ def matches_mystnb(
     # is there at least on fenced code block with a code/raw directive language
     for token in tokens:
         if token.type == "fence" and (
-            token.info.startswith(code_directive)
-            or token.info.startswith(raw_directive)
+                token.info.startswith(code_directive)
+                or token.info.startswith(raw_directive)
         ):
             return True
 
@@ -206,10 +206,10 @@ def read_cell_metadata(token, cell_index):
 
 
 def myst_to_notebook(
-    text,
-    code_directive=CODE_DIRECTIVE,
-    raw_directive=RAW_DIRECTIVE,
-    add_source_map=False,
+        text,
+        code_directive=CODE_DIRECTIVE,
+        raw_directive=RAW_DIRECTIVE,
+        add_source_map=False,
 ):
     """Convert text written in the myst format to a notebook.
 
@@ -306,7 +306,7 @@ def myst_to_notebook(
 
 
 def notebook_to_myst(
-    nb, code_directive=CODE_DIRECTIVE, raw_directive=RAW_DIRECTIVE, default_lexer=None,
+        nb, code_directive=CODE_DIRECTIVE, raw_directive=RAW_DIRECTIVE, default_lexer=None,
 ):
     """Parse a notebook to a MyST formatted text document.
 

--- a/jupytext/myst.py
+++ b/jupytext/myst.py
@@ -14,7 +14,8 @@ try:
     from myst_parser.main import default_parser
     from myst_parser.parse_directives import DirectiveParsingError, parse_directive_text
 except ImportError as err:
-    myst_parser = DirectiveParsingError = None
+    myst_parser = None
+    DirectiveParsingError = Exception
     default_parser = parse_directive_text = reraise(err)
 
 MYST_FORMAT_NAME = "myst"


### PR DESCRIPTION
I followed pylint's suggestions and
- fixed whitespaces issues
- moved imports at the top
- added docstrings
- and used more specific exception catching

@chrisjsewell , could you let me know if you're OK with this? I think we should double check the exception catching on `parser.parse` in `matches_mystnb` - can we really narrow it to `(TypeError, ValueError)` ?