### PR TITLE
DOC: fix writes function docstring

### DIFF
--- a/jupytext/jupytext.py
+++ b/jupytext/jupytext.py
@@ -407,7 +407,7 @@ def read(fp, as_version=nbformat.NO_CONVERT, fmt=None, **kwargs):
 
 
 def writes(notebook, fmt, version=nbformat.NO_CONVERT, **kwargs):
-    """Write a notebook to a file name or a file object
+    """Return text representation of the notebook
 
     :param notebook: the notebook
     :param fmt: the jupytext format like `md`, `py:percent`, ...


### PR DESCRIPTION
writes returns a string, and does not operate on a file object.

Can't say this enough - but I use this module so much that it's difficult to
imagine life without it.  Thanks again for all your work.