### PR TITLE
Use compatible release syntax for myst extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ error will occur if the required dependencies, resp. `myst-parser` and `pandoc`,
 - Configured coverage targets in `codecov.yml`
 - Only scripts can have an encoding comment, not Markdown or R Markdown files (#576)
 - Spaces in `--pipe` commands are supported (#562)
-- Use `>=` and `<` rather than `~=` in the `extras_require` of `setup.py` (#589)
 - Bash commands starting with special characters are now correctly detected, thanks to Aaron Gokaslan (#587)
 - MyST Markdown files are recognized as such even if `myst` is missing (#556)
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     tests_require=["pytest"],
     install_requires=["nbformat>=4.0.0", "pyyaml", "toml", 'mock;python_version<"3"'],
     extras_require={
-        "myst": ["myst-parser>=0.8; python_version >= '3.6'", "myst-parser<0.9"],
+        "myst": ["myst-parser~=0.8.0; python_version >= '3.6'"],
         "toml": ["toml"],
     },
     license="MIT",


### PR DESCRIPTION
Following the [discussion in PR #590](https://github.com/mwouts/jupytext/pull/590#issuecomment-681623137), use the compatible release syntax (`~=`) to require a version of `myst-parser` in the `v0.8.X` range for the `myst` extra.

Additionally, remove the note in the `CHANGELOG`, as it is no longer relevant.

The changes from PR #590 for Conda

https://github.com/mwouts/jupytext/blob/5f292f2dc08cca074ae5a7eaae9ad3600b5c41b9/.github/workflows/continuous-integration-conda.yml#L68-L69

are left as they are, as there is no equivalent syntax in Conda.

---
**Short notes to save people in the future from reading the above mentioned discussion:**

In [PEP 440's "Compatible release" section](https://www.python.org/dev/peps/pep-0440/#compatible-release)

> For a given release identifier V.N, the compatible release clause is approximately equivalent to the pair of comparison clauses:
> ```
>>= V.N, == V.*
>```

As an example, in a fresh virtual environment

```
(myst-example) $ pip install -qq "myst-parser~=0.8"
(myst-example) $ pip list | grep myst
myst-parser                   0.12.5
(myst-example) $ pip install --upgrade -qq "myst-parser~=0.8.0"
(myst-example) $ pip list | grep myst
myst-parser                   0.8.2
```