### PR TITLE
suggest to use `--sync` instead of `--set-formats` when argument is a file name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ of R Markdown notebooks as a raw cell in Jupyter (#415)
 - New option `doxygen_equation_markers` to translate Markdown equations into Doxygen equations (#517)
 - Tested `isort` on notebooks (#553)
 - `jupytext notebook.ipynb --to filename.py` will warn that `--to` is used in place of `--output`.
+- `jupytext --set-formats filename.py` will suggest to use `--sync` instead of `--set-formats` (#544)
 - Warn if 'Include Metadata' is off when saving text files in Jupyter (#561)
 - Test that notebooks paired through a configuration file are left unmodified (#598)
 

--- a/jupytext/cli.py
+++ b/jupytext/cli.py
@@ -404,7 +404,10 @@ def jupytext(args=None):
 def jupytext_single_file(nb_file, args, log):
     """Apply the jupytext commmand, with given arguments, to a single file"""
     if nb_file == "-" and args.sync:
-        raise ValueError("Cannot sync a notebook on stdin")
+        msg = "Missing notebook path."
+        if args.set_formats is not None and os.path.isfile(args.set_formats):
+            msg += " Maybe you mean 'jupytext --sync {}' ?".format(args.set_formats)
+        raise ValueError(msg)
 
     nb_dest = args.output or (
         None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -289,7 +289,6 @@ def test_combine_lower_version_raises(tmpdir):
         "This error occurs because notebook.py is in the light format in version 55.4, "
         "while jupytext version .* installed at .* can only read the light format in versions .*",
     ):
-
         jupytext([tmp_nbpy, "--to", "ipynb", "--update"])
 
 
@@ -1140,3 +1139,30 @@ def test_jupytext_to_file_emits_a_warning(tmpdir):
 
     with pytest.warns(UserWarning, match="Maybe you want to use the '-o' option"):
         jupytext(["notebook.ipynb", "--to", "script.py"])
+
+
+def test_jupytext_set_formats_file_gives_an_informative_error(tmpdir):
+    """The user may type
+        jupytext --set-formats notebook.md
+    meaning
+        jupytext --syn notebook.md
+    """
+    os.chdir(str(tmpdir))
+
+    cfg_file = tmpdir.join("jupytext.toml")
+    cfg_file.write('default_jupytext_formats = "md,ipynb,py:percent"')
+
+    md_file = tmpdir.join("notebook.md")
+    py_file = tmpdir.join("notebook.py")
+    nb_file = tmpdir.join("notebook.ipynb")
+    md_file.write("Some text")
+
+    with pytest.warns(None) as record:
+        jupytext(["--sync", "notebook.md"])
+
+    assert len(record) == 0
+    assert py_file.exists()
+    assert nb_file.exists()
+
+    with pytest.raises(ValueError, match="jupytext --sync notebook.md"):
+        jupytext(["--set-formats", "notebook.md"])


### PR DESCRIPTION
Closes #544 