### PR TITLE
Fix new text notebook

### DIFF
--- a/jupyter-config/nbconfig/notebook.d/jupytext.json
+++ b/jupyter-config/nbconfig/notebook.d/jupytext.json
@@ -1,5 +1,5 @@
 {
   "load_extensions": {
-    "jupytext/index": true
+    "jupytext/jupytext": true
   }
 }

--- a/jupytext/version.py
+++ b/jupytext/version.py
@@ -1,3 +1,3 @@
 """Jupytext's version number"""
 
-__version__ = "1.5.0.rc2"
+__version__ = "1.5.0.rc3"

--- a/tests/test_contentsmanager.py
+++ b/tests/test_contentsmanager.py
@@ -1708,5 +1708,7 @@ def test_new_untitled(tmpdir):
     cm = jupytext.TextFileContentsManager()
     cm.root_dir = str(tmpdir)
 
-    assert cm.new_untitled(type="notebook", ext=".md")["path"] == "Untitled.md"
+    assert cm.new_untitled(type="notebook")["path"] == "Untitled.ipynb"
     assert cm.new_untitled(type="notebook", ext=".md")["path"] == "Untitled1.md"
+    assert cm.new_untitled(type="notebook", ext=".py")["path"] == "Untitled2.py"
+    assert cm.new_untitled(type="notebook")["path"] == "Untitled3.ipynb"


### PR DESCRIPTION
- The notebook extension is activated by default
- `new_untitled` works with the default extensions (`""` and `".ipynb"`)

Closes #443 