### PR TITLE
Configure codecov, set up code scanning

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,7 +1,0 @@
-
-coverage:
-  status:
-    # pull-requests only
-    patch:
-      default:
-        threshold: 0.1%

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,54 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [master, ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [master]
+  schedule:
+    - cron: '0 11 * * 4'
+
+jobs:
+  analyse:
+    name: Analyse
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        # We must fetch at least the immediate parents so that if this is
+        # a pull request then we can checkout the head.
+        fetch-depth: 2
+
+    # If this run was triggered by a pull request event, then checkout
+    # the head of the pull request instead of the merge commit.
+    - run: git checkout HEAD^2
+      if: ${{ github.event_name == 'pull_request' }}
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      # Override language selection by uncommenting this and choosing your languages
+      # with:
+      #   languages: go, javascript, csharp, python, cpp, java
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 https://git.io/JvXDl
+
+    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+    #    and modify them (or add more) to build your code if your project
+    #    uses a compiled language
+
+    #- run: |
+    #   make bootstrap
+    #   make release
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,25 +30,9 @@ jobs:
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
-      # Override language selection by uncommenting this and choosing your languages
-      # with:
-      #   languages: go, javascript, csharp, python, cpp, java
-
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
+      # Override language selection
+      with:
+        languages: python, javascript
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 1.6.0-dev (2020-08-??)
 ----------------------
 
+**Added**
+- Activated GitHub code scanning alerts
+
 **Changed**
 - Install Jupytext from source on MyBinder to avoid cache issues (#567)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 **Changed**
 - Install Jupytext from source on MyBinder to avoid cache issues (#567)
 
+**Fixed**
+- Configured coverage targets in `codecov.yml`
+
 
 1.5.2 (2020-07-21)
 ------------------

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+codecov:
+    notify:
+        after_n_builds: 10  # wait for the 10 GitHub jobs before notifying
+
+coverage:
+  status:
+    project:
+      default: false  # disable the default status that measures entire project
+      tests:
+        paths: "tests/"
+        target: 99.8%
+      source:
+        paths: "jupytext/"
+        target: 97%
+        threshold': .2%
+    patch:
+      default:
+        target: 80%  # new contributions should have a coverage at least equal to target


### PR DESCRIPTION
This PR improves the configuration of codecov:
- no notifications should be send before all jobs finish running
- target coverage for patches is 80%
- no alert should be triggered when coverage decreases by less than 0.2%

It also activates the new code scanning feature by GitHub