### PR TITLE
Catch timeout messages both in the logs and in stderr #489

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -657,6 +657,9 @@ def test_utf8_out_331(capsys, caplog):
         pytest.skip(caplog.text)  # Issue 489
 
     out, err = capsys.readouterr()
+    if "Timeout" in err:
+        pytest.skip(err)  # Issue 489
+
     assert err == ""
     nb = reads(out, "ipynb")
     assert len(nb.cells) == 1

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -4,8 +4,18 @@ from jupytext import read
 from jupytext.cli import jupytext
 
 
+def skip_if_timeout(caplog, capsys):
+    """Skip the test if a timeout occurs when executing the notebook. See Issue 489"""
+    if "Timeout" in caplog.text:
+        pytest.skip(caplog.text)
+
+    _, err = capsys.readouterr()
+    if "Timeout" in err:
+        pytest.skip(err)
+
+
 @requires_nbconvert
-def test_pipe_nbconvert_execute(tmpdir, caplog):
+def test_pipe_nbconvert_execute(tmpdir, caplog, capsys):
     tmp_ipynb = str(tmpdir.join("notebook.ipynb"))
     tmp_py = str(tmpdir.join("notebook.py"))
 
@@ -26,8 +36,7 @@ def test_pipe_nbconvert_execute(tmpdir, caplog):
             "jupyter nbconvert --stdin --stdout --to notebook --execute",
         ]
     )
-    if "Timeout" in caplog.text:
-        pytest.skip(caplog.text)  # Issue 489
+    skip_if_timeout(caplog, capsys)
 
     nb = read(tmp_ipynb)
     assert len(nb.cells) == 1
@@ -35,7 +44,7 @@ def test_pipe_nbconvert_execute(tmpdir, caplog):
 
 
 @requires_nbconvert
-def test_pipe_nbconvert_execute_sync(tmpdir, caplog):
+def test_pipe_nbconvert_execute_sync(tmpdir, caplog, capsys):
     tmp_ipynb = str(tmpdir.join("notebook.ipynb"))
     tmp_py = str(tmpdir.join("notebook.py"))
 
@@ -57,8 +66,7 @@ def test_pipe_nbconvert_execute_sync(tmpdir, caplog):
             "jupyter nbconvert --stdin --stdout --to notebook --execute",
         ]
     )
-    if "Timeout" in caplog.text:
-        pytest.skip(caplog.text)  # Issue 489
+    skip_if_timeout(caplog, capsys)
 
     nb = read(tmp_ipynb)
     assert len(nb.cells) == 1
@@ -66,7 +74,7 @@ def test_pipe_nbconvert_execute_sync(tmpdir, caplog):
 
 
 @requires_nbconvert
-def test_execute(tmpdir, caplog):
+def test_execute(tmpdir, caplog, capsys):
     tmp_ipynb = str(tmpdir.join("notebook.ipynb"))
     tmp_py = str(tmpdir.join("notebook.py"))
 
@@ -77,8 +85,7 @@ def test_execute(tmpdir, caplog):
         )
 
     jupytext(args=[tmp_py, "--to", "ipynb", "--execute"])
-    if "Timeout" in caplog.text:
-        pytest.skip(caplog.text)  # Issue 489
+    skip_if_timeout(caplog, capsys)
 
     nb = read(tmp_ipynb)
     assert len(nb.cells) == 1
@@ -127,7 +134,7 @@ a + 1
 
 
 @requires_nbconvert
-def test_execute_sync(tmpdir, caplog):
+def test_execute_sync(tmpdir, caplog, capsys):
     tmp_ipynb = str(tmpdir.join("notebook.ipynb"))
     tmp_py = str(tmpdir.join("notebook.py"))
 
@@ -138,8 +145,7 @@ def test_execute_sync(tmpdir, caplog):
         )
 
     jupytext(args=[tmp_py, "--set-formats", "py,ipynb", "--sync", "--execute"])
-    if "Timeout" in caplog.text:
-        pytest.skip(caplog.text)  # Issue 489
+    skip_if_timeout(caplog, capsys)
 
     nb = read(tmp_ipynb)
     assert len(nb.cells) == 1
@@ -148,7 +154,7 @@ def test_execute_sync(tmpdir, caplog):
 
 @requires_nbconvert
 @requires_ir_kernel
-def test_execute_r(tmpdir, caplog):  # pragma: no cover
+def test_execute_r(tmpdir, caplog, capsys):  # pragma: no cover
     tmp_ipynb = str(tmpdir.join("notebook.ipynb"))
     tmp_md = str(tmpdir.join("notebook.md"))
 
@@ -161,8 +167,7 @@ def test_execute_r(tmpdir, caplog):  # pragma: no cover
         )
 
     jupytext(args=[tmp_md, "--to", "ipynb", "--execute"])
-    if "Timeout" in caplog.text:
-        pytest.skip(caplog.text)  # Issue 489
+    skip_if_timeout(caplog, capsys)
 
     nb = read(tmp_ipynb)
     assert len(nb.cells) == 1
@@ -170,7 +175,7 @@ def test_execute_r(tmpdir, caplog):  # pragma: no cover
 
 
 @requires_nbconvert
-def test_execute_in_subfolder(tmpdir, caplog):
+def test_execute_in_subfolder(tmpdir, caplog, capsys):
     tmpdir.mkdir("subfolder")
 
     tmp_csv = str(tmpdir.join("subfolder", "inputs.csv"))
@@ -192,8 +197,7 @@ sum(ast.literal_eval(line) for line in text.splitlines())
         )
 
     jupytext(args=[tmp_py, "--to", "ipynb", "--execute"])
-    if "Timeout" in caplog.text:
-        pytest.skip(caplog.text)  # Issue 489
+    skip_if_timeout(caplog, capsys)
 
     nb = read(tmp_ipynb)
     assert len(nb.cells) == 3


### PR DESCRIPTION
In some instances the timeout message appears on stderr #489 