### PR TITLE
Fixes paired path edge case of unnormalized paths. Closes: #564

### DIFF
--- a/jupytext/paired_paths.py
+++ b/jupytext/paired_paths.py
@@ -224,6 +224,7 @@ def find_base_path_and_format(main_path, formats):
 
 def paired_paths(main_path, fmt, formats):
     """Return the list of paired notebooks, given main path, and the list of formats"""
+    main_path = os.path.normpath(main_path)
     if not formats:
         return [(main_path, {"extension": os.path.splitext(main_path)[1]})]
 
@@ -231,7 +232,7 @@ def paired_paths(main_path, fmt, formats):
 
     # Is there a format that matches the main path?
     base = base_path(main_path, fmt)
-    paths = [full_path(base, f) for f in formats]
+    paths = [os.path.normpath(full_path(base, f)) for f in formats]
 
     if main_path not in paths:
         raise InconsistentPath(

--- a/tests/test_paired_paths.py
+++ b/tests/test_paired_paths.py
@@ -66,6 +66,14 @@ def test_base_path_in_tree_from_non_root_no_subfolder():
     paired_paths(nb_file, fmt, formats)
 
 
+def test_base_path_in_tree_from_non_root_no_subfolder_dotdot():
+    nb_file = "/parent/notebooks/wrap_markdown.ipynb"
+    formats = "notebooks/../notebooks///ipynb,script/../scripts///py:percent"
+    fmt = "notebooks///ipynb"
+    assert base_path(nb_file, fmt) == "/parent///wrap_markdown"
+    paired_paths(nb_file, fmt, formats)
+
+
 def test_full_path_in_tree_from_root():
     fmt = long_form_one_format("notebooks///ipynb")
     assert full_path("//subfolder/test", fmt=fmt) == "notebooks/subfolder/test.ipynb"


### PR DESCRIPTION
Normalizes all the paths before doing checks against them using os.path.normpath. See #564 