### PR TITLE
Fixes #634 bug: no `metadata` attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-.idea
-.vscode
 .build
 .cache
 .coverage
@@ -18,3 +16,13 @@ docs/_build
 
 # Will be created by postBuild
 demo/get_started.ipynb
+
+# jetbrains ide stuff
+*.iml
+.idea/
+
+# vscode ide stuff
+*.code-workspace
+.history
+.vscode/*
+!.vscode/*.template

--- a/jupytext/contentsmanager.py
+++ b/jupytext/contentsmanager.py
@@ -155,7 +155,9 @@ def build_jupytext_contents_manager_class(base_contents_manager_class):
                     text_model = dict(
                         type="file",
                         format="text",
-                        content=jupytext.writes(model["content"], fmt=fmt),
+                        content=jupytext.writes(
+                            nbformat.from_dict(model["content"]), fmt=fmt
+                        ),
                     )
 
                     return self.super.save(text_model, path)
@@ -163,8 +165,12 @@ def build_jupytext_contents_manager_class(base_contents_manager_class):
                 return write_pair(path, jupytext_formats, save_one_file)
 
             except Exception as e:
-                self.log.error(u'Error while saving file: %s %s', path, e, exc_info=True)
-                raise HTTPError(500, u'Unexpected error while saving file: %s %s' % (path, e))
+                self.log.error(
+                    u"Error while saving file: %s %s", path, e, exc_info=True
+                )
+                raise HTTPError(
+                    500, u"Unexpected error while saving file: %s %s" % (path, e)
+                )
 
         def get(
             self,

--- a/jupytext/contentsmanager.py
+++ b/jupytext/contentsmanager.py
@@ -162,8 +162,9 @@ def build_jupytext_contents_manager_class(base_contents_manager_class):
 
                 return write_pair(path, jupytext_formats, save_one_file)
 
-            except Exception as err:
-                raise HTTPError(400, str(err))
+            except Exception as e:
+                self.log.error(u'Error while saving file: %s %s', path, e, exc_info=True)
+                raise HTTPError(500, u'Unexpected error while saving file: %s %s' % (path, e))
 
         def get(
             self,


### PR DESCRIPTION
Fixes the bug mentioned in https://github.com/mwouts/jupytext/pull/634#issuecomment-699834971. Previously, the monkey patch here:

https://github.com/mwouts/jupytext/blob/aea84d9850fe24a71fe871064ffb0646f5a44eb4/jupytext/contentsmanager.py#L172-L173

called the parent `save` method, which would [then call `nbformat.from_dict`](https://github.com/jupyter/notebook/blob/09ba565c96619d2150448bb0f4392004decc1014/notebook/services/contents/filemanager.py#L473-L479):

```python
            if model['type'] == 'notebook':
                nb = nbformat.from_dict(model['content'])
                self.check_and_sign(nb, path)
                self._save_notebook(os_path, nb)
                # One checkpoint should always exist for notebooks.
                if not self.checkpoints.list_checkpoints(path):
                    self.create_checkpoint(path)
```

before eventually calling `jupytext.writes` (via the patched `nbformat.writes`) as part of the `_save_notebook` call.

In the current code, `jupytext.writes` (which expects a `NotebookNode`, not just a notebook dict) is called before the parent save method:

https://github.com/mwouts/jupytext/blob/af2b15b2879948c2054c616d7835cca73e11291b/jupytext/contentsmanager.py#L155-L161

so we need to explicitly add a conversion from dict to `NotebookNode` somewhere.

@mwouts Not sure if I put the `nbformat.from_dict` call in the ideal spot (I assume you know more about this than I do), but it does seem to fix the problem.