### PR TITLE
Add Coconut language

### DIFF
--- a/jupytext/languages.py
+++ b/jupytext/languages.py
@@ -8,6 +8,7 @@ _JUPYTER_LANGUAGES = [
     "python",
     "python2",
     "python3",
+    "coconut",
     "javascript",
     "js",
     "perl",
@@ -30,6 +31,7 @@ _JUPYTER_LANGUAGES = [
 # Please add more languages here (and add a few tests) - see CONTRIBUTING.md
 _SCRIPT_EXTENSIONS = {
     ".py": {"language": "python", "comment": "#"},
+    ".coco": {"language": "coconut", "comment": "#"},
     ".R": {"language": "R", "comment": "#"},
     ".r": {"language": "R", "comment": "#"},
     ".jl": {"language": "julia", "comment": "#"},

--- a/tests/notebooks/ipynb_coconut/coconut_homepage_demo.ipynb
+++ b/tests/notebooks/ipynb_coconut/coconut_homepage_demo.ipynb
@@ -1,0 +1,401 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Taken fron [coconut-lang.org](coconut-lang.org)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "pipeline-style programming"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hello, world!\n"
+     ]
+    }
+   ],
+   "source": [
+    "\"hello, world!\" |> print"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    " prettier lambdas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<function __main__.<lambda>(x)>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x -> x ** 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "partial application"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[0, 1, 4, 9, 16, 25, 36, 49, 64, 81]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "range(10) |> map$(pow$(?, 2)) |> list"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "pattern-matching"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0 [1, 2, 3]\n"
+     ]
+    }
+   ],
+   "source": [
+    "match [head] + tail in [0, 1, 2, 3]:\n",
+    "    print(head, tail)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "destructuring assignment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "{\"list\": [0] + rest} = {\"list\": [0, 1, 2, 3]}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "infix notation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 5 `mod` 3 == 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "operator functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "product = reduce$(*)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "function composition"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# (f..g..h)(x, y, z)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "lazy lists"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# (| first_elem() |) :: rest_elems()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "parallel programming"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[1.0,\n",
+       " 2.0,\n",
+       " 4.0,\n",
+       " 8.0,\n",
+       " 16.0,\n",
+       " 32.0,\n",
+       " 64.0,\n",
+       " 128.0,\n",
+       " 256.0,\n",
+       " 512.0,\n",
+       " 1024.0,\n",
+       " 2048.0,\n",
+       " 4096.0,\n",
+       " 8192.0,\n",
+       " 16384.0,\n",
+       " 32768.0,\n",
+       " 65536.0,\n",
+       " 131072.0,\n",
+       " 262144.0,\n",
+       " 524288.0,\n",
+       " 1048576.0,\n",
+       " 2097152.0,\n",
+       " 4194304.0,\n",
+       " 8388608.0,\n",
+       " 16777216.0,\n",
+       " 33554432.0,\n",
+       " 67108864.0,\n",
+       " 134217728.0,\n",
+       " 268435456.0,\n",
+       " 536870912.0,\n",
+       " 1073741824.0,\n",
+       " 2147483648.0,\n",
+       " 4294967296.0,\n",
+       " 8589934592.0,\n",
+       " 17179869184.0,\n",
+       " 34359738368.0,\n",
+       " 68719476736.0,\n",
+       " 137438953472.0,\n",
+       " 274877906944.0,\n",
+       " 549755813888.0,\n",
+       " 1099511627776.0,\n",
+       " 2199023255552.0,\n",
+       " 4398046511104.0,\n",
+       " 8796093022208.0,\n",
+       " 17592186044416.0,\n",
+       " 35184372088832.0,\n",
+       " 70368744177664.0,\n",
+       " 140737488355328.0,\n",
+       " 281474976710656.0,\n",
+       " 562949953421312.0,\n",
+       " 1125899906842624.0,\n",
+       " 2251799813685248.0,\n",
+       " 4503599627370496.0,\n",
+       " 9007199254740992.0,\n",
+       " 1.8014398509481984e+16,\n",
+       " 3.602879701896397e+16,\n",
+       " 7.205759403792794e+16,\n",
+       " 1.4411518807585587e+17,\n",
+       " 2.8823037615171174e+17,\n",
+       " 5.764607523034235e+17,\n",
+       " 1.152921504606847e+18,\n",
+       " 2.305843009213694e+18,\n",
+       " 4.611686018427388e+18,\n",
+       " 9.223372036854776e+18,\n",
+       " 1.8446744073709552e+19,\n",
+       " 3.6893488147419103e+19,\n",
+       " 7.378697629483821e+19,\n",
+       " 1.4757395258967641e+20,\n",
+       " 2.9514790517935283e+20,\n",
+       " 5.902958103587057e+20,\n",
+       " 1.1805916207174113e+21,\n",
+       " 2.3611832414348226e+21,\n",
+       " 4.722366482869645e+21,\n",
+       " 9.44473296573929e+21,\n",
+       " 1.888946593147858e+22,\n",
+       " 3.777893186295716e+22,\n",
+       " 7.555786372591432e+22,\n",
+       " 1.5111572745182865e+23,\n",
+       " 3.022314549036573e+23,\n",
+       " 6.044629098073146e+23,\n",
+       " 1.2089258196146292e+24,\n",
+       " 2.4178516392292583e+24,\n",
+       " 4.835703278458517e+24,\n",
+       " 9.671406556917033e+24,\n",
+       " 1.9342813113834067e+25,\n",
+       " 3.8685626227668134e+25,\n",
+       " 7.737125245533627e+25,\n",
+       " 1.5474250491067253e+26,\n",
+       " 3.094850098213451e+26,\n",
+       " 6.189700196426902e+26,\n",
+       " 1.2379400392853803e+27,\n",
+       " 2.4758800785707605e+27,\n",
+       " 4.951760157141521e+27,\n",
+       " 9.903520314283042e+27,\n",
+       " 1.9807040628566084e+28,\n",
+       " 3.961408125713217e+28,\n",
+       " 7.922816251426434e+28,\n",
+       " 1.5845632502852868e+29,\n",
+       " 3.1691265005705735e+29,\n",
+       " 6.338253001141147e+29]"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "range(100) |> parallel_map$(pow$(2)) |> list"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "tail call optimization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def factorial(n, acc=1):\n",
+    "    case n:\n",
+    "        match 0:\n",
+    "            return acc\n",
+    "        match _ is int if n > 0:\n",
+    "            return factorial(n-1, acc*n)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "algebraic data types"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data Empty()\n",
+    "data Leaf(n)\n",
+    "data Node(l, r)\n",
+    "\n",
+    "def size(Empty()) = 0\n",
+    "\n",
+    "addpattern def size(Leaf(n)) = 1\n",
+    "\n",
+    "addpattern def size(Node(l, r)) = size(l) + size(r)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "and much more!\n",
+    "\n",
+    "Like what you see? Don't forget to star Coconut on GitHub!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Coconut",
+   "language": "coconut",
+   "name": "coconut"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "python",
+    "version": 3
+   },
+   "file_extension": ".coco",
+   "mimetype": "text/x-python3",
+   "name": "coconut",
+   "pygments_lexer": "coconut",
+   "version": "1.4.3-post_dev25"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tests/notebooks/mirror/ipynb_to_Rmd/coconut_homepage_demo.Rmd
+++ b/tests/notebooks/mirror/ipynb_to_Rmd/coconut_homepage_demo.Rmd
@@ -1,0 +1,104 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Coconut
+    language: coconut
+    name: coconut
+---
+
+Taken fron [coconut-lang.org](coconut-lang.org)
+
+
+pipeline-style programming
+
+```{coconut}
+"hello, world!" |> print
+```
+
+ prettier lambdas
+
+```{coconut}
+x -> x ** 2
+```
+
+partial application
+
+```{coconut}
+range(10) |> map$(pow$(?, 2)) |> list
+```
+
+pattern-matching
+
+```{coconut}
+match [head] + tail in [0, 1, 2, 3]:
+    print(head, tail)
+```
+
+destructuring assignment
+
+```{coconut}
+{"list": [0] + rest} = {"list": [0, 1, 2, 3]}
+```
+
+infix notation
+
+```{coconut}
+# 5 `mod` 3 == 2
+```
+
+operator functions
+
+```{coconut}
+product = reduce$(*)
+```
+
+function composition
+
+```{coconut}
+# (f..g..h)(x, y, z)
+```
+
+lazy lists
+
+```{coconut}
+# (| first_elem() |) :: rest_elems()
+```
+
+parallel programming
+
+```{coconut}
+range(100) |> parallel_map$(pow$(2)) |> list
+```
+
+tail call optimization
+
+```{coconut}
+def factorial(n, acc=1):
+    case n:
+        match 0:
+            return acc
+        match _ is int if n > 0:
+            return factorial(n-1, acc*n)
+```
+
+algebraic data types
+
+```{coconut}
+data Empty()
+data Leaf(n)
+data Node(l, r)
+
+def size(Empty()) = 0
+
+addpattern def size(Leaf(n)) = 1
+
+addpattern def size(Node(l, r)) = size(l) + size(r)
+```
+
+and much more!
+
+Like what you see? Don't forget to star Coconut on GitHub!
+
+```{coconut}
+
+```

--- a/tests/notebooks/mirror/ipynb_to_hydrogen/coconut_homepage_demo.coco
+++ b/tests/notebooks/mirror/ipynb_to_hydrogen/coconut_homepage_demo.coco
@@ -1,0 +1,103 @@
+# ---
+# jupyter:
+#   kernelspec:
+#     display_name: Coconut
+#     language: coconut
+#     name: coconut
+# ---
+
+# %% [markdown]
+# Taken fron [coconut-lang.org](coconut-lang.org)
+
+# %% [markdown]
+# pipeline-style programming
+
+# %%
+"hello, world!" |> print
+
+# %% [markdown]
+#  prettier lambdas
+
+# %%
+x -> x ** 2
+
+# %% [markdown]
+# partial application
+
+# %%
+range(10) |> map$(pow$(?, 2)) |> list
+
+# %% [markdown]
+# pattern-matching
+
+# %%
+match [head] + tail in [0, 1, 2, 3]:
+    print(head, tail)
+
+# %% [markdown]
+# destructuring assignment
+
+# %%
+{"list": [0] + rest} = {"list": [0, 1, 2, 3]}
+
+# %% [markdown]
+# infix notation
+
+# %%
+# 5 `mod` 3 == 2
+
+# %% [markdown]
+# operator functions
+
+# %%
+product = reduce$(*)
+
+# %% [markdown]
+# function composition
+
+# %%
+# (f..g..h)(x, y, z)
+
+# %% [markdown]
+# lazy lists
+
+# %%
+# (| first_elem() |) :: rest_elems()
+
+# %% [markdown]
+# parallel programming
+
+# %%
+range(100) |> parallel_map$(pow$(2)) |> list
+
+# %% [markdown]
+# tail call optimization
+
+# %%
+def factorial(n, acc=1):
+    case n:
+        match 0:
+            return acc
+        match _ is int if n > 0:
+            return factorial(n-1, acc*n)
+
+# %% [markdown]
+# algebraic data types
+
+# %%
+data Empty()
+data Leaf(n)
+data Node(l, r)
+
+def size(Empty()) = 0
+
+addpattern def size(Leaf(n)) = 1
+
+addpattern def size(Node(l, r)) = size(l) + size(r)
+
+# %% [markdown]
+# and much more!
+#
+# Like what you see? Don't forget to star Coconut on GitHub!
+
+# %%

--- a/tests/notebooks/mirror/ipynb_to_md/coconut_homepage_demo.md
+++ b/tests/notebooks/mirror/ipynb_to_md/coconut_homepage_demo.md
@@ -1,0 +1,104 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Coconut
+    language: coconut
+    name: coconut
+---
+
+Taken fron [coconut-lang.org](coconut-lang.org)
+
+
+pipeline-style programming
+
+```coconut
+"hello, world!" |> print
+```
+
+ prettier lambdas
+
+```coconut
+x -> x ** 2
+```
+
+partial application
+
+```coconut
+range(10) |> map$(pow$(?, 2)) |> list
+```
+
+pattern-matching
+
+```coconut
+match [head] + tail in [0, 1, 2, 3]:
+    print(head, tail)
+```
+
+destructuring assignment
+
+```coconut
+{"list": [0] + rest} = {"list": [0, 1, 2, 3]}
+```
+
+infix notation
+
+```coconut
+# 5 `mod` 3 == 2
+```
+
+operator functions
+
+```coconut
+product = reduce$(*)
+```
+
+function composition
+
+```coconut
+# (f..g..h)(x, y, z)
+```
+
+lazy lists
+
+```coconut
+# (| first_elem() |) :: rest_elems()
+```
+
+parallel programming
+
+```coconut
+range(100) |> parallel_map$(pow$(2)) |> list
+```
+
+tail call optimization
+
+```coconut
+def factorial(n, acc=1):
+    case n:
+        match 0:
+            return acc
+        match _ is int if n > 0:
+            return factorial(n-1, acc*n)
+```
+
+algebraic data types
+
+```coconut
+data Empty()
+data Leaf(n)
+data Node(l, r)
+
+def size(Empty()) = 0
+
+addpattern def size(Leaf(n)) = 1
+
+addpattern def size(Node(l, r)) = size(l) + size(r)
+```
+
+and much more!
+
+Like what you see? Don't forget to star Coconut on GitHub!
+
+```coconut
+
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/coconut_homepage_demo.md
+++ b/tests/notebooks/mirror/ipynb_to_myst/coconut_homepage_demo.md
@@ -1,0 +1,104 @@
+---
+kernelspec:
+  display_name: Coconut
+  language: coconut
+  name: coconut
+---
+
+Taken fron [coconut-lang.org](coconut-lang.org)
+
++++
+
+pipeline-style programming
+
+```{code-cell} coconut
+"hello, world!" |> print
+```
+
+ prettier lambdas
+
+```{code-cell} coconut
+x -> x ** 2
+```
+
+partial application
+
+```{code-cell} coconut
+range(10) |> map$(pow$(?, 2)) |> list
+```
+
+pattern-matching
+
+```{code-cell} coconut
+match [head] + tail in [0, 1, 2, 3]:
+    print(head, tail)
+```
+
+destructuring assignment
+
+```{code-cell} coconut
+{"list": [0] + rest} = {"list": [0, 1, 2, 3]}
+```
+
+infix notation
+
+```{code-cell} coconut
+# 5 `mod` 3 == 2
+```
+
+operator functions
+
+```{code-cell} coconut
+product = reduce$(*)
+```
+
+function composition
+
+```{code-cell} coconut
+# (f..g..h)(x, y, z)
+```
+
+lazy lists
+
+```{code-cell} coconut
+# (| first_elem() |) :: rest_elems()
+```
+
+parallel programming
+
+```{code-cell} coconut
+range(100) |> parallel_map$(pow$(2)) |> list
+```
+
+tail call optimization
+
+```{code-cell} coconut
+def factorial(n, acc=1):
+    case n:
+        match 0:
+            return acc
+        match _ is int if n > 0:
+            return factorial(n-1, acc*n)
+```
+
+algebraic data types
+
+```{code-cell} coconut
+data Empty()
+data Leaf(n)
+data Node(l, r)
+
+def size(Empty()) = 0
+
+addpattern def size(Leaf(n)) = 1
+
+addpattern def size(Node(l, r)) = size(l) + size(r)
+```
+
+and much more!
+
+Like what you see? Don't forget to star Coconut on GitHub!
+
+```{code-cell} coconut
+
+```

--- a/tests/notebooks/mirror/ipynb_to_percent/coconut_homepage_demo.coco
+++ b/tests/notebooks/mirror/ipynb_to_percent/coconut_homepage_demo.coco
@@ -1,0 +1,103 @@
+# ---
+# jupyter:
+#   kernelspec:
+#     display_name: Coconut
+#     language: coconut
+#     name: coconut
+# ---
+
+# %% [markdown]
+# Taken fron [coconut-lang.org](coconut-lang.org)
+
+# %% [markdown]
+# pipeline-style programming
+
+# %%
+"hello, world!" |> print
+
+# %% [markdown]
+#  prettier lambdas
+
+# %%
+x -> x ** 2
+
+# %% [markdown]
+# partial application
+
+# %%
+range(10) |> map$(pow$(?, 2)) |> list
+
+# %% [markdown]
+# pattern-matching
+
+# %%
+match [head] + tail in [0, 1, 2, 3]:
+    print(head, tail)
+
+# %% [markdown]
+# destructuring assignment
+
+# %%
+{"list": [0] + rest} = {"list": [0, 1, 2, 3]}
+
+# %% [markdown]
+# infix notation
+
+# %%
+# 5 `mod` 3 == 2
+
+# %% [markdown]
+# operator functions
+
+# %%
+product = reduce$(*)
+
+# %% [markdown]
+# function composition
+
+# %%
+# (f..g..h)(x, y, z)
+
+# %% [markdown]
+# lazy lists
+
+# %%
+# (| first_elem() |) :: rest_elems()
+
+# %% [markdown]
+# parallel programming
+
+# %%
+range(100) |> parallel_map$(pow$(2)) |> list
+
+# %% [markdown]
+# tail call optimization
+
+# %%
+def factorial(n, acc=1):
+    case n:
+        match 0:
+            return acc
+        match _ is int if n > 0:
+            return factorial(n-1, acc*n)
+
+# %% [markdown]
+# algebraic data types
+
+# %%
+data Empty()
+data Leaf(n)
+data Node(l, r)
+
+def size(Empty()) = 0
+
+addpattern def size(Leaf(n)) = 1
+
+addpattern def size(Node(l, r)) = size(l) + size(r)
+
+# %% [markdown]
+# and much more!
+#
+# Like what you see? Don't forget to star Coconut on GitHub!
+
+# %%

--- a/tests/notebooks/mirror/ipynb_to_script/coconut_homepage_demo.coco
+++ b/tests/notebooks/mirror/ipynb_to_script/coconut_homepage_demo.coco
@@ -1,0 +1,85 @@
+# ---
+# jupyter:
+#   kernelspec:
+#     display_name: Coconut
+#     language: coconut
+#     name: coconut
+# ---
+
+# Taken fron [coconut-lang.org](coconut-lang.org)
+
+# pipeline-style programming
+
+"hello, world!" |> print
+
+#  prettier lambdas
+
+x -> x ** 2
+
+# partial application
+
+range(10) |> map$(pow$(?, 2)) |> list
+
+# pattern-matching
+
+match [head] + tail in [0, 1, 2, 3]:
+    print(head, tail)
+
+# destructuring assignment
+
+{"list": [0] + rest} = {"list": [0, 1, 2, 3]}
+
+# infix notation
+
+# +
+# 5 `mod` 3 == 2
+# -
+
+# operator functions
+
+product = reduce$(*)
+
+# function composition
+
+# +
+# (f..g..h)(x, y, z)
+# -
+
+# lazy lists
+
+# +
+# (| first_elem() |) :: rest_elems()
+# -
+
+# parallel programming
+
+range(100) |> parallel_map$(pow$(2)) |> list
+
+# tail call optimization
+
+def factorial(n, acc=1):
+    case n:
+        match 0:
+            return acc
+        match _ is int if n > 0:
+            return factorial(n-1, acc*n)
+
+# algebraic data types
+
+# +
+data Empty()
+data Leaf(n)
+data Node(l, r)
+
+def size(Empty()) = 0
+
+addpattern def size(Leaf(n)) = 1
+
+addpattern def size(Node(l, r)) = size(l) + size(r)
+# -
+
+# and much more!
+#
+# Like what you see? Don't forget to star Coconut on GitHub!
+
+


### PR DESCRIPTION
After this [jupyter-related issue](https://github.com/evhub/coconut/issues/540), Coconut has up-to-date and easy-to-use interactions with the jupyter kernel. 

I've set up the test notebook to mimic the [home-page](http://coconut-lang.org) of the project, though examples that require extra definitions have been commented out. 

- Tests were successful: `2441 passed, 2 skipped in 40.37s`
-  pre-commit hooks successful: 
``` 
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Initializing environment for https://gitlab.com/pycqa/flake8.
[INFO] Initializing environment for https://github.com/psf/black.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://gitlab.com/pycqa/flake8.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/psf/black.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
Check JSON...........................................(no files to check)Skipped
Check Yaml...........................................(no files to check)Skipped
Fix End of Files.........................................................Passed
Trim Trailing Whitespace.................................................Passed
flake8...................................................................Passed
black....................................................................Passed
[master 578f8e1] add coconut language
 8 files changed, 1006 insertions(+)
 create mode 100644 tests/notebooks/ipynb_coconut/coconut_homepage_demo.ipynb
 create mode 100644 tests/notebooks/mirror/ipynb_to_Rmd/coconut_homepage_demo.Rmd
 create mode 100644 tests/notebooks/mirror/ipynb_to_hydrogen/coconut_homepage_demo.coco
 create mode 100644 tests/notebooks/mirror/ipynb_to_md/coconut_homepage_demo.md
 create mode 100644 tests/notebooks/mirror/ipynb_to_myst/coconut_homepage_demo.md
 create mode 100644 tests/notebooks/mirror/ipynb_to_percent/coconut_homepage_demo.coco
 create mode 100644 tests/notebooks/mirror/ipynb_to_script/coconut_homepage_demo.coco
```

