### PR TITLE
Warn if 'Include Metadata' is off when saving text files in Jupyter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - New option `hide_notebook_metadata` to encapsulate the notebook metadata in an HTML comment (#527)
 - Tested `isort` on notebooks (#553)
 - `jupytext notebook.ipynb --to filename.py` will warn that `--to` is used in place of `--output`.
+- Warn if 'Include Metadata' is off when saving text files in Jupyter (#561)
 
 **Changed**
 - Install Jupytext from source on MyBinder to avoid cache issues (#567)

--- a/jupytext/contentsmanager.py
+++ b/jupytext/contentsmanager.py
@@ -148,6 +148,19 @@ def build_jupytext_contents_manager_class(base_contents_manager_class):
                     if fmt["extension"] == ".ipynb":
                         return super(JupytextContentsManager, self).save(model, path)
 
+                    if (
+                        model["content"]["metadata"]
+                        .get("jupytext", {})
+                        .get("notebook_metadata_filter")
+                        == "-all"
+                    ):
+                        self.log.warning(
+                            "Stripping metadata from {} as 'Include Metadata' is off "
+                            "(toggle 'Include Metadata' in the Jupytext Menu or Commands if desired)".format(
+                                path
+                            )
+                        )
+
                     with mock.patch("nbformat.writes", _jupytext_writes(fmt)):
                         return super(JupytextContentsManager, self).save(model, path)
 

--- a/tests/test_contentsmanager.py
+++ b/tests/test_contentsmanager.py
@@ -202,7 +202,7 @@ def test_save_load_paired_md_pandoc_notebook(nb_file, tmpdir):
 
 @skip_if_dict_is_not_ordered
 @pytest.mark.parametrize("py_file", list_notebooks("percent"))
-def test_pair_plain_script(py_file, tmpdir):
+def test_pair_plain_script(py_file, tmpdir, caplog):
     tmp_py = "notebook.py"
     tmp_ipynb = "notebook.ipynb"
 
@@ -213,6 +213,8 @@ def test_pair_plain_script(py_file, tmpdir):
     nb = jupytext.read(py_file)
     nb.metadata["jupytext"]["formats"] = "ipynb,py:hydrogen"
     cm.save(model=dict(type="notebook", content=nb), path=tmp_py)
+
+    assert "'Include Metadata' is off" in caplog.text
 
     assert os.path.isfile(str(tmpdir.join(tmp_py)))
     assert os.path.isfile(str(tmpdir.join(tmp_ipynb)))


### PR DESCRIPTION
Closes #561 