### PR TITLE
Reproduce the conditions for #564

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1103,3 +1103,19 @@ default_jupytext_formats = "notebooks///ipynb,scripts///py:percent"
     text = nb.cells[0].source
     assert len(text.splitlines()) == 3
     assert text != long_text
+
+
+def test_sync_script_dotdot_folder_564(tmpdir):
+    """Reproduce the setting of issue #564"""
+    nb_file = tmpdir.mkdir("colabs").mkdir("colabs").join("rigid_object_tutorial.ipynb")
+    py_file = tmpdir.join("colabs").mkdir("nb_python").join("rigid_object_tutorial.py")
+    py_file.write("1 + 1\n")
+
+    jupytext(
+        ["--set-formats", "../nb_python//py:percent,../colabs//ipynb", str(py_file)]
+    )
+
+    assert nb_file.exists()
+
+    jupytext(["--sync", str(py_file)])
+    jupytext(["--sync", str(nb_file)])

--- a/tests/test_paired_paths.py
+++ b/tests/test_paired_paths.py
@@ -105,6 +105,12 @@ def test_paired_paths_windows_no_subfolder():
         paired_paths(nb_file, "notebooks///ipynb", formats)
 
 
+def test_paired_path_dotdot_564():
+    main_path = "examples/tutorials/colabs/rigid_object_tutorial.ipynb"
+    formats = "../nb_python//py:percent,../colabs//ipynb"
+    paired_paths(main_path, "ipynb", formats)
+
+
 def test_path_in_tree_limited_to_config_dir(tmpdir):
     root_nb_dir = tmpdir.mkdir("notebooks")
     nb_dir = root_nb_dir.mkdir("notebooks")


### PR DESCRIPTION
In versions prior to 1.5.0, Jupytext had issue with `..` in paired formats. Here we had two tests that should be able to catch the issue documented at #564 .