### PR TITLE
Catch expected warnings in the test suite

### DIFF
--- a/tests/test_read_simple_nomarker.py
+++ b/tests/test_read_simple_nomarker.py
@@ -46,7 +46,8 @@ def h(x):
         text = writes(nb2, "py:bare")
     with pytest.warns(DeprecationWarning, match="nomarker"):
         nb3 = reads(text, "py:bare")
-    combine_inputs_with_outputs(nb3, nb2, "py:bare")
+    with pytest.warns(DeprecationWarning, match="nomarker"):
+        combine_inputs_with_outputs(nb3, nb2, "py:bare")
     nb3.metadata.pop("jupytext")
 
     compare(nb3, nb2)

--- a/tests/test_read_simple_percent.py
+++ b/tests/test_read_simple_percent.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import pytest
 from nbformat.v4.nbbase import (
     new_notebook,
     new_code_cell,
@@ -434,7 +435,8 @@ def test_default_cell_markers_in_contents_manager_does_not_impact_light_format(t
             "jupytext": {"formats": "ipynb,py", "notebook_metadata_filter": "-all"}
         },
     )
-    cm.save(model=dict(type="notebook", content=nb), path="notebook.ipynb")
+    with pytest.warns(UserWarning, match="Ignored cell markers"):
+        cm.save(model=dict(type="notebook", content=nb), path="notebook.ipynb")
 
     assert os.path.isfile(tmp_ipynb)
     assert os.path.isfile(tmp_py)


### PR DESCRIPTION
This removes the last two warnings when running `pytest`.