### PR TITLE
Hide notebook metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 **Added**
 - Activated GitHub code scanning alerts
+- New option `hide_notebook_metadata` to encapsulate the notebook metadata in an HTML comment (#527)
 
 **Changed**
 - Install Jupytext from source on MyBinder to avoid cache issues (#567)

--- a/docs/config.md
+++ b/docs/config.md
@@ -105,6 +105,8 @@ It is possible to filter nested metadata. For example, if you want to preserve t
 default_notebook_metadata_filter = "-jupytext.text_representation.jupytext_version"
 ```
 
+Finally, to hide the notebook metadata in an HTML comment in Markdown files, use the option `hide_notebook_metadata`.
+
 ### More options
 
 There are a couple more options available - please have a look at the `JupytextConfiguration` class in [config.py](https://github.com/mwouts/jupytext/blob/master/jupytext/config.py).

--- a/jupytext/config.py
+++ b/jupytext/config.py
@@ -62,14 +62,21 @@ class JupytextConfiguration(Configurable):
 
     default_notebook_metadata_filter = Unicode(
         u"",
-        help="Cell metadata that should be save in the text representations. "
+        help="Notebook metadata that should be save in the text representations. "
         "Examples: 'all', '-all', 'widgets,nteract', 'kernelspec,jupytext-all'",
+        config=True,
+    )
+
+    hide_notebook_metadata = Enum(
+        values=[True, False],
+        allow_none=True,
+        help="Should the notebook metadata be wrapped into an HTML comment in the Markdown format?",
         config=True,
     )
 
     default_cell_metadata_filter = Unicode(
         u"",
-        help="Notebook metadata that should be saved in the text representations. "
+        help="Cell metadata that should be saved in the text representations. "
         "Examples: 'all', 'hide_input,hide_output'",
         config=True,
     )
@@ -123,6 +130,10 @@ class JupytextConfiguration(Configurable):
         if self.default_cell_metadata_filter:
             format_options.setdefault(
                 "cell_metadata_filter", self.default_cell_metadata_filter
+            )
+        if self.hide_notebook_metadata is not None:
+            format_options.setdefault(
+                "hide_notebook_metadata", self.hide_notebook_metadata
             )
         if self.comment_magics is not None:
             format_options.setdefault("comment_magics", self.comment_magics)

--- a/jupytext/formats.py
+++ b/jupytext/formats.py
@@ -692,6 +692,7 @@ def short_form_multiple_formats(jupytext_formats):
 _VALID_FORMAT_INFO = ["extension", "format_name", "suffix", "prefix"]
 _BINARY_FORMAT_OPTIONS = [
     "comment_magics",
+    "hide_notebook_metadata",
     "split_at_heading",
     "rst2md",
     "cell_metadata_json",

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -148,3 +148,41 @@ jupyter:
     compare(actual, markdown)
     nb2 = jupytext.reads(markdown, ".md")
     compare(nb2, notebook)
+
+
+def test_header_in_html_comment():
+    text = """<!--
+
+---
+jupyter:
+  title: Sample header
+---
+
+-->
+"""
+    lines = text.splitlines()
+    metadata, _, cell, _ = header_to_metadata_and_cell(lines, "")
+
+    assert metadata == {"title": "Sample header"}
+    assert cell is None
+
+
+def test_header_to_html_comment(no_jupytext_version_number):
+    metadata = {"jupytext": {"mainlanguage": "python", "hide_notebook_metadata": True}}
+    nb = new_notebook(metadata=metadata, cells=[])
+    header, lines_to_next_cell = metadata_and_cell_to_header(
+        nb, metadata, get_format_implementation(".md"), ".md"
+    )
+    compare(
+        "\n".join(header),
+        """<!--
+
+---
+jupyter:
+  jupytext:
+    hide_notebook_metadata: true
+    mainlanguage: python
+---
+
+-->""",
+    )

--- a/tests/test_read_simple_markdown.py
+++ b/tests/test_read_simple_markdown.py
@@ -916,3 +916,37 @@ jupyter:
     compare(md2, md)
     nb2 = jupytext.reads(md, "md")
     compare_notebooks(nb2, nb)
+
+
+def test_hide_notebook_metadata(
+    no_jupytext_version_number,
+    nb=new_notebook(
+        metadata={
+            "jupytext": {"hide_notebook_metadata": True},
+            "kernelspec": {
+                "display_name": "Python 3",
+                "language": "python",
+                "name": "python3",
+            },
+        }
+    ),
+    md="""<!--
+
+---
+jupyter:
+  jupytext:
+    hide_notebook_metadata: true
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+---
+
+-->
+""",
+):
+    """Test the hide_notebook_metadata option"""
+    md2 = jupytext.writes(nb, "md")
+    compare(md2, md)
+    nb2 = jupytext.reads(md, "md")
+    compare_notebooks(nb2, nb)


### PR DESCRIPTION
This PR introduces the `hide_notebook_metadata` option for the Markdown format.
Closes #527 .