### PR TITLE
Simplify format options on the CLI

### DIFF
--- a/jupytext/paired_paths.py
+++ b/jupytext/paired_paths.py
@@ -13,7 +13,7 @@ class InconsistentPath(ValueError):
 
 def base_path(main_path, fmt):
     """Given a path and options for a format (ext, suffix, prefix), return the corresponding base path"""
-    if not fmt:
+    if not fmt or (isinstance(fmt, dict) and "extension" not in fmt):
         base, ext = os.path.splitext(main_path)
         if ext not in NOTEBOOK_EXTENSIONS:
             raise InconsistentPath(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1260,3 +1260,22 @@ def test_create_header_with_set_formats_and_set_kernel(format_name, tmpdir):
     nb = read(tmp_nb)
     assert nb["metadata"]["jupytext"]["formats"] == format_name
     assert "kernelspec" in nb["metadata"]
+
+
+def test_set_option_split_at_heading(tmpdir):
+    tmp_rmd = tmpdir.join("notebook.Rmd")
+    tmp_rmd.write(
+        """A paragraph
+
+# H1 Header
+"""
+    )
+
+    jupytext([str(tmp_rmd), "--opt", "split_at_heading=true"])
+    assert "split_at_heading: true" in tmp_rmd.read()
+    nb = read(str(tmp_rmd))
+
+    nb_expected = new_notebook(
+        cells=[new_markdown_cell("A paragraph"), new_markdown_cell("# H1 Header")]
+    )
+    compare_notebooks(nb, nb_expected)

--- a/tests/test_read_simple_markdown.py
+++ b/tests/test_read_simple_markdown.py
@@ -265,6 +265,25 @@ def test_split_on_header_after_two_blank_lines(
     compare(markdown2, markdown)
 
 
+def test_split_at_heading_in_metadata(
+    markdown="""---
+jupyter:
+  jupytext:
+    split_at_heading: true
+---
+
+A paragraph
+
+# H1 Header
+""",
+    nb_expected=new_notebook(
+        cells=[new_markdown_cell("A paragraph"), new_markdown_cell("# H1 Header")]
+    ),
+):
+    nb = jupytext.reads(markdown, ".md")
+    compare_notebooks(nb, nb_expected)
+
+
 def test_code_cell_with_metadata(
     markdown="""```python tags=["parameters"]
 a = 1


### PR DESCRIPTION
Jupytext can be used to set format options on the command line (#130) with e.g. 

    jupytext --opt split_at_heading=true notebook.Rmd