### PR TITLE
Root prefix not above config

### DIFF
--- a/jupytext/config.py
+++ b/jupytext/config.py
@@ -10,10 +10,6 @@ from .formats import (
     long_form_multiple_formats,
     rearrange_jupytext_metadata,
 )
-from .paired_paths import (
-    base_path,
-    InconsistentPath,
-)
 
 JUPYTEXT_CONFIG_FILES = [
     "jupytext",
@@ -138,6 +134,11 @@ class JupytextConfiguration(Configurable):
 
     def default_formats(self, path):
         """Return the default formats, if they apply to the current path #157"""
+        from .paired_paths import (
+            base_path,
+            InconsistentPath,
+        )
+
         formats = long_form_multiple_formats(self.default_jupytext_formats)
         for fmt in formats:
             try:

--- a/jupytext/paired_paths.py
+++ b/jupytext/paired_paths.py
@@ -131,6 +131,10 @@ def base_path(main_path, fmt):
             )
         left, right = long_notebook_dir.rsplit(long_prefix_root, 1)
         notebook_dir = left + sep + "//" + right
+
+        # We are going to remove the last char, but we need to insert it back in the end...
+        if not right:
+            sep = notebook_dir[-1]
         notebook_dir = notebook_dir[len(sep) : -len(sep)]
 
     if base_dir:

--- a/jupytext/paired_paths.py
+++ b/jupytext/paired_paths.py
@@ -4,6 +4,7 @@ import os
 from .formats import long_form_one_format, long_form_multiple_formats
 from .formats import short_form_one_format, short_form_multiple_formats
 from .formats import NOTEBOOK_EXTENSIONS
+from .config import find_jupytext_configuration_file
 
 
 class InconsistentPath(ValueError):
@@ -67,6 +68,14 @@ def base_path(main_path, fmt):
     notebook_dir, notebook_file_name = split(base)
     sep = base[len(notebook_dir) : -len(notebook_file_name)]
 
+    base_dir = None
+    config_file = find_jupytext_configuration_file(notebook_dir)
+    if config_file:
+        config_file_dir = os.path.dirname(config_file)
+        if notebook_dir.startswith(config_file_dir):
+            base_dir = config_file_dir
+            notebook_dir = notebook_dir[len(config_file_dir) :]
+
     if prefix_file_name:
         if not notebook_file_name.startswith(prefix_file_name):
             raise InconsistentPath(
@@ -115,6 +124,9 @@ def base_path(main_path, fmt):
             )
         notebook_dir = "///".join(long_notebook_dir.rsplit(long_prefix_root, 1))
         notebook_dir = notebook_dir[len(sep) : -len(sep)]
+
+    if base_dir:
+        notebook_dir = base_dir + notebook_dir
 
     if not notebook_dir:
         return notebook_file_name


### PR DESCRIPTION
- Notebook pairings are bounded by the config directory
- Fixed paired notebooks in trees when the notebook is right under the notebook folder