### PR TITLE
Skip the tests that execute notebooks on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 **Changed**
 - Install Jupytext from source on MyBinder to avoid cache issues (#567)
+- Skip the tests that execute a notebook on Windows to avoid timeout issues (#489)
 
 **Fixed**
 - Configured coverage targets in `codecov.yml`

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![CI (pip)](https://github.com/mwouts/jupytext/workflows/CI%20(pip)/badge.svg)
 ![CI (conda)](https://github.com/mwouts/jupytext/workflows/CI%20(conda)/badge.svg)
 [![Documentation Status](https://readthedocs.org/projects/jupytext/badge/?version=latest)](https://jupytext.readthedocs.io/en/latest/?badge=latest)
-[![codecov.io](https://codecov.io/github/mwouts/jupytext/coverage.svg?branch=master)](https://codecov.io/github/mwouts/jupytext?branch=master)
+[![codecov.io](https://codecov.io/github/mwouts/jupytext/coverage.svg?branch=master)](https://codecov.io/gh/mwouts/jupytext/branch/master)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/mwouts/jupytext.svg)](https://lgtm.com/projects/g/mwouts/jupytext/context:python)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 ![GitHub language count](https://img.shields.io/github/languages/count/mwouts/jupytext)

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,7 +8,7 @@ coverage:
       default: false  # disable the default status that measures entire project
       tests:
         paths: "tests/"
-        target: 99.8%
+        target: 100%
       source:
         paths: "jupytext/"
         target: 97%

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,7 +24,12 @@ from jupytext.compare import compare_notebooks
 from jupytext.paired_paths import paired_paths, InconsistentPath
 from jupytext.formats import long_form_one_format, JupytextFormatError
 from .utils import list_notebooks, requires_sphinx_gallery
-from .utils import requires_jupytext_installed, requires_pandoc, requires_myst
+from .utils import (
+    requires_jupytext_installed,
+    requires_pandoc,
+    requires_myst,
+    skip_on_windows,
+)
 
 
 def test_str2bool():
@@ -663,18 +668,14 @@ def test_set_kernel_works_with_pipes_326(capsys):
     assert "kernelspec" in nb.metadata
 
 
+@skip_on_windows
 def test_utf8_out_331(capsys, caplog):
     py = u"from IPython.core.display import HTML; HTML(u'\xd7')"
 
     with mock.patch("sys.stdin", StringIO(py)):
         jupytext(["--to", "ipynb", "--execute", "-"])
 
-    if "Timeout" in caplog.text:
-        pytest.skip(caplog.text)  # Issue 489
-
     out, err = capsys.readouterr()
-    if "Timeout" in err:
-        pytest.skip(err)  # Issue 489
 
     assert err == ""
     nb = reads(out, "ipynb")

--- a/tests/test_combine.py
+++ b/tests/test_combine.py
@@ -137,10 +137,7 @@ def test_combine_stable(nb_file):
     nb_outputs = deepcopy(nb_org)
 
     for cell in nb_source.cells:
-        try:
-            cell.outputs = []
-        except KeyError:
-            continue
+        cell.outputs = []
 
     combine_inputs_with_outputs(nb_source, nb_outputs)
     compare_notebooks(nb_source, nb_org)

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -1,20 +1,11 @@
-from .utils import requires_nbconvert, requires_ir_kernel
+from .utils import requires_nbconvert, requires_ir_kernel, skip_on_windows
 import pytest
 from jupytext import read
 from jupytext.cli import jupytext
 
 
-def skip_if_timeout(caplog, capsys):
-    """Skip the test if a timeout occurs when executing the notebook. See Issue 489"""
-    if "Timeout" in caplog.text:
-        pytest.skip(caplog.text)
-
-    _, err = capsys.readouterr()
-    if "Timeout" in err:
-        pytest.skip(err)
-
-
 @requires_nbconvert
+@skip_on_windows
 def test_pipe_nbconvert_execute(tmpdir):
     tmp_ipynb = str(tmpdir.join("notebook.ipynb"))
     tmp_py = str(tmpdir.join("notebook.py"))
@@ -33,7 +24,7 @@ def test_pipe_nbconvert_execute(tmpdir):
             "--pipe-fmt",
             "ipynb",
             "--pipe",
-            "jupyter nbconvert --stdin --stdout --to notebook --execute --NotebookClient.iopub_timeout=60",
+            "jupyter nbconvert --stdin --stdout --to notebook --execute",
         ]
     )
 
@@ -43,6 +34,7 @@ def test_pipe_nbconvert_execute(tmpdir):
 
 
 @requires_nbconvert
+@skip_on_windows
 def test_pipe_nbconvert_execute_sync(tmpdir):
     tmp_ipynb = str(tmpdir.join("notebook.ipynb"))
     tmp_py = str(tmpdir.join("notebook.py"))
@@ -62,7 +54,7 @@ def test_pipe_nbconvert_execute_sync(tmpdir):
             "--pipe-fmt",
             "ipynb",
             "--pipe",
-            "jupyter nbconvert --stdin --stdout --to notebook --execute --NotebookClient.iopub_timeout=60",
+            "jupyter nbconvert --stdin --stdout --to notebook --execute",
         ]
     )
 
@@ -72,6 +64,7 @@ def test_pipe_nbconvert_execute_sync(tmpdir):
 
 
 @requires_nbconvert
+@skip_on_windows
 def test_execute(tmpdir, caplog, capsys):
     tmp_ipynb = str(tmpdir.join("notebook.ipynb"))
     tmp_py = str(tmpdir.join("notebook.py"))
@@ -83,7 +76,6 @@ def test_execute(tmpdir, caplog, capsys):
         )
 
     jupytext(args=[tmp_py, "--to", "ipynb", "--execute"])
-    skip_if_timeout(caplog, capsys)
 
     nb = read(tmp_ipynb)
     assert len(nb.cells) == 1
@@ -109,6 +101,7 @@ A readme with correct instructions
 
 
 @requires_nbconvert
+@skip_on_windows
 def test_execute_readme_not_ok(tmpdir):
     tmp_md = str(tmpdir.join("notebook.md"))
 
@@ -132,6 +125,7 @@ a + 1
 
 
 @requires_nbconvert
+@skip_on_windows
 def test_execute_sync(tmpdir, caplog, capsys):
     tmp_ipynb = str(tmpdir.join("notebook.ipynb"))
     tmp_py = str(tmpdir.join("notebook.py"))
@@ -143,7 +137,6 @@ def test_execute_sync(tmpdir, caplog, capsys):
         )
 
     jupytext(args=[tmp_py, "--set-formats", "py,ipynb", "--sync", "--execute"])
-    skip_if_timeout(caplog, capsys)
 
     nb = read(tmp_ipynb)
     assert len(nb.cells) == 1
@@ -152,6 +145,7 @@ def test_execute_sync(tmpdir, caplog, capsys):
 
 @requires_nbconvert
 @requires_ir_kernel
+@skip_on_windows
 def test_execute_r(tmpdir, caplog, capsys):  # pragma: no cover
     tmp_ipynb = str(tmpdir.join("notebook.ipynb"))
     tmp_md = str(tmpdir.join("notebook.md"))
@@ -165,7 +159,6 @@ def test_execute_r(tmpdir, caplog, capsys):  # pragma: no cover
         )
 
     jupytext(args=[tmp_md, "--to", "ipynb", "--execute"])
-    skip_if_timeout(caplog, capsys)
 
     nb = read(tmp_ipynb)
     assert len(nb.cells) == 1
@@ -173,6 +166,7 @@ def test_execute_r(tmpdir, caplog, capsys):  # pragma: no cover
 
 
 @requires_nbconvert
+@skip_on_windows
 def test_execute_in_subfolder(tmpdir, caplog, capsys):
     tmpdir.mkdir("subfolder")
 
@@ -195,7 +189,6 @@ sum(ast.literal_eval(line) for line in text.splitlines())
         )
 
     jupytext(args=[tmp_py, "--to", "ipynb", "--execute"])
-    skip_if_timeout(caplog, capsys)
 
     nb = read(tmp_ipynb)
     assert len(nb.cells) == 3

--- a/tests/test_pep8.py
+++ b/tests/test_pep8.py
@@ -170,7 +170,7 @@ def test_no_metadata_when_py_is_pep8(py_file):
 
     for i, cell in enumerate(nb.cells):
         if "title" in cell.metadata:
-            cell.metadata.pop("title")
+            cell.metadata.pop("title")  # pragma: no cover
         if i == 0 and not cell.source:
             assert cell.metadata == {"lines_to_next_cell": 0}, py_file
         else:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -49,6 +49,7 @@ requires_ir_kernel = pytest.mark.skipif(
 requires_myst = pytest.mark.skipif(
     not is_myst_available(), reason="myst_parser not found"
 )
+skip_on_windows = pytest.mark.skipif(sys.platform.startswith("win"), reason="Issue 489")
 
 
 def list_notebooks(path="ipynb", skip="World"):


### PR DESCRIPTION
- Skip the tests that execute a notebook on Windows to avoid timeout issues (close #489)
- Target 100% coverage in tests