### PR TITLE
Add toml as an explicit dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 **Fixed**
 - Filtered out `__pycache__` and `.pyc` files from the pip package.
+- Added `toml` as a dependency.
 - Added `coverage` as a dependency on the conda CI workflow to allow coverage to be uploaded.
 - Skipped Python 2.7 on the conda CI due to an "ImportError: No module named functools_lru_cache" when executing notebooks.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 nbformat>=4.0.0
 pyyaml
+toml

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     ],
     entry_points={"console_scripts": ["jupytext = jupytext.cli:jupytext"]},
     tests_require=["pytest"],
-    install_requires=["nbformat>=4.0.0", "pyyaml", 'mock;python_version<"3"'],
+    install_requires=["nbformat>=4.0.0", "pyyaml", "toml", 'mock;python_version<"3"'],
     extras_require={
         "myst": ["myst-parser~=0.8; python_version >= '3.6'"],
         "toml": ["toml"],


### PR DESCRIPTION
TOML is the default format for Jupytext configuration files (`.jupytext`, `.jupytext.toml` or `jupytext.toml`).