### PR TITLE
Include code files feature: Write python code cells to separate files that are referenced in Extended Markdown

### DIFF
--- a/jupytext/cell_metadata.py
+++ b/jupytext/cell_metadata.py
@@ -329,6 +329,14 @@ def is_active(ext, metadata, default=True):
     return ext.replace(".", "") in re.split(r"\.|,", metadata["active"])
 
 
+def get_pyref_tag(metadata):
+    """Returns python file reference from tags, if exists"""
+    for tag in metadata.get("tags", []):
+        if tag.endswith(".py"):
+            return tag[:-3]
+    return
+
+
 def metadata_to_double_percent_options(metadata, plain_json):
     """Metadata to double percent lines"""
     text = []

--- a/jupytext/jupytext.py
+++ b/jupytext/jupytext.py
@@ -449,16 +449,18 @@ def writes(notebook, fmt, version=nbformat.NO_CONVERT, **kwargs):
         jupytext_metadata.pop("text_representation", {})
         if not jupytext_metadata:
             metadata.pop("jupytext", {})
-        return nbformat.writes(
-            NotebookNode(
-                nbformat=notebook.nbformat,
-                nbformat_minor=notebook.nbformat_minor,
-                metadata=metadata,
-                cells=notebook.cells,
-            ),
-            version,
-            **kwargs,
-        )
+        return [
+            nbformat.writes(
+                NotebookNode(
+                    nbformat=notebook.nbformat,
+                    nbformat_minor=notebook.nbformat_minor,
+                    metadata=metadata,
+                    cells=notebook.cells,
+                ),
+                version,
+                **kwargs,
+            )
+        ]
 
     if not format_name:
         format_name = format_name_for_ext(metadata, ext, explicit_default=False)


### PR DESCRIPTION
This is not a fully fledged-ready-to-merge feature. Rather, this is a quick implementation to demonstrate an idea (see #625 ).

Instead of surrounding code-cells as code-blocks by triple-ticks in markdown, they are stored as separate `.py` files and referenced in markdown file with Extended Markdown format `!INCLUDECODE`.

* by default, python files are named with underscore (`_`) in ascending order, according to their code-cell position, e.g.:
```output
_001.py
_002.py
_003.py
_004.py
_005.py
_006.py
_007.py
_008.py
_009.py
_010.py
```
* in the notebook-markdown file, this looks like:
```md
## Parameters


This is a collection of parameters that affect processing of graphics.

!INCLUDECODE "_001.py"

**Create paths**

!INCLUDECODE "_002.py"

## Load dependencies
```
* if code-cells in jupyter lab contain a tag that ends with `.py`, the tag is used instead to link the cells to a specific python file.
    * for example, a code cell with the tag `create_grid_df.py`..
    * will be linked in the markdown-notebook as `!INCLUDECODE "create_grid_df.py"`
    * and stored to the file `create_grid_df.py`
* in another notebook, it is now possible to load the code of selected methods with the `%load`-magic
    * e.g. `%load Path(Path.cwd / "jupytext_converts" / "create_grid_df.py")`

The primary benefit of this include-format is that Python-code can be imported from other notebooks on a per-cell basis. Assume, for example, that a big method (`def create_grid_df():`) is defined in a particular notebook-cell. In another notebook, importing only this method is impossible without executing all other top-level code. However, if cells are synced to individual python files, it is possible to import methods from these files instead (e.g. `%load Path(Path.cwd / "jupytext_converts" / "create_grid_df.py")` - which will import `create_grid_df()`). This makes it unnecessary to explicitly write reusable code to python files with the [`%%writeandexecute`-magic](https://ipython-extensions.readthedocs.io/en/latest/magics.html#cellmagic-writeandexecute).

When viewed from a version control perspective, this allows to track code in separate files, instead as in one big file. In contrast to the `%%writeandexecute` magic, code can be tracked _only_ in python files and comment-cells (as markdown) _only_ in md files. With the `%%writeandexecute`, code must either be tracked with all other comments in one giant file (e.g. through Jupytext), or tracked twice in external written *.py files _and_ the main notebook, which includes code+comments.

In the current PR, conversion works both ways, e.g.:  
* `jupytext --to notebook sample.md`
* `jupytext --to md sample.ipynb`

Caveats:  
* Likely, this is not implemented according to conventions used in jupytext
* Performance: not only one file needs to be written, but many. I found performance ok here for my test notebook containing 116 code cells, but this is subjective
* Likely, my tampering has introduced bugs with other features. The current PR is not tested at all beyond the specific use case
* in the PR, the option for include files is static and enabled. I expect there's some serious refactoring needed, but will wait for comments first..

What if..
* ..the same tag is used (e.g. two times  `create_grid_df.py`). Append content of multiple code-cells to single python file? Add additional number?
* ..integrity is lost (e.g. moved files etc.), or additional files/tags are present in folder that accidentally match pattern. Better to store split-md files in subfolder? Is this perhaps better implemented in a new jupytext format (e.g. "md-py")?

Many thanks for any comments.