### PR TITLE
Informative runtime error if myst is not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,10 @@ error will occur if the required dependencies, resp. `myst-parser` and `pandoc`,
 **Fixed**
 - Configured coverage targets in `codecov.yml`
 - Only scripts can have an encoding comment, not Markdown or R Markdown files (#576)
-- Support spaces in `--pipe` commands (#562)
+- Spaces in `--pipe` commands are supported (#562)
 - Use `>=` and `<` rather than `~=` in the `extras_require` of `setup.py` (#589)
 - Bash commands starting with special characters are now correctly detected, thanks to Aaron Gokaslan (#587)
+- MyST Markdown files are recognized as such even if `myst` is missing (#556)
 
 
 1.5.2 (2020-07-21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Install Jupytext from source on MyBinder to avoid cache issues (#567)
 - Skip the tests that execute a notebook on Windows to avoid timeout issues (#489)
 - The `# %%` cell marker has the same indentation as the first line in the cell (#562)
+- The `md:myst` and `md:pandoc` are always included in the Jupytext formats, and an informative runtime
+error will occur if the required dependencies, resp. `myst-parser` and `pandoc`, are not installed. (#556)
 
 **Fixed**
 - Configured coverage targets in `codecov.yml`

--- a/jupytext/formats.py
+++ b/jupytext/formats.py
@@ -30,7 +30,7 @@ from .cell_to_text import (
 from .metadata_filter import metadata_filter_as_string
 from .stringparser import StringParser
 from .languages import _SCRIPT_EXTENSIONS, _COMMENT_CHARS, same_language
-from .pandoc import pandoc_version, is_pandoc_available
+from .pandoc import pandoc_version
 from .magics import is_magic
 from .myst import (
     MYST_FORMAT_NAME,
@@ -191,12 +191,7 @@ JUPYTEXT_FORMATS = (
             cell_exporter_class=SphinxGalleryCellExporter,
             # Version 1.0 on 2018-09-22 - jupytext v0.7.0rc0 : Initial version
             current_version_number="1.1",
-        )
-    ]
-)
-
-if is_pandoc_available():
-    JUPYTEXT_FORMATS.append(
+        ),
         NotebookFormatDescription(
             format_name="pandoc",
             extension=".md",
@@ -204,23 +199,20 @@ if is_pandoc_available():
             cell_reader_class=None,
             cell_exporter_class=None,
             current_version_number=pandoc_version(),
+        ),
+    ]
+    + [
+        NotebookFormatDescription(
+            format_name=MYST_FORMAT_NAME,
+            extension=ext,
+            header_prefix="",
+            cell_reader_class=None,
+            cell_exporter_class=None,
+            current_version_number=myst_version(),
         )
-    )
-
-if is_myst_available():
-    JUPYTEXT_FORMATS.extend(
-        [
-            NotebookFormatDescription(
-                format_name=MYST_FORMAT_NAME,
-                extension=ext,
-                header_prefix="",
-                cell_reader_class=None,
-                cell_exporter_class=None,
-                current_version_number=myst_version(),
-            )
-            for ext in myst_extensions()
-        ]
-    )
+        for ext in myst_extensions()
+    ]
+)
 
 NOTEBOOK_EXTENSIONS = list(
     dict.fromkeys([".ipynb"] + [fmt.extension for fmt in JUPYTEXT_FORMATS])

--- a/jupytext/formats.py
+++ b/jupytext/formats.py
@@ -5,6 +5,7 @@ new formats here!
 
 import os
 import re
+import yaml
 import warnings
 import nbformat
 from .header import header_to_metadata_and_cell, insert_or_test_version_number
@@ -260,6 +261,18 @@ def read_metadata(text, ext):
     metadata, _, _, _ = header_to_metadata_and_cell(lines, comment, ext)
     if ext in [".r", ".R"] and not metadata:
         metadata, _, _, _ = header_to_metadata_and_cell(lines, "#'", ext)
+
+    # MyST has the metadata at the root level
+    if not metadata and ext in myst_extensions() and text.startswith("---"):
+        for header in yaml.safe_load_all(text):
+            if (
+                header.get("jupytext", {})
+                .get("text_representation", {})
+                .get("format_name")
+                == "myst"
+            ):
+                return header
+            return metadata
 
     return metadata
 

--- a/jupytext/myst.py
+++ b/jupytext/myst.py
@@ -34,9 +34,19 @@ def is_myst_available():
     return True
 
 
+def raise_if_myst_is_not_available():
+    if not is_myst_available():
+        raise ImportError(
+            "The MyST Markdown format requires 'myst_parser>=0.8'. "
+            "Install it with e.g. 'pip install jupytext[myst]'"
+        )
+
+
 def myst_version():
     """The major version of myst parser."""
-    return ".".join(myst_parser.__version__.split(".")[:2])
+    if is_myst_available():
+        return ".".join(myst_parser.__version__.split(".")[:2])
+    return "N/A"
 
 
 def myst_extensions(no_md=False):
@@ -232,6 +242,8 @@ def myst_to_notebook(
     NOTE: we assume here that all of these directives are at the top-level,
     i.e. not nested in other directives.
     """
+    raise_if_myst_is_not_available()
+
     # parse markdown file up to the block level (i.e. don't worry about inline text)
     parser = default_parser("html", disable_syntax=["inline"])
     tokens = parser.parse(text + "\n")
@@ -322,6 +334,7 @@ def notebook_to_myst(
     :param default_lexer: a lexer name to use for annotating code cells
         (if ``nb.metadata.language_info.pygments_lexer`` is not available)
     """
+    raise_if_myst_is_not_available()
     string = ""
 
     nb_metadata = from_nbnode(nb.metadata)

--- a/tests/test_ipynb_to_myst.py
+++ b/tests/test_ipynb_to_myst.py
@@ -4,6 +4,7 @@ except ImportError:
     import mock
 from textwrap import dedent
 import pytest
+from nbformat.v4.nbbase import new_notebook
 
 from jupytext.formats import get_format_implementation, JupytextFormatError
 from jupytext.myst import (
@@ -13,7 +14,9 @@ from jupytext.myst import (
     matches_mystnb,
     myst_extensions,
 )
-from .utils import requires_myst
+from jupytext.cli import jupytext as jupytext_cli
+import jupytext
+from .utils import requires_myst, requires_no_myst
 
 
 @requires_myst
@@ -144,3 +147,14 @@ def test_add_source_map():
         add_source_map=True,
     )
     assert notebook.metadata.source_map == [3, 5, 7, 12]
+
+
+@requires_no_myst
+def test_meaningfull_error_when_myst_is_missing(tmpdir):
+    nb_file = tmpdir.join("notebook.ipynb")
+    jupytext.write(new_notebook(), str(nb_file))
+
+    with pytest.raises(
+        ImportError, match="The MyST Markdown format requires 'myst_parser>=0.8'."
+    ):
+        jupytext_cli([str(nb_file), "--to", "md:myst"])

--- a/tests/test_read_simple_pandoc.py
+++ b/tests/test_read_simple_pandoc.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
+import pytest
 from jupytext.compare import compare
 from nbformat.v4.nbbase import new_notebook, new_markdown_cell
 from jupytext.compare import compare_notebooks
+from jupytext.cli import jupytext as jupytext_cli
+from jupytext.pandoc import PandocError
 import jupytext
-from .utils import requires_pandoc
+from .utils import requires_pandoc, requires_no_pandoc
 
 
 @requires_pandoc
@@ -73,3 +76,14 @@ This is the greek letter $\\pi$: π"""
     nb2 = jupytext.reads(markdown, "md:pandoc")
     nb2.metadata.pop("jupytext")
     compare_notebooks(nb, nb2, "md:pandoc")
+
+
+@requires_no_pandoc
+def test_meaningfull_error_when_pandoc_is_missing(tmpdir):
+    nb_file = tmpdir.join("notebook.ipynb")
+    jupytext.write(new_notebook(), str(nb_file))
+
+    with pytest.raises(
+        PandocError, match="The Pandoc Markdown format requires 'pandoc>=2.7.2'"
+    ):
+        jupytext_cli([str(nb_file), "--to", "md:pandoc"])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -44,12 +44,16 @@ requires_pandoc = pytest.mark.skipif(
     not is_pandoc_available() or sys.version_info < (3,),
     reason="pandoc>=2.7.2 is not available",
 )
+requires_no_pandoc = pytest.mark.skipif(
+    is_pandoc_available(), reason="Pandoc is installed"
+)
 requires_ir_kernel = pytest.mark.skipif(
     kernelspec_from_language("R") is None, reason="irkernel is not installed"
 )
 requires_myst = pytest.mark.skipif(
     not is_myst_available(), reason="myst_parser not found"
 )
+requires_no_myst = pytest.mark.skipif(is_myst_available(), reason="myst is available")
 skip_on_windows = pytest.mark.skipif(sys.platform.startswith("win"), reason="Issue 489")
 
 


### PR DESCRIPTION
With this PR, the `md:myst` and `md:pandoc` are always included in the Jupytext formats, and an informative runtime
error will occur if the required dependencies, resp. `myst-parser` and `pandoc`, are not installed. (#556)

For instance, if I don't have `myst-parser`, `jupytext README.md --to md:myst` results into
```bash
[jupytext] Reading README.md in format md
[jupytext] Writing README.md in format md:myst (destination file replaced)
(...)
ImportError: The MyST Markdown format requires 'myst_parser>=0.8'. Install it with e.g. 'pip install jupytext[myst]'
```

A [similar error message](https://user-images.githubusercontent.com/29915202/88977741-bb869500-d2be-11ea-947e-ce779c05253b.png) is displayed in Jupyter Notebook or Lab user if they opens a myst file without having installed `myst`.

I have also simplified the documentation of the `--to` option in `jupytext --help` to make `md:myst` easier to find:
```
  --to OUTPUT_FORMAT    The destination format: 'ipynb', 'markdown' or 'script', or a file
                        extension: 'md', 'Rmd', 'jl', 'py', 'R', ..., 'auto' (script extension
                        matching the notebook language), or a combination of an extension and a
                        format name, e.g. md:myst, md:pandoc, md:markdown or py:hydrogen,
                        py:nomarker, py:sphinx, py:percent, py:light. The default format for scripts
                        is the 'light' format, which uses few cell markers (none when possible).
                        Alternatively, a format compatible with many editors is the 'percent'
                        format, which uses '# %%' as cell markers. The main formats (markdown,
                        light, percent) preserve notebooks and text documents in a roundtrip. Use
                        the --test and and --test-strict commands to test the roundtrip on your
                        files. Read more about the available formats at
                        https://jupytext.readthedocs.io/en/latest/formats.html (default: None)

```
