### PR TITLE
The --set-kernel - command fails when no Python kernel matches the current Python executable

### DIFF
--- a/.github/workflows/continuous-integration-pip.yml
+++ b/.github/workflows/continuous-integration-pip.yml
@@ -52,6 +52,8 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --statistics
       - name: Install from source (required for the pre-commit tests)
         run: pip install .
+      - name: Install a Jupyter Kernel
+        run: python -m ipykernel install --name python_kernel --user
       - name: Test with pytest
         run: pytest --cov=./ --cov-report=xml
       - name: Upload coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@
 
 **Changed**
 - Jupytext's contents manager uses the parent CM's `get` and `save` methods to read and save text files, and explicitly calls `jupytext.reads` and `jupytext.writes` to do the conversion. We don't use `mock` nor internal parent methods any more. Thanks to Max Klein for helping making this work! (#634, #635)
-- Thanks to the above, Jupytext can work on top of contents manager that don't derive from `FileContentsManager`, and in particular with `jupyterfs` (#618)
+- Thanks to the above, Jupytext can work on top of contents manager that don't derive from `FileContentsManager`, and in particular it works with `jupyterfs` (#618)
 - The documentation was reorganized. `README.md` was simplified and now includes many links to the documentation.
 - The documentation now uses `myst_parser` rather than `recommonmark`. And we use `conda` on RTD (#650, #652)
 - The `readf` and `writef` functions were dropped (they had been deprecated in favor of `read` and `write` in June 2019, v1.2.0)
 - The description & dependencies of the JupyterLab extension were updated (#654)
+- The `--set-kernel -` command, on a Python notebook, gives an explicit error when no kernel is not found that matches the current Python executable.
 
 **Added**
 - Configuration errors are reported in the console and/or in Jupyter (#613)

--- a/jupytext/cli.py
+++ b/jupytext/cli.py
@@ -499,9 +499,6 @@ def jupytext_single_file(nb_file, args, log):
                 )
 
             kernelspec = kernelspec_from_language(language)
-
-            if not kernelspec:
-                raise ValueError("Found no kernel for {}".format(language))
         else:
             try:
                 kernelspec = get_kernel_spec(set_kernel)

--- a/jupytext/kernels.py
+++ b/jupytext/kernels.py
@@ -17,52 +17,45 @@ def set_kernelspec_from_language(notebook):
     """Set the kernel specification based on the 'main_language' metadata"""
     language = notebook.metadata.get("jupytext", {}).get("main_language")
     if "kernelspec" not in notebook.metadata and language:
-        kernelspec = kernelspec_from_language(language)
-        if kernelspec:
-            notebook.metadata["kernelspec"] = kernelspec
-            notebook.metadata.get("jupytext", {}).pop("main_language")
+        try:
+            kernelspec = kernelspec_from_language(language)
+        except ValueError:
+            return
+        notebook.metadata["kernelspec"] = kernelspec
+        notebook.metadata.get("jupytext", {}).pop("main_language")
 
 
 def kernelspec_from_language(language):
     """Return the python kernel that matches the current env, or the first kernel that matches the given language"""
-    try:
-        if language == "python":
-            # Return the kernel that matches the current Python executable
-            for name in find_kernel_specs():
-                kernel_specs = get_kernel_spec(name)
-                cmd = kernel_specs.argv[0]
-                if (
-                    kernel_specs.language == "python"
-                    and os.path.isfile(cmd)
-                    and os.path.samefile(cmd, sys.executable)
-                ):
-                    return {
-                        "name": name,
-                        "language": language,
-                        "display_name": kernel_specs.display_name,
-                    }
-
-            # If none was found, return the first kernel that has 'python' as argv[0]
-            for name in find_kernel_specs():
-                kernel_specs = get_kernel_spec(name)
-                if (
-                    kernel_specs.language == "python"
-                    and kernel_specs.argv[0] == "python"
-                ):
-                    return {
-                        "name": name,
-                        "language": language,
-                        "display_name": kernel_specs.display_name,
-                    }
-
+    if language == "python":
+        # Return the kernel that matches the current Python executable
         for name in find_kernel_specs():
             kernel_specs = get_kernel_spec(name)
-            if same_language(kernel_specs.language, language):
+            cmd = kernel_specs.argv[0]
+            if (
+                kernel_specs.language == "python"
+                and os.path.isfile(cmd)
+                and os.path.samefile(cmd, sys.executable)
+            ):
                 return {
                     "name": name,
                     "language": language,
                     "display_name": kernel_specs.display_name,
                 }
-    except (KeyError, ValueError):
-        pass
-    return None
+        raise ValueError(
+            "No kernel found that matches the current python executable {}\n".format(
+                sys.executable
+            )
+            + "Install one with 'python -m ipykernel install --name kernel_name [--user]'"
+        )
+
+    for name in find_kernel_specs():
+        kernel_specs = get_kernel_spec(name)
+        if same_language(kernel_specs.language, language):
+            return {
+                "name": name,
+                "language": language,
+                "display_name": kernel_specs.display_name,
+            }
+
+    raise ValueError("No kernel found for the language {}".format(language))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,7 +6,7 @@ import pytest
 from jupytext.cli import system
 from jupytext.cell_reader import rst2md
 from jupytext.pandoc import is_pandoc_available
-from jupytext.kernels import kernelspec_from_language
+from jupyter_client.kernelspec import find_kernel_specs, get_kernel_spec
 from jupytext.myst import is_myst_available
 
 skip_if_dict_is_not_ordered = pytest.mark.skipif(
@@ -61,7 +61,8 @@ requires_no_pandoc = pytest.mark.skipif(
     is_pandoc_available(), reason="Pandoc is installed"
 )
 requires_ir_kernel = pytest.mark.skipif(
-    kernelspec_from_language("R") is None, reason="irkernel is not installed"
+    not any(get_kernel_spec(name).language == "R" for name in find_kernel_specs()),
+    reason="irkernel is not installed",
 )
 requires_myst = pytest.mark.skipif(
     not is_myst_available(), reason="myst_parser not found"


### PR DESCRIPTION
The `--set-kernel -` command, on a Python notebook, now gives an explicit error when no kernel is not found that matches the current Python executable (instead of using the default Python kernel as was the case previously).