### PR TITLE
Jupytext --to file warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Activated GitHub code scanning alerts
 - New option `hide_notebook_metadata` to encapsulate the notebook metadata in an HTML comment (#527)
 - Tested `isort` on notebooks (#553)
+- `jupytext notebook.ipynb --to filename.py` will warn that `--to` is used in place of `--output`.
 
 **Changed**
 - Install Jupytext from source on MyBinder to avoid cache issues (#567)

--- a/jupytext/cli.py
+++ b/jupytext/cli.py
@@ -8,6 +8,7 @@ import shlex
 import subprocess
 import argparse
 import json
+import warnings
 from copy import copy
 from tempfile import NamedTemporaryFile
 from .jupytext import read, reads, write, writes
@@ -351,6 +352,19 @@ def jupytext(args=None):
 
     if args.output and len(args.notebooks) != 1:
         raise ValueError("Please input a single notebook when using --output")
+
+    # Warn if '--to' is used in place of '--output'
+    if (
+        not args.output
+        and args.output_format
+        and "." in args.output_format
+        and not args.output_format.startswith(".")
+        and "//" not in args.output_format
+    ):
+        warnings.warn(
+            "You have passed a file name to the '--to' option, "
+            "when a format description was expected. Maybe you want to use the '-o' option instead?"
+        )
 
     if args.input_format:
         args.input_format = long_form_one_format(args.input_format)

--- a/jupytext/cli.py
+++ b/jupytext/cli.py
@@ -361,6 +361,11 @@ def jupytext(args=None):
         and not args.output_format.startswith(".")
         and "//" not in args.output_format
     ):
+
+        def single_line(msg, *args, **kwargs):
+            return "[warning] {}\n".format(msg)
+
+        warnings.formatwarning = single_line
         warnings.warn(
             "You have passed a file name to the '--to' option, "
             "when a format description was expected. Maybe you want to use the '-o' option instead?"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1120,3 +1120,23 @@ def test_sync_script_dotdot_folder_564(tmpdir):
 
     jupytext(["--sync", str(py_file)])
     jupytext(["--sync", str(nb_file)])
+
+
+def test_jupytext_to_file_emits_a_warning(tmpdir):
+    """The user may type
+        jupytext notebook.ipynb --to script.py
+    meaning
+        jupytext notebook.ipynb -o script.py
+    """
+    os.chdir(str(tmpdir))
+
+    nb_file = tmpdir.join("notebook.ipynb")
+    write(new_notebook(), str(nb_file))
+
+    with pytest.warns(None) as record:
+        jupytext(["notebook.ipynb", "-o", "script.py"])
+
+    assert len(record) == 0
+
+    with pytest.warns(UserWarning, match="Maybe you want to use the '-o' option"):
+        jupytext(["notebook.ipynb", "--to", "script.py"])


### PR DESCRIPTION
 `jupytext notebook.ipynb --to filename.py` will warn that `--to` is used in place of `--output`.