### PR TITLE
Use double quotes for long commands on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 **Added**
 - Jupytext is tested in `pip` and `conda` environments, on Linux, Mac OS and Windows, using Github actions (#487)
 - Pre-commit checks and automatic reformatting of Jupytext's code with `pre-commit`, `black` and `flake8` (#483)
-- Documented that the YAML header can be created with either `--set-kernel`, `--set-formats`, or both (#485)
+- Mention that the YAML header can be created with either `--set-kernel`, `--set-formats`, or both (#485)
+- Mention that one should use double quotes, not single quotes, around `jupytext --check` commands like `"pytest {}"` on Windows (#475)
 
 **Fixed**
 - Skip the `jupytext --execute` tests when the warning _Timeout waiting for IOPub output_ occurs, which is the case intermittently on Windows (#489)

--- a/docs/using-cli.md
+++ b/docs/using-cli.md
@@ -47,7 +47,8 @@ For programs that don't accept pipes, use `{}` as a placeholder for the name of 
 ```bash
 jupytext --check 'pytest {}' notebook.ipynb    # export the notebook in format py:percent in a temp file, run pytest
 ```
-(read more about running `pytest` on notebooks in our example [`Tests in a notebook.md`](https://github.com/mwouts/jupytext/blob/master/demo/Tests%20in%20a%20notebook.md#)).
+Read more about running `pytest` on notebooks in our example [`Tests in a notebook.md`](https://github.com/mwouts/jupytext/blob/master/demo/Tests%20in%20a%20notebook.md#).
+Note also that on Windows you need to use double quotes instead of single quotes and type e.g. `jupytext --check "pytest {}" notebook.ipynb`.
 
 Execute `jupytext --help` to access the full documentation.
 


### PR DESCRIPTION
Closes #475 