### PR TITLE
Jupytext tests work on non-English locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 **Fixed**
 - Optional dependency on `sphinx-gallery` frozen to version `~=0.7.0` (#614)
 - Codecov/patch reports should be OK now (#639)
+- Jupytext tests work on non-English locales (#636)
 
 
 1.6.0 (2020-09-01)

--- a/tests/test_contentsmanager.py
+++ b/tests/test_contentsmanager.py
@@ -1706,11 +1706,17 @@ def test_new_untitled(tmpdir):
     cm = jupytext.TextFileContentsManager()
     cm.root_dir = str(tmpdir)
 
-    assert cm.new_untitled(type="notebook")["path"] == "Untitled.ipynb"
-    assert cm.new_untitled(type="notebook", ext=".md")["path"] == "Untitled1.md"
-    assert cm.new_untitled(type="notebook", ext=".py")["path"] == "Untitled2.py"
-    assert cm.new_untitled(type="notebook")["path"] == "Untitled3.ipynb"
-    assert cm.new_untitled(type="notebook", ext=".py:percent")["path"] == "Untitled4.py"
+    # untitled is "Untitled" only when the locale is English #636
+    untitled, ext = cm.new_untitled(type="notebook")["path"].split(".")
+    assert untitled
+    assert ext == "ipynb"
+
+    assert cm.new_untitled(type="notebook", ext=".md")["path"] == untitled + "1.md"
+    assert cm.new_untitled(type="notebook", ext=".py")["path"] == untitled + "2.py"
+    assert cm.new_untitled(type="notebook")["path"] == untitled + "3.ipynb"
+    assert (
+        cm.new_untitled(type="notebook", ext=".py:percent")["path"] == untitled + "4.py"
+    )
 
 
 def test_nested_prefix(tmpdir):


### PR DESCRIPTION
Closes #636 