### PR TITLE
Jupytext's CM uses parent CM's get and save methods to read text files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-.idea
-.vscode
 .build
 .cache
 .coverage
@@ -18,3 +16,13 @@ docs/_build
 
 # Will be created by postBuild
 demo/get_started.ipynb
+
+# jetbrains ide stuff
+*.iml
+.idea/
+
+# vscode ide stuff
+*.code-workspace
+.history
+.vscode/*
+!.vscode/*.template

--- a/jupytext/contentsmanager.py
+++ b/jupytext/contentsmanager.py
@@ -155,7 +155,9 @@ def build_jupytext_contents_manager_class(base_contents_manager_class):
                     text_model = dict(
                         type="file",
                         format="text",
-                        content=jupytext.writes(model["content"], fmt=fmt),
+                        content=jupytext.writes(
+                            nbformat.from_dict(model["content"]), fmt=fmt
+                        ),
                     )
 
                     return self.super.save(text_model, path)
@@ -163,8 +165,12 @@ def build_jupytext_contents_manager_class(base_contents_manager_class):
                 return write_pair(path, jupytext_formats, save_one_file)
 
             except Exception as e:
-                self.log.error(u'Error while saving file: %s %s', path, e, exc_info=True)
-                raise HTTPError(500, u'Unexpected error while saving file: %s %s' % (path, e))
+                self.log.error(
+                    u"Error while saving file: %s %s", path, e, exc_info=True
+                )
+                raise HTTPError(
+                    500, u"Unexpected error while saving file: %s %s" % (path, e)
+                )
 
         def get(
             self,

--- a/jupytext/contentsmanager.py
+++ b/jupytext/contentsmanager.py
@@ -162,8 +162,9 @@ def build_jupytext_contents_manager_class(base_contents_manager_class):
 
                 return write_pair(path, jupytext_formats, save_one_file)
 
-            except Exception as err:
-                raise HTTPError(400, str(err))
+            except Exception as e:
+                self.log.error(u'Error while saving file: %s %s', path, e, exc_info=True)
+                raise HTTPError(500, u'Unexpected error while saving file: %s %s' % (path, e))
 
         def get(
             self,

--- a/jupytext/contentsmanager.py
+++ b/jupytext/contentsmanager.py
@@ -437,20 +437,21 @@ def build_jupytext_contents_manager_class(base_contents_manager_class):
                     return path
 
             if not directory:
-                return find_global_jupytext_configuration_file()
+                return None
 
             parent_dir = self.get_parent_dir(directory)
             return self.get_config_file(parent_dir)
 
-        def load_config_file(self, config_file):
+        def load_config_file(self, config_file, is_os_path=False):
             """Load the configuration file"""
             if config_file is None:
                 return None
             self.log.info("Loading Jupytext configuration file at %s", config_file)
-            if config_file.endswith(".py"):
-                config_dict = load_jupytext_configuration_file(
-                    self._get_os_path(config_file)
-                )
+            if config_file.endswith(".py") and not is_os_path:
+                config_file = self._get_os_path(config_file)
+                is_os_path = True
+            if is_os_path:
+                config_dict = load_jupytext_configuration_file(config_file)
             else:
                 model = self.super.get(config_file, content=True, type="file")
                 config_dict = load_jupytext_configuration_file(

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,4 +18,4 @@ exclude_lines =
 [flake8]
 max-line-length=127
 exclude=tests/notebooks/*
-ignore=E203,W503
+ignore=E203,E231,W503

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1166,3 +1166,6 @@ def test_jupytext_set_formats_file_gives_an_informative_error(tmpdir):
 
     with pytest.raises(ValueError, match="jupytext --sync notebook.md"):
         jupytext(["--set-formats", "notebook.md"])
+
+    # Remove the config file, otherwise test_jupytext_jupyter_fs_metamanager fails later on!
+    cfg_file.remove()

--- a/tests/test_cm_config.py
+++ b/tests/test_cm_config.py
@@ -9,6 +9,7 @@ from nbformat import read
 import pytest
 from tornado.web import HTTPError
 import jupytext
+from .utils import notebook_model
 
 SAMPLE_NOTEBOOK = new_notebook(
     cells=[new_markdown_cell("A Markdown cell"), new_code_cell("# A code cell\n1 + 1")]
@@ -24,11 +25,11 @@ def test_local_config_overrides_cm_config(tmpdir):
     with open(str(nested.join(".jupytext.yml")), "w") as fp:
         fp.write("default_jupytext_formats: ''\n")
 
-    cm.save(dict(type="notebook", content=SAMPLE_NOTEBOOK), "notebook.ipynb")
+    cm.save(notebook_model(SAMPLE_NOTEBOOK), "notebook.ipynb")
     assert os.path.isfile(str(tmpdir.join("notebook.ipynb")))
     assert os.path.isfile(str(tmpdir.join("notebook.py")))
 
-    cm.save(dict(type="notebook", content=SAMPLE_NOTEBOOK), "nested/notebook.ipynb")
+    cm.save(notebook_model(SAMPLE_NOTEBOOK), "nested/notebook.ipynb")
     assert os.path.isfile(str(nested.join("notebook.ipynb")))
     assert not os.path.isfile(str(nested.join("notebook.py")))
 
@@ -64,7 +65,7 @@ def test_pairing_through_config_leaves_ipynb_unmodified(tmpdir):
 
     cfg_file.write("default_jupytext_formats: 'ipynb,py'\n")
 
-    cm.save(dict(type="notebook", content=SAMPLE_NOTEBOOK), "notebook.ipynb")
+    cm.save(notebook_model(SAMPLE_NOTEBOOK), "notebook.ipynb")
     assert nb_file.isfile()
     assert py_file.isfile()
 
@@ -99,7 +100,7 @@ def test_incorrect_config_message(tmpdir, cfg_file, cfg_text):
         cm.get("empty.ipynb", type="notebook", content=False)
 
     with pytest.raises(HTTPError, match=expected_message):
-        cm.save(dict(type="notebook", content=SAMPLE_NOTEBOOK), "notebook.ipynb")
+        cm.save(notebook_model(SAMPLE_NOTEBOOK), "notebook.ipynb")
 
 
 def test_global_config_file(tmpdir):
@@ -117,7 +118,7 @@ def test_global_config_file(tmpdir):
         fake_global_config_directory,
     ):
         nb = new_notebook(cells=[new_code_cell("1+1")])
-        model = dict(content=nb, type="notebook")
+        model = notebook_model(nb)
         cm.save(model, "notebook.ipynb")
         assert set(model["path"] for model in cm.get("/", content=True)["content"]) == {
             "notebook.ipynb",

--- a/tests/test_contentsmanager.py
+++ b/tests/test_contentsmanager.py
@@ -22,6 +22,7 @@ from .utils import (
     requires_sphinx_gallery,
     requires_pandoc,
     skip_if_dict_is_not_ordered,
+    notebook_model,
 )
 
 
@@ -91,12 +92,12 @@ def test_pair_unpair_notebook(tmpdir):
     cm.root_dir = str(tmpdir)
 
     # save notebook
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_ipynb)
+    cm.save(model=notebook_model(nb), path=tmp_ipynb)
     assert not os.path.isfile(str(tmpdir.join(tmp_md)))
 
     # pair notebook
     nb["metadata"]["jupytext"] = {"formats": "ipynb,md"}
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_ipynb)
+    cm.save(model=notebook_model(nb), path=tmp_ipynb)
     assert os.path.isfile(str(tmpdir.join(tmp_md)))
 
     # reload and get outputs
@@ -105,7 +106,7 @@ def test_pair_unpair_notebook(tmpdir):
 
     # unpair and save as md
     del nb["metadata"]["jupytext"]
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_md)
+    cm.save(model=notebook_model(nb), path=tmp_md)
     nb2 = cm.get(tmp_md)["content"]
 
     # we get no outputs here
@@ -125,12 +126,12 @@ def test_load_save_rename(nb_file, tmpdir):
 
     # open ipynb, save Rmd, reopen
     nb = jupytext.read(nb_file)
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_rmd)
+    cm.save(model=notebook_model(nb), path=tmp_rmd)
     nb_rmd = cm.get(tmp_rmd)
     compare_notebooks(nb_rmd["content"], nb, "Rmd")
 
     # save ipynb
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_ipynb)
+    cm.save(model=notebook_model(nb), path=tmp_ipynb)
 
     # rename ipynb
     cm.rename(tmp_ipynb, "new.ipynb")
@@ -145,7 +146,7 @@ def test_load_save_rename(nb_file, tmpdir):
     assert not os.path.isfile(str(tmpdir.join("new.Rmd")))
     model = cm.get("new.ipynb", content=False)
     assert "last_modified" in model
-    cm.save(model=dict(type="notebook", content=nb), path="new.ipynb")
+    cm.save(model=notebook_model(nb), path="new.ipynb")
     assert os.path.isfile(str(tmpdir.join("new.Rmd")))
 
     cm.delete("new.Rmd")
@@ -170,7 +171,7 @@ def test_save_load_paired_md_notebook(nb_file, tmpdir):
     nb = jupytext.read(nb_file)
     nb.metadata["jupytext"] = {"formats": "ipynb,md"}
 
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_ipynb)
+    cm.save(model=notebook_model(nb), path=tmp_ipynb)
     nb_md = cm.get(tmp_md)
 
     compare_notebooks(nb_md["content"], nb, "md")
@@ -194,7 +195,7 @@ def test_save_load_paired_md_pandoc_notebook(nb_file, tmpdir):
     nb = jupytext.read(nb_file)
     nb.metadata["jupytext"] = {"formats": "ipynb,md:pandoc"}
 
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_ipynb)
+    cm.save(model=notebook_model(nb), path=tmp_ipynb)
     nb_md = cm.get(tmp_md)
 
     compare_notebooks(nb_md["content"], nb, "md:pandoc")
@@ -213,7 +214,7 @@ def test_pair_plain_script(py_file, tmpdir, caplog):
     # open py file, pair, save with cm
     nb = jupytext.read(py_file)
     nb.metadata["jupytext"]["formats"] = "ipynb,py:hydrogen"
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_py)
+    cm.save(model=notebook_model(nb), path=tmp_py)
 
     assert "'Include Metadata' is off" in caplog.text
 
@@ -236,7 +237,7 @@ def test_pair_plain_script(py_file, tmpdir, caplog):
 
     # remove the pairing and save
     del nb.metadata["jupytext"]["formats"]
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_py)
+    cm.save(model=notebook_model(nb), path=tmp_py)
 
     # reopen py file with the cm
     nb2 = cm.get(tmp_py)["content"]
@@ -256,12 +257,12 @@ def test_load_save_rename_nbpy(nb_file, tmpdir):
 
     # open ipynb, save nb.py, reopen
     nb = jupytext.read(nb_file)
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_nbpy)
+    cm.save(model=notebook_model(nb), path=tmp_nbpy)
     nbpy = cm.get(tmp_nbpy)
     compare_notebooks(nbpy["content"], nb)
 
     # save ipynb
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_ipynb)
+    cm.save(model=notebook_model(nb), path=tmp_ipynb)
 
     # rename nbpy
     cm.rename(tmp_nbpy, "new.nb.py")
@@ -294,7 +295,7 @@ def test_load_save_py_freeze_metadata(script, tmpdir):
 
     # open and save notebook
     nb = cm.get(tmp_nbpy)["content"]
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_nbpy)
+    cm.save(model=notebook_model(nb), path=tmp_nbpy)
 
     with open(str(tmpdir.join(tmp_nbpy))) as fp:
         text_py2 = fp.read()
@@ -314,12 +315,12 @@ def test_load_save_rename_notebook_with_dot(nb_file, tmpdir):
 
     # open ipynb, save nb.py, reopen
     nb = jupytext.read(nb_file)
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_nbpy)
+    cm.save(model=notebook_model(nb), path=tmp_nbpy)
     nbpy = cm.get(tmp_nbpy)
     compare_notebooks(nbpy["content"], nb)
 
     # save ipynb
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_ipynb)
+    cm.save(model=notebook_model(nb), path=tmp_ipynb)
 
     # rename py
     cm.rename(tmp_nbpy, "2.new_notebook.py")
@@ -343,7 +344,7 @@ def test_load_save_rename_nbpy_default_config(nb_file, tmpdir):
     # open ipynb, save nb.py, reopen
     nb = jupytext.read(nb_file)
 
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_nbpy)
+    cm.save(model=notebook_model(nb), path=tmp_nbpy)
     nbpy = cm.get(tmp_nbpy)
     compare_notebooks(nbpy["content"], nb)
 
@@ -352,7 +353,7 @@ def test_load_save_rename_nbpy_default_config(nb_file, tmpdir):
     compare_notebooks(nbipynb["content"], nb)
 
     # save ipynb
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_ipynb)
+    cm.save(model=notebook_model(nb), path=tmp_ipynb)
 
     # rename notebook.nb.py to new.nb.py
     cm.rename(tmp_nbpy, "new.nb.py")
@@ -384,7 +385,7 @@ def test_load_save_rename_non_ascii_path(nb_file, tmpdir):
     # open ipynb, save nb.py, reopen
     nb = jupytext.read(nb_file)
 
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_nbpy)
+    cm.save(model=notebook_model(nb), path=tmp_nbpy)
     nbpy = cm.get(tmp_nbpy)
     compare_notebooks(nbpy["content"], nb)
 
@@ -393,7 +394,7 @@ def test_load_save_rename_non_ascii_path(nb_file, tmpdir):
     compare_notebooks(nbipynb["content"], nb)
 
     # save ipynb
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_ipynb)
+    cm.save(model=notebook_model(nb), path=tmp_ipynb)
 
     # rename notebôk.nb.py to nêw.nb.py
     cm.rename(tmp_nbpy, u"nêw.nb.py")
@@ -425,7 +426,7 @@ def test_outdated_text_notebook(nb_file, tmpdir):
 
     # open ipynb, save py, reopen
     nb = jupytext.read(nb_file)
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_nbpy)
+    cm.save(model=notebook_model(nb), path=tmp_nbpy)
     model_py = cm.get(tmp_nbpy, load_alternative_format=False)
     model_ipynb = cm.get(tmp_ipynb, load_alternative_format=False)
 
@@ -464,7 +465,7 @@ def test_reload_notebook_after_jupytext_cli(nb_file, tmpdir):
     # write the paired notebook
     nb = jupytext.read(nb_file)
     nb.metadata.setdefault("jupytext", {})["formats"] = "py,ipynb"
-    cm.save(model=dict(type="notebook", content=nb), path="notebook.py")
+    cm.save(model=notebook_model(nb), path="notebook.py")
 
     assert os.path.isfile(tmp_ipynb)
     assert os.path.isfile(tmp_nbpy)
@@ -495,7 +496,7 @@ def test_load_save_percent_format(nb_file, tmpdir):
     # open python, save
     nb = cm.get(tmp_py)["content"]
     del nb.metadata["jupytext"]["notebook_metadata_filter"]
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_py)
+    cm.save(model=notebook_model(nb), path=tmp_py)
 
     # compare the new file with original one
     with open(str(tmpdir.join(tmp_py))) as stream:
@@ -525,7 +526,7 @@ def test_save_to_percent_format(nb_file, tmpdir):
     nb["metadata"]["jupytext"] = {"formats": "ipynb,jl"}
 
     # save to ipynb and jl
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_ipynb)
+    cm.save(model=notebook_model(nb), path=tmp_ipynb)
 
     # read jl file
     with open(str(tmpdir.join(tmp_jl))) as stream:
@@ -550,7 +551,7 @@ def test_save_using_preferred_and_default_format_170(nb_file, tmpdir):
     cm.default_jupytext_formats = "ipynb,python//py"
 
     # save to ipynb and py
-    cm.save(model=dict(type="notebook", content=nb), path="notebook.ipynb")
+    cm.save(model=notebook_model(nb), path="notebook.ipynb")
 
     # read py file
     nb_py = read(tmp_py)
@@ -565,7 +566,7 @@ def test_save_using_preferred_and_default_format_170(nb_file, tmpdir):
     cm.default_jupytext_formats = "ipynb,python//py"
 
     # save to ipynb and py
-    cm.save(model=dict(type="notebook", content=nb), path="notebook.ipynb")
+    cm.save(model=notebook_model(nb), path="notebook.ipynb")
 
     # read py file
     nb_py = read(tmp_py)
@@ -579,7 +580,7 @@ def test_save_using_preferred_and_default_format_170(nb_file, tmpdir):
     cm.default_jupytext_formats = "ipynb,python//py:percent"
 
     # save to ipynb and py
-    cm.save(model=dict(type="notebook", content=nb), path="notebook.ipynb")
+    cm.save(model=notebook_model(nb), path="notebook.ipynb")
 
     # read py file
     nb_py = read(tmp_py)
@@ -669,7 +670,7 @@ def test_save_to_light_percent_sphinx_format(nb_file, tmpdir):
     }
 
     # save to ipynb and three python flavors
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_ipynb)
+    cm.save(model=notebook_model(nb), path=tmp_ipynb)
 
     # read files
     with open(str(tmpdir.join(tmp_pct_py))) as stream:
@@ -708,7 +709,7 @@ def test_pair_notebook_with_dot(nb_file, tmpdir):
     nb["metadata"]["jupytext"] = {"formats": "ipynb,py:percent"}
 
     # save to ipynb and three python flavors
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_ipynb)
+    cm.save(model=notebook_model(nb), path=tmp_ipynb)
 
     assert os.path.isfile(str(tmpdir.join(tmp_ipynb)))
 
@@ -738,7 +739,7 @@ def test_preferred_format_allows_to_read_others_format(nb_file, tmpdir):
     # load notebook and save it using the cm
     nb = jupytext.read(nb_file)
     nb["metadata"]["jupytext"] = {"formats": "ipynb,py"}
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_ipynb)
+    cm.save(model=notebook_model(nb), path=tmp_ipynb)
 
     # Saving does not update the metadata, as 'save' makes a copy of the notebook
     # assert nb['metadata']['jupytext']['formats'] == 'ipynb,py:light'
@@ -758,7 +759,7 @@ def test_preferred_format_allows_to_read_others_format(nb_file, tmpdir):
     # Change save format and save
     model["content"]["metadata"]["jupytext"]["formats"] == "ipynb,py"
     cm.preferred_jupytext_formats_save = "py:percent"
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_ipynb)
+    cm.save(model=notebook_model(nb), path=tmp_ipynb)
 
     # Read notebook
     model = cm.get(tmp_nbpy)
@@ -810,7 +811,7 @@ def test_save_in_auto_extension_global(nb_file, tmpdir):
     cm.root_dir = str(tmpdir)
 
     # save notebook
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_ipynb)
+    cm.save(model=notebook_model(nb), path=tmp_ipynb)
 
     # check that text representation exists, and is in percent format
     with open(str(tmpdir.join(tmp_script))) as stream:
@@ -838,7 +839,7 @@ def test_global_auto_pairing_works_with_empty_notebook(tmpdir):
     cm.root_dir = str(tmpdir)
 
     # save notebook
-    cm.save(model=dict(type="notebook", content=nb), path="notebook.ipynb")
+    cm.save(model=notebook_model(nb), path="notebook.ipynb")
 
     # check that only the ipynb representation exists
     assert os.path.isfile(tmp_ipynb)
@@ -861,7 +862,7 @@ def test_global_auto_pairing_works_with_empty_notebook(tmpdir):
     }
 
     # save again
-    cm.save(model=dict(type="notebook", content=nb), path="notebook.ipynb")
+    cm.save(model=notebook_model(nb), path="notebook.ipynb")
 
     # check that ipynb + py representations exists
     assert os.path.isfile(tmp_ipynb)
@@ -893,7 +894,7 @@ def test_save_in_auto_extension_global_with_format(nb_file, tmpdir):
     cm.root_dir = str(tmpdir)
 
     # save notebook
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_ipynb)
+    cm.save(model=notebook_model(nb), path=tmp_ipynb)
 
     # check that text representation exists, and is in percent format
     with open(str(tmpdir.join(tmp_script))) as stream:
@@ -923,7 +924,7 @@ def test_save_in_auto_extension_local(nb_file, tmpdir):
     cm.root_dir = str(tmpdir)
 
     # save notebook
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_ipynb)
+    cm.save(model=notebook_model(nb), path=tmp_ipynb)
 
     # check that text representation exists, and is in percent format
     with open(str(tmpdir.join(tmp_script))) as stream:
@@ -952,7 +953,7 @@ def test_save_in_pct_and_lgt_auto_extensions(nb_file, tmpdir):
     cm.root_dir = str(tmpdir)
 
     # save notebook
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_ipynb)
+    cm.save(model=notebook_model(nb), path=tmp_ipynb)
 
     # check that text representation exists in percent format
     with open(str(tmpdir.join(tmp_pct_script))) as stream:
@@ -974,7 +975,7 @@ def test_metadata_filter_is_effective(nb_file, tmpdir):
     cm.root_dir = str(tmpdir)
 
     # save notebook to tmpdir
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_ipynb)
+    cm.save(model=notebook_model(nb), path=tmp_ipynb)
 
     # set config
     cm.default_jupytext_formats = "ipynb,py"
@@ -988,7 +989,7 @@ def test_metadata_filter_is_effective(nb_file, tmpdir):
     assert nb.metadata["jupytext"]["notebook_metadata_filter"] == "jupytext,-all"
 
     # save notebook again
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_ipynb)
+    cm.save(model=notebook_model(nb), path=tmp_ipynb)
 
     # read text version
     nb2 = jupytext.read(str(tmpdir.join(tmp_script)))
@@ -1063,7 +1064,7 @@ def test_local_format_can_deactivate_pairing(nb_file, ext, tmpdir):
     cm.root_dir = str(tmpdir)
 
     # save notebook
-    cm.save(model=dict(type="notebook", content=nb), path="notebook" + ext)
+    cm.save(model=notebook_model(nb), path="notebook" + ext)
 
     # check that only the text representation exists
     assert os.path.isfile(str(tmpdir.join("notebook.py"))) == (ext == ".py")
@@ -1072,7 +1073,7 @@ def test_local_format_can_deactivate_pairing(nb_file, ext, tmpdir):
     compare_notebooks(nb2, nb)
 
     # resave, check again
-    cm.save(model=dict(type="notebook", content=nb2), path="notebook" + ext)
+    cm.save(model=notebook_model(nb2), path="notebook" + ext)
 
     assert os.path.isfile(str(tmpdir.join("notebook.py"))) == (ext == ".py")
     assert os.path.isfile(str(tmpdir.join("notebook.ipynb"))) == (ext == ".ipynb")
@@ -1091,7 +1092,7 @@ def test_global_pairing_allows_to_save_other_file_types(nb_file, tmpdir):
     cm.root_dir = str(tmpdir)
 
     # save notebook
-    cm.save(model=dict(type="notebook", content=nb), path="notebook.Rmd")
+    cm.save(model=notebook_model(nb), path="notebook.Rmd")
 
     # check that only the original file is saved
     assert os.path.isfile(str(tmpdir.join("notebook.Rmd")))
@@ -1136,9 +1137,8 @@ def test_pair_notebook_in_another_folder(tmpdir):
     tmp_py = str(tmpdir.join("scripts/notebook_name.py"))
 
     cm.save(
-        model=dict(
-            type="notebook",
-            content=new_notebook(
+        model=notebook_model(
+            new_notebook(
                 metadata={"jupytext": {"formats": "notebooks//ipynb,scripts//py"}}
             ),
         ),
@@ -1161,11 +1161,8 @@ def test_pair_notebook_in_dotdot_folder(tmpdir):
     tmp_py = str(tmpdir.join("scripts/notebook_name.py"))
 
     cm.save(
-        model=dict(
-            type="notebook",
-            content=new_notebook(
-                metadata={"jupytext": {"formats": "ipynb,../scripts//py"}}
-            ),
+        model=notebook_model(
+            new_notebook(metadata={"jupytext": {"formats": "ipynb,../scripts//py"}})
         ),
         path="notebooks/notebook_name.ipynb",
     )
@@ -1269,19 +1266,19 @@ def test_set_then_change_formats(tmpdir):
     cm = jupytext.TextFileContentsManager()
     cm.root_dir = str(tmpdir)
 
-    cm.save(model=dict(content=nb, type="notebook"), path="nb.ipynb")
+    cm.save(model=notebook_model(nb), path="nb.ipynb")
     assert os.path.isfile(tmp_py)
     assert read(tmp_py).metadata["jupytext"]["formats"] == "ipynb,py:light"
     os.remove(tmp_py)
 
     nb.metadata["jupytext"]["formats"] = "ipynb,py:percent"
-    cm.save(model=dict(content=nb, type="notebook"), path="nb.ipynb")
+    cm.save(model=notebook_model(nb), path="nb.ipynb")
     assert os.path.isfile(tmp_py)
     assert read(tmp_py).metadata["jupytext"]["formats"] == "ipynb,py:percent"
     os.remove(tmp_py)
 
     del nb.metadata["jupytext"]["formats"]
-    cm.save(model=dict(content=nb, type="notebook"), path="nb.ipynb")
+    cm.save(model=notebook_model(nb), path="nb.ipynb")
     assert not os.path.isfile(tmp_py)
 
 
@@ -1297,7 +1294,7 @@ def test_set_then_change_auto_formats(tmpdir, nb_file):
 
     # Pair ipynb/py and save
     nb.metadata["jupytext"] = {"formats": "ipynb,auto:light"}
-    cm.save(model=dict(content=nb, type="notebook"), path="nb.ipynb")
+    cm.save(model=notebook_model(nb), path="nb.ipynb")
     assert "nb.py" in cm.paired_notebooks
     assert "nb.auto" not in cm.paired_notebooks
     assert os.path.isfile(tmp_py)
@@ -1306,7 +1303,7 @@ def test_set_then_change_auto_formats(tmpdir, nb_file):
     # Pair ipynb/Rmd and save
     time.sleep(0.5)
     nb.metadata["jupytext"] = {"formats": "ipynb,Rmd"}
-    cm.save(model=dict(content=nb, type="notebook"), path="nb.ipynb")
+    cm.save(model=notebook_model(nb), path="nb.ipynb")
     assert "nb.Rmd" in cm.paired_notebooks
     assert "nb.py" not in cm.paired_notebooks
     assert "nb.auto" not in cm.paired_notebooks
@@ -1317,7 +1314,7 @@ def test_set_then_change_auto_formats(tmpdir, nb_file):
     # Unpair and save
     time.sleep(0.5)
     del nb.metadata["jupytext"]
-    cm.save(model=dict(content=nb, type="notebook"), path="nb.ipynb")
+    cm.save(model=notebook_model(nb), path="nb.ipynb")
     assert "nb.Rmd" not in cm.paired_notebooks
     assert "nb.py" not in cm.paired_notebooks
     assert "nb.auto" not in cm.paired_notebooks
@@ -1343,7 +1340,7 @@ def test_share_py_recreate_ipynb(tmpdir, nb_file):
     cm.default_cell_metadata_filter = "-all"
 
     nb = read(nb_file)
-    model_ipynb = cm.save(model=dict(content=nb, type="notebook"), path="nb.ipynb")
+    model_ipynb = cm.save(model=notebook_model(nb), path="nb.ipynb")
 
     assert os.path.isfile(tmp_ipynb)
     assert os.path.isfile(tmp_py)
@@ -1383,7 +1380,7 @@ def test_vim_folding_markers(tmpdir):
             new_code_cell("a = 1\n\n\nb = 1"),
         ]
     )
-    cm.save(model=dict(content=nb, type="notebook"), path="nb.ipynb")
+    cm.save(model=notebook_model(nb), path="nb.ipynb")
 
     assert os.path.isfile(tmp_ipynb)
     assert os.path.isfile(tmp_py)
@@ -1439,7 +1436,7 @@ def test_vscode_pycharm_folding_markers(tmpdir):
             new_code_cell("a = 1\n\n\nb = 1"),
         ]
     )
-    cm.save(model=dict(content=nb, type="notebook"), path="nb.ipynb")
+    cm.save(model=notebook_model(nb), path="nb.ipynb")
 
     assert os.path.isfile(tmp_ipynb)
     assert os.path.isfile(tmp_py)
@@ -1495,7 +1492,7 @@ def test_open_file_with_default_cell_markers(tmpdir):
     nb = cm.get("nb.py")["content"]
     assert len(nb.cells) == 1
 
-    cm.save(model=dict(type="notebook", content=nb), path="nb.py")
+    cm.save(model=notebook_model(nb), path="nb.py")
 
     with open(tmp_py) as fp:
         text2 = fp.read()
@@ -1535,7 +1532,7 @@ def test_save_file_with_default_cell_markers(tmpdir):
 
     nb.metadata["jupytext"]["cell_markers"] = "+,-"
     del nb.metadata["jupytext"]["notebook_metadata_filter"]
-    cm.save(model=dict(type="notebook", content=nb), path="nb.py")
+    cm.save(model=notebook_model(nb), path="nb.py")
 
     with open(tmp_py) as fp:
         text2 = fp.read()
@@ -1635,9 +1632,7 @@ def test_multiple_pairing(tmpdir):
     cm = jupytext.TextFileContentsManager()
     cm.root_dir = str(tmpdir)
 
-    cm.save(
-        model=dict(type="notebook", content=nb("saved from cm")), path="notebook.ipynb"
-    )
+    cm.save(model=notebook_model(nb("saved from cm")), path="notebook.ipynb")
     compare_notebooks(jupytext.read(tmp_ipynb), nb("saved from cm"))
     compare_notebooks(jupytext.read(tmp_md), nb("saved from cm"))
     compare_notebooks(jupytext.read(tmp_py), nb("saved from cm"))
@@ -1690,7 +1685,7 @@ def test_filter_jupytext_version_information_416(nb_file, tmpdir):
     # load notebook
     notebook = jupytext.read(nb_file)
     notebook.metadata["jupytext_formats"] = "ipynb,py"
-    model = dict(type="notebook", content=notebook)
+    model = notebook_model(notebook)
 
     # save to ipynb and py
     cm.save(model=model, path="notebook.ipynb")
@@ -1727,7 +1722,7 @@ def test_nested_prefix(tmpdir):
         cells=[new_code_cell("1+1"), new_markdown_cell("Some text")],
         metadata={"jupytext": {"formats": "ipynb,nested/prefix//.py"}},
     )
-    cm.save(model=dict(type="notebook", content=nb), path="notebook.ipynb")
+    cm.save(model=notebook_model(nb), path="notebook.ipynb")
 
     assert tmpdir.join("nested").join("prefix").join("notebook.py").isfile()
 
@@ -1762,8 +1757,8 @@ def test_jupytext_jupyter_fs_metamanager(tmpdir):
     nb = new_notebook(
         cells=[new_markdown_cell("A markdown cell"), new_code_cell("1 + 1")]
     )
-    cm.save(dict(type="notebook", content=nb), osfs + ":notebook.ipynb")
-    cm.save(dict(type="notebook", content=nb), osfs + ":text_notebook.md")
+    cm.save(notebook_model(nb), osfs + ":notebook.ipynb")
+    cm.save(notebook_model(nb), osfs + ":text_notebook.md")
 
     # list the directory
     directory = cm.get(osfs + ":/")
@@ -1804,9 +1799,9 @@ def test_config_jupytext_jupyter_fs_meta_manager(tmpdir):
     # save a few files
     nb = new_notebook()
     cm.save(dict(type="file", content="text", format="text"), path=osfs + ":text.md")
-    cm.save(dict(type="notebook", content=nb), osfs + ":script.py")
-    cm.save(dict(type="notebook", content=nb), osfs + ":text_notebook.md")
-    cm.save(dict(type="notebook", content=nb), osfs + ":notebook.ipynb")
+    cm.save(notebook_model(nb), osfs + ":script.py")
+    cm.save(notebook_model(nb), osfs + ":text_notebook.md")
+    cm.save(notebook_model(nb), osfs + ":notebook.ipynb")
 
     # list the directory
     directory = cm.get(osfs + ":/")

--- a/tests/test_escape_magics.py
+++ b/tests/test_escape_magics.py
@@ -4,6 +4,7 @@ from jupytext.compare import compare
 from jupytext.magics import comment_magic, uncomment_magic, unesc, is_magic
 from jupytext.compare import compare_notebooks
 import jupytext
+from .utils import notebook_model
 
 
 def test_unesc():
@@ -144,12 +145,12 @@ def test_force_comment_using_contents_manager(tmpdir):
 
     nb = new_notebook(cells=[new_code_cell("%pylab inline")])
 
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_py)
+    cm.save(model=notebook_model(nb), path=tmp_py)
     with open(str(tmpdir.join(tmp_py))) as stream:
         assert "# %pylab inline" in stream.read().splitlines()
 
     cm.comment_magics = False
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_py)
+    cm.save(model=notebook_model(nb), path=tmp_py)
     with open(str(tmpdir.join(tmp_py))) as stream:
         assert "%pylab inline" in stream.read().splitlines()
 

--- a/tests/test_read_simple_percent.py
+++ b/tests/test_read_simple_percent.py
@@ -10,6 +10,7 @@ from nbformat.v4.nbbase import (
 )
 from jupytext.compare import compare, compare_notebooks
 import jupytext
+from .utils import notebook_model
 
 
 def test_read_simple_file(
@@ -352,7 +353,7 @@ def test_cell_markers_option_in_contents_manager(tmpdir):
             }
         },
     )
-    cm.save(model=dict(type="notebook", content=nb), path="notebook.ipynb")
+    cm.save(model=notebook_model(nb), path="notebook.ipynb")
 
     assert os.path.isfile(tmp_ipynb)
     assert os.path.isfile(tmp_py)
@@ -395,7 +396,7 @@ def test_default_cell_markers_in_contents_manager(tmpdir):
             }
         },
     )
-    cm.save(model=dict(type="notebook", content=nb), path="notebook.ipynb")
+    cm.save(model=notebook_model(nb), path="notebook.ipynb")
 
     assert os.path.isfile(tmp_ipynb)
     assert os.path.isfile(tmp_py)
@@ -436,7 +437,7 @@ def test_default_cell_markers_in_contents_manager_does_not_impact_light_format(t
         },
     )
     with pytest.warns(UserWarning, match="Ignored cell markers"):
-        cm.save(model=dict(type="notebook", content=nb), path="notebook.ipynb")
+        cm.save(model=notebook_model(nb), path="notebook.ipynb")
 
     assert os.path.isfile(tmp_ipynb)
     assert os.path.isfile(tmp_py)

--- a/tests/test_save_multiple.py
+++ b/tests/test_save_multiple.py
@@ -6,7 +6,7 @@ from tornado.web import HTTPError
 import jupytext
 from jupytext.contentsmanager import TextFileContentsManager
 from jupytext.compare import compare_notebooks
-from .utils import list_notebooks
+from .utils import list_notebooks, notebook_model
 
 
 @pytest.mark.parametrize("nb_file", list_notebooks(skip="66"))
@@ -20,7 +20,7 @@ def test_rmd_is_ok(nb_file, tmpdir):
     cm = TextFileContentsManager()
     cm.root_dir = str(tmpdir)
 
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_ipynb)
+    cm.save(model=notebook_model(nb), path=tmp_ipynb)
 
     nb2 = jupytext.read(str(tmpdir.join(tmp_rmd)))
 
@@ -37,7 +37,7 @@ def test_ipynb_is_ok(nb_file, tmpdir):
     cm.root_dir = str(tmpdir)
     cm.default_jupytext_formats = "ipynb,Rmd"
 
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_rmd)
+    cm.save(model=notebook_model(nb), path=tmp_rmd)
 
     nb2 = jupytext.read(str(tmpdir.join(tmp_ipynb)))
     compare_notebooks(nb2, nb)
@@ -54,7 +54,7 @@ def test_all_files_created(nb_file, tmpdir):
     cm = TextFileContentsManager()
     cm.root_dir = str(tmpdir)
 
-    cm.save(model=dict(type="notebook", content=nb), path=tmp_ipynb)
+    cm.save(model=notebook_model(nb), path=tmp_ipynb)
 
     nb2 = jupytext.read(str(tmpdir.join(tmp_py)))
     compare_notebooks(nb2, nb)
@@ -73,7 +73,7 @@ def test_no_files_created_on_no_format(tmpdir):
     cm.default_jupytext_formats = ""
 
     cm.save(
-        model=dict(type="notebook", content=new_notebook(nbformat=4, metadata=dict())),
+        model=notebook_model(new_notebook(nbformat=4, metadata=dict())),
         path=tmp_ipynb,
     )
 
@@ -121,8 +121,6 @@ def test_no_rmd_on_not_v4(tmpdir):
     cm.default_jupytext_formats = "ipynb,Rmd"
 
     with pytest.raises(NotebookValidationError):
-        cm.save(
-            model=dict(type="notebook", content=new_notebook(nbformat=3)), path=tmp_rmd
-        )
+        cm.save(model=notebook_model(new_notebook(nbformat=3)), path=tmp_rmd)
 
     assert not os.path.isfile(str(tmpdir.join(tmp_ipynb)))

--- a/tests/test_trust_notebook.py
+++ b/tests/test_trust_notebook.py
@@ -115,3 +115,31 @@ def test_ipynb_notebooks_can_be_trusted_even_with_metadata_filter(
         assert cell.metadata.get("trusted", True)
 
     compare_notebooks(nb2["content"], model["content"])
+
+
+@pytest.mark.parametrize("nb_file", list_notebooks("percent", skip="hash sign"))
+def test_text_notebooks_can_be_trusted(nb_file, tmpdir, no_jupytext_version_number):
+    cm = TextFileContentsManager()
+    root, file = os.path.split(nb_file)
+    py_file = str(tmpdir.join(file))
+    shutil.copy(nb_file, py_file)
+
+    cm.root_dir = str(tmpdir)
+    model = cm.get(file)
+    model["type"] == "notebook"
+    cm.save(model, file)
+
+    # Unsign notebook
+    nb = model["content"]
+    for cell in nb.cells:
+        if "trusted" in cell.metadata:
+            cell.metadata.pop("trusted")
+
+    cm.notary.unsign(nb)
+
+    # Trust and reload
+    cm.trust_notebook(file)
+
+    model = cm.get(file)
+    for cell in model["content"].cells:
+        assert cell.metadata.get("trusted", True)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import re
+import json
 import pytest
 from jupytext.cli import system
 from jupytext.cell_reader import rst2md
@@ -107,3 +108,8 @@ def list_notebooks(path="ipynb", skip="World"):
 
     # ignore ".ipynb_checkpoints" sub-folder
     return [nb_file for nb_file in notebooks if os.path.isfile(nb_file)]
+
+
+def notebook_model(nb):
+    """Return a notebook model, with content a dictionary rather than a notebook object"""
+    return dict(type="notebook", content=json.loads(json.dumps(nb)))


### PR DESCRIPTION
With this PR we stop using `mock` to replace the `nbformat.reads` and `writes` functions with Jupytext's ones. Instead we use the parent contents manager to load/write the text files and parse them with Jupytext.

As a side effect, we don't use any more private methods from the `FileContentsManager` or `LargeFileManager`, and Jupytext can work on top of other contents managers like Jupyter-FS.

This is a follow-up on #621 and will hopefully close #618