### PR TITLE
New option root_level_metadata_as_raw_cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 **Added**
 - Activated GitHub code scanning alerts
 - New option `hide_notebook_metadata` to encapsulate the notebook metadata in an HTML comment (#527)
+- New option `root_level_metadata_as_raw_cell`. Set it to `False` if you don't want to see root level metadata
+of R Markdown notebooks as a raw cell in Jupyter (#415)
+- New option `doxygen_equation_markers` to translate Markdown equations into Doxygen equations (#517)
 - Tested `isort` on notebooks (#553)
 - `jupytext notebook.ipynb --to filename.py` will warn that `--to` is used in place of `--output`.
 - Warn if 'Include Metadata' is off when saving text files in Jupyter (#561)
@@ -14,8 +17,8 @@
 - Skip the tests that execute a notebook on Windows to avoid timeout issues (#489)
 - The `# %%` cell marker has the same indentation as the first line in the cell (#562)
 - The `md:myst` and `md:pandoc` are always included in the Jupytext formats, and an informative runtime
-error will occur if the required dependencies, resp. `myst-parser` and `pandoc`, are not installed. (#556)
-- Jupytext now depends on `markdown-it-py` and always feature the MyST-Markdown format (Python 3.6 and above, #591)  
+error will occur if the required dependencies, resp. `markdown-it-py` and `pandoc`, are not installed. (#556)
+- Jupytext now depends on `markdown-it-py` and always feature the MyST-Markdown format (Python 3.6 and above, #591)
 
 **Fixed**
 - Configured coverage targets in `codecov.yml`

--- a/jupytext/config.py
+++ b/jupytext/config.py
@@ -74,6 +74,14 @@ class JupytextConfiguration(Configurable):
         config=True,
     )
 
+    root_level_metadata_as_raw_cell = Bool(
+        True,
+        help="Should the root level metadata of text documents (like the fields 'title' or 'author' in "
+        "R Markdown document) appear as a raw cell in the notebook (True), or go to the notebook"
+        "metadata?",
+        config=True,
+    )
+
     default_cell_metadata_filter = Unicode(
         u"",
         help="Cell metadata that should be saved in the text representations. "
@@ -141,6 +149,10 @@ class JupytextConfiguration(Configurable):
         if self.hide_notebook_metadata is not None:
             format_options.setdefault(
                 "hide_notebook_metadata", self.hide_notebook_metadata
+            )
+        if self.root_level_metadata_as_raw_cell is False:
+            format_options.setdefault(
+                "root_level_metadata_as_raw_cell", self.root_level_metadata_as_raw_cell
             )
         if self.comment_magics is not None:
             format_options.setdefault("comment_magics", self.comment_magics)

--- a/jupytext/formats.py
+++ b/jupytext/formats.py
@@ -698,6 +698,7 @@ _VALID_FORMAT_INFO = ["extension", "format_name", "suffix", "prefix"]
 _BINARY_FORMAT_OPTIONS = [
     "comment_magics",
     "hide_notebook_metadata",
+    "root_level_metadata_as_raw_cell",
     "split_at_heading",
     "rst2md",
     "cell_metadata_json",

--- a/jupytext/jupytext.py
+++ b/jupytext/jupytext.py
@@ -82,7 +82,10 @@ class TextNotebookConverter(NotebookReader, NotebookWriter):
 
         cells = []
         metadata, jupyter_md, header_cell, pos = header_to_metadata_and_cell(
-            lines, self.implementation.header_prefix, self.implementation.extension
+            lines,
+            self.implementation.header_prefix,
+            self.implementation.extension,
+            self.fmt.get("root_level_metadata_as_raw_cell", True),
         )
         default_language = default_language_from_metadata_and_ext(
             metadata, self.implementation.extension
@@ -242,7 +245,11 @@ class TextNotebookConverter(NotebookReader, NotebookWriter):
 
         header = encoding_and_executable(nb, metadata, self.ext)
         header_content, header_lines_to_next_cell = metadata_and_cell_to_header(
-            nb, metadata, self.implementation, self.ext
+            nb,
+            metadata,
+            self.implementation,
+            self.ext,
+            self.fmt.get("root_level_metadata_as_raw_cell", True),
         )
         header.extend(header_content)
 


### PR DESCRIPTION
New option `root_level_metadata_as_raw_cell`. Set it to `False` if you don't want to see root level metadata of R Markdown notebooks as a raw cell in Jupyter.

Closes #415.