### PR TITLE
Add Cython to list of language magics

### DIFF
--- a/jupytext/languages.py
+++ b/jupytext/languages.py
@@ -25,6 +25,7 @@ _JUPYTER_LANGUAGES = [
     "robotframework",
     "spark",
     "sql",
+    "cython",
 ]
 
 # Supported file extensions (and languages)


### PR DESCRIPTION
Add [Cython](https://cython.readthedocs.io/en/latest/src/quickstart/build.html#using-the-jupyter-notebook) to the list of language magics, so that Cython cells get commented out in non-notebook formats.

FWIW I don't think it would make sense to open Cython files as notebooks; each Cython cell in a notebook is compiled separately, so a file with any dependencies between cells would fail as a notebook.