### PR TITLE
Freeze optional dependency on `sphinx-gallery` to version `~=0.7.0`

### DIFF
--- a/.github/workflows/continuous-integration-conda.yml
+++ b/.github/workflows/continuous-integration-conda.yml
@@ -63,7 +63,7 @@ jobs:
           conda install isort>=5.3.0 --freeze-installed
           conda install autopep8 --freeze-installed
           # install sphinx_gallery and matplotlib if available
-          conda install sphinx-gallery --freeze-installed
+          conda install 'sphinx-gallery>=0.7' 'sphinx-gallery<0.8' --freeze-installed
           # myst-parser
           conda install 'markdown-it-py>=0.5' 'markdown-it-py<0.6' --freeze-installed
           exit 0

--- a/.github/workflows/continuous-integration-pip.yml
+++ b/.github/workflows/continuous-integration-pip.yml
@@ -24,7 +24,7 @@ jobs:
           pip install isort>=5.3.0 || true
           pip install autopep8 || true
           # install sphinx_gallery and matplotlib if available (may not work on pypy)
-          pip install sphinx_gallery || true
+          pip install sphinx_gallery~=0.7.0 || true
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+1.6.1-dev (2020-09-??)
+----------------------
+
+**Fixed**
+- Freeze optional dependency on `sphinx-gallery` to version `~=0.7.0` (#614)
+
+
 1.6.0 (2020-09-01)
 ------------------
 

--- a/environment.yml
+++ b/environment.yml
@@ -19,14 +19,13 @@ dependencies:
   - black
   - isort
   - autopep8
-  - sphinx-gallery
-  - nodejs<13
+  - sphinx-gallery<0.8
+  - nodejs
   - yarn
   - pip
   - setuptools
   - twine
   - pandoc>=2.9
-  - myst-parser
   # make html in docs folder
   - sphinx
   - recommonmark

--- a/jupytext/version.py
+++ b/jupytext/version.py
@@ -1,3 +1,3 @@
 """Jupytext's version number"""
 
-__version__ = "1.6.0"
+__version__ = "1.6.1-dev"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ pytest-cov
 notebook
 jupyter_client
 nbconvert
-sphinx-gallery
+sphinx-gallery<=0.7.0
 setuptools
 toml
 

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         # left for back-compatibility
         "myst": [],
         "toml": ["toml"],
+        "rst2md": ["sphinx-gallery~=0.7.0"],
     },
     license="MIT",
     classifiers=[


### PR DESCRIPTION
Closes #614 