### PR TITLE
Fix jupyterlab build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ error will occur if the required dependencies, resp. `markdown-it-py` and `pando
 - Spaces in `--pipe` commands are supported (#562)
 - Bash commands starting with special characters are now correctly detected, thanks to Aaron Gokaslan (#587)
 - MyST Markdown files are recognized as such even if `myst` is missing (#556)
+- Build JupyterLab with `dev-build=False` and `minimize=False` on mybinder to avoid build errors
 
 
 1.5.2 (2020-07-21)

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -19,5 +19,5 @@ jupyter trust demo/World\ population.ipynb
 # Install the bash kernel
 python -m bash_kernel.install
 
-# Build jupyter lab to include the Jupytext extension
-jupyter lab build
+# Build jupyter lab to include the Jupytext extension, using low-memory settings
+jupyter lab build --dev-build=False --minimize=False


### PR DESCRIPTION
The mybinder build was failing at the command `jupyterlab build` with an advice to use `dev-build=False` and `minimize=False`.
With these new arguments the problem disappears.