### PR TITLE
Upload coverage from the conda CI workflow

### DIFF
--- a/.github/workflows/continuous-integration-conda.yml
+++ b/.github/workflows/continuous-integration-conda.yml
@@ -11,6 +11,9 @@ jobs:
           # This one fails, cf. https://github.com/mwouts/jupytext/runs/736344037
           - os: windows-latest
             python-version: 2.7
+          # Jupyter commands fail with "ImportError: No module named functools_lru_cache",
+          # Cf. https://github.com/mwouts/jupytext/runs/793874319
+          - python-version: 2.7
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/continuous-integration-conda.yml
+++ b/.github/workflows/continuous-integration-conda.yml
@@ -40,12 +40,12 @@ jobs:
           # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --statistics
       - name: Install from source
-        shell: pwsh
         # This is required for the pre-commit tests
-        run: |
-          $ErrorActionPreference='silentlycontinue'
-          pip install .
-          exit 0
+        shell: pwsh
+        run: pip install .
+      - name: Create kernel
+        shell: pwsh
+        run: python -m ipykernel install --name jupytext-ci --user
       - name: Install optional dependencies
         shell: pwsh
         run: |

--- a/.github/workflows/continuous-integration-conda.yml
+++ b/.github/workflows/continuous-integration-conda.yml
@@ -56,7 +56,7 @@ jobs:
           conda install black --freeze-installed
           conda install autopep8 --freeze-installed
           # install sphinx_gallery and matplotlib if available
-          conda install sphinx_gallery --freeze-installed
+          conda install sphinx-gallery --freeze-installed
           conda install myst-parser --freeze-installed
           exit 0
       - name: Conda list

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 **Fixed**
 - Filtered out `__pycache__` and `.pyc` files from the pip package.
+- Added `coverage` as a dependency on the conda CI workflow to allow coverage to be uploaded.
+- Skipped Python 2.7 on the conda CI due to an "ImportError: No module named functools_lru_cache" when executing notebooks.
 
 
 1.5.0 (2020-06-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+1.5.1 (2020-06-??)
+------------------
+
+**Fixed**
+- Filtered out `__pycache__` and `.pyc` files from the pip package.
+
+
 1.5.0 (2020-06-07)
 ------------------
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include *.txt
 include *.rst
 
 graft tests
-prune tests\__pycache__
+global-exclude *__pycache__
+global-exclude *.pyc
 global-exclude *population.ipynb
 global-exclude plotly_graphs.ipynb

--- a/environment-ci.yml
+++ b/environment-ci.yml
@@ -13,6 +13,7 @@ dependencies:
   - pip
   - pytest
   - pytest-cov
+  - coverage
   - flake8
   - pandoc>=2.9
   # pathlib is required on Python 2

--- a/environment-ci.yml
+++ b/environment-ci.yml
@@ -7,6 +7,7 @@ channels:
   - conda-forge
 dependencies:
   - jupyter
+  - ipykernel
   - nbconvert
   - pyyaml
   - toml

--- a/jupytext/version.py
+++ b/jupytext/version.py
@@ -1,3 +1,3 @@
 """Jupytext's version number"""
 
-__version__ = "1.5.0"
+__version__ = "1.5.1-dev"


### PR DESCRIPTION
Code coverage is higher on the conda CI than on the pip CI, as more of Jupytext's optional dependencies are available (pandoc, myst-parser, sphinx-gallery). This PR fixes the coverage upload by adding `coverage` as an explicit dependency for the conda workflow (and deactivates Python 2.7 due to an error when executing Jupyter notebooks).