### PR TITLE
Indented markers percent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 **Changed**
 - Install Jupytext from source on MyBinder to avoid cache issues (#567)
 - Skip the tests that execute a notebook on Windows to avoid timeout issues (#489)
+- The `# %%` cell marker has the same indentation as the first line in the cell (#562)
 
 **Fixed**
 - Configured coverage targets in `codecov.yml`

--- a/jupytext/cell_reader.py
+++ b/jupytext/cell_reader.py
@@ -747,9 +747,9 @@ class DoublePercentScriptCellReader(LightScriptCellReader):
         script = _SCRIPT_EXTENSIONS[self.ext]
         self.default_language = default_language or script["language"]
         self.comment = script["comment"]
-        self.start_code_re = re.compile(r"^{}\s*%%(%*)\s(.*)$".format(self.comment))
+        self.start_code_re = re.compile(r"^\s*{}\s*%%(%*)\s(.*)$".format(self.comment))
         self.alternative_start_code_re = re.compile(
-            r"^{}\s*(%%|<codecell>|In\[[0-9 ]*\]:?)\s*$".format(self.comment)
+            r"^\s*{}\s*(%%|<codecell>|In\[[0-9 ]*\]:?)\s*$".format(self.comment)
         )
         self.explicit_soc = True
 

--- a/jupytext/cell_to_text.py
+++ b/jupytext/cell_to_text.py
@@ -457,10 +457,18 @@ class DoublePercentCellExporter(BaseCellExporter):  # pylint: disable=W0223
         options = metadata_to_double_percent_options(
             self.metadata, self.cell_metadata_json
         )
+        indent = ""
+        if self.is_code() and active and self.source:
+            first_line = self.source[0]
+            if first_line.strip():
+                left_space = re.compile(r"^(\s*)").match(first_line)
+                if left_space:
+                    indent = left_space.groups()[0]
+
         if options.startswith("%") or not options:
-            lines = [self.comment + " %%" + options]
+            lines = [indent + self.comment + " %%" + options]
         else:
-            lines = [self.comment + " %% " + options]
+            lines = [indent + self.comment + " %% " + options]
 
         if self.is_code() and active:
             source = copy(self.source)

--- a/jupytext/version.py
+++ b/jupytext/version.py
@@ -1,3 +1,3 @@
 """Jupytext's version number"""
 
-__version__ = "1.5.2"
+__version__ = "1.6.0-dev"

--- a/tests/test_read_simple_percent.py
+++ b/tests/test_read_simple_percent.py
@@ -502,3 +502,32 @@ def test_docstring_with_quadruple_quote(
     py = jupytext.writes(nb, "py:percent")
     nb2 = jupytext.reads(py, "py")
     compare_notebooks(nb2, nb)
+
+
+def test_cell_marker_has_same_indentation_as_code(
+    text="""# %%
+if __name__ == '__main__':
+    print(1)
+
+    # %%
+    # INDENTED COMMENT
+    print(2)
+""",
+    nb_expected=new_notebook(
+        cells=[
+            new_code_cell(
+                """if __name__ == '__main__':
+    print(1)"""
+            ),
+            new_code_cell(
+                """    # INDENTED COMMENT
+    print(2)"""
+            ),
+        ]
+    ),
+):
+    """The cell marker should have the same indentation as the first code line. See issue #562"""
+    nb_actual = jupytext.reads(text, fmt="py:percent")
+    compare_notebooks(nb_actual, nb_expected)
+    text_actual = jupytext.writes(nb_actual, fmt="py:percent")
+    compare(text_actual, text)


### PR DESCRIPTION
Code cell markers in the `percent` format have the same indentation as the first line of code in the cell.
Closes #562 