### PR TITLE
Filter out the execution cell metadata by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,13 @@
 - The GitHub actions run on both push events and pull requests, and duplicate jobs are skipped (#605)
 - Jupytext has a `tox.ini` file, thanks to Chris Sewell (#605)
 - Jupytext is tested against Python 3.9
+- The `execution` cell metadata is now filtered by default (#656)
 
 **Fixed**
 - Optional dependency on `sphinx-gallery` frozen to version `~=0.7.0` (#614)
 - Codecov/patch reports should be OK now (#639)
 - Jupytext tests work on non-English locales (#636)
+- Cell metadata that are already present in text notebook can be filtered out using a config file (#656)
 
 
 1.6.0 (2020-09-01)

--- a/environment-ci.yml
+++ b/environment-ci.yml
@@ -16,6 +16,6 @@ dependencies:
   - pytest-cov
   - coverage
   - flake8
-  - pandoc>=2.9
+  - pandoc>=2.11
   # pathlib is required on Python 2
   - pathlib

--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,7 @@ dependencies:
   - pip
   - setuptools
   - twine
-  - pandoc>=2.9
+  - pandoc>=2.11
   # make html in docs folder
   - sphinx
   - tox-conda

--- a/jupytext/cell_metadata.py
+++ b/jupytext/cell_metadata.py
@@ -56,6 +56,7 @@ _IGNORE_CELL_METADATA = ",".join(
         "collapsed",
         "scrolled",
         "trusted",
+        "execution",
         "ExecuteTime",
     ]
     + _JUPYTEXT_CELL_METADATA

--- a/jupytext/metadata_filter.py
+++ b/jupytext/metadata_filter.py
@@ -81,7 +81,15 @@ def metadata_filter_as_string(metadata_filter):
 def update_metadata_filters(metadata, jupyter_md, cell_metadata):
     """Update or set the notebook and cell metadata filters"""
 
-    if "cell_metadata_filter" in metadata.get("jupytext", {}):
+    if not jupyter_md:
+        # Set a metadata filter equal to the current metadata in script
+        metadata.setdefault("jupytext", {})["notebook_metadata_filter"] = "-all"
+        metadata["jupytext"].setdefault(
+            "cell_metadata_filter",
+            metadata_filter_as_string({"additional": cell_metadata, "excluded": "all"}),
+        )
+    elif "cell_metadata_filter" in metadata.get("jupytext", {}):
+        # Update the existing metadata filter
         metadata_filter = metadata_filter_as_dict(
             metadata.get("jupytext", {})["cell_metadata_filter"]
         )
@@ -97,14 +105,6 @@ def update_metadata_filters(metadata, jupyter_md, cell_metadata):
         metadata.setdefault("jupytext", {})[
             "cell_metadata_filter"
         ] = metadata_filter_as_string(metadata_filter)
-
-    if not jupyter_md:
-        # Set a metadata filter equal to the current metadata in script
-        cell_metadata = {"additional": cell_metadata, "excluded": "all"}
-        metadata.setdefault("jupytext", {})["notebook_metadata_filter"] = "-all"
-        metadata.setdefault("jupytext", {})[
-            "cell_metadata_filter"
-        ] = metadata_filter_as_string(cell_metadata)
     else:
         # Update the notebook metadata filter to include existing entries 376
         nb_md_filter = (

--- a/tests/notebooks/mirror/ipynb_to_pandoc/julia_benchmark_plotly_barchart.md
+++ b/tests/notebooks/mirror/ipynb_to_pandoc/julia_benchmark_plotly_barchart.md
@@ -3,7 +3,7 @@ jupyter:
   kernelspec:
     display_name: Julia 1.1.1
     language: julia
-    name: 'julia-1.1'
+    name: julia-1.1
   nbformat: 4
   nbformat_minor: 1
 ---

--- a/tests/test_metadata_filter.py
+++ b/tests/test_metadata_filter.py
@@ -1,5 +1,5 @@
 import pytest
-from nbformat.v4.nbbase import new_notebook
+from nbformat.v4.nbbase import new_notebook, new_code_cell
 from jupytext import reads, writes
 from jupytext.metadata_filter import filter_metadata, metadata_filter_as_dict
 
@@ -120,3 +120,25 @@ def test_filter_nested_metadata():
 
     # That one is not supported yet
     # assert filter_metadata(metadata, 'I.1.a', '-I') == {'I': {'1': {'a': 1}}}
+
+
+def test_filter_out_execution_metadata():
+    nb = new_notebook(
+        cells=[
+            new_code_cell(
+                "1 + 1",
+                metadata={
+                    "execution": {
+                        "iopub.execute_input": "2020-10-12T19:13:45.306603Z",
+                        "iopub.status.busy": "2020-10-12T19:13:45.306233Z",
+                        "iopub.status.idle": "2020-10-12T19:13:45.316103Z",
+                        "shell.execute_reply": "2020-10-12T19:13:45.315429Z",
+                        "shell.execute_reply.started": "2020-10-12T19:13:45.306577Z",
+                    }
+                },
+            )
+        ]
+    )
+
+    text = writes(nb, fmt="py:percent")
+    assert "execution" not in text


### PR DESCRIPTION
And fix the issue documented at #656 - the global configuration was uneffective on cell metadata present in the text file.