### PR TITLE
Revisit the function combine_inputs_with_outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-1.7.0-rc0 (2020-10-05)
+1.7.0-rc1 (2020-11-09)
 ----------------------
 
 **Changed**
@@ -23,6 +23,7 @@
 - Codecov/patch reports should be OK now (#639)
 - Jupytext tests work on non-English locales (#636)
 - Cell metadata that are already present in text notebook can be filtered out using a config file (#656)
+- Optional cell attributes like attachments are preserved (#671)
 
 
 1.6.0 (2020-09-01)

--- a/jupytext/cli.py
+++ b/jupytext/cli.py
@@ -663,7 +663,7 @@ def jupytext_single_file(nb_file, args, log):
                 raise ValueError("--update is only for ipynb files")
             action = " (destination file updated)"
             check_file_version(notebook, nb_file, nb_dest)
-            combine_inputs_with_outputs(notebook, read(nb_dest), fmt=fmt)
+            notebook = combine_inputs_with_outputs(notebook, read(nb_dest), fmt=fmt)
         elif os.path.isfile(nb_dest):
             action = " (destination file replaced)"
         else:
@@ -909,7 +909,7 @@ def pipe_notebook(notebook, command, fmt="py:percent", update=True, prefix=None)
         piped_notebook = reads(cmd_output.decode("utf-8"), fmt)
 
     if fmt["extension"] != ".ipynb":
-        combine_inputs_with_outputs(piped_notebook, notebook, fmt)
+        piped_notebook = combine_inputs_with_outputs(piped_notebook, notebook, fmt)
 
     # Remove jupytext / text_representation entry
     piped_notebook.metadata.pop("jupytext")

--- a/jupytext/compare.py
+++ b/jupytext/compare.py
@@ -334,7 +334,7 @@ def test_round_trip_conversion(
     round_trip = reads(text, fmt)
 
     if update:
-        combine_inputs_with_outputs(round_trip, notebook, fmt)
+        round_trip = combine_inputs_with_outputs(round_trip, notebook, fmt)
 
     compare_notebooks(
         round_trip,

--- a/jupytext/pairs.py
+++ b/jupytext/pairs.py
@@ -114,6 +114,6 @@ def read_pair(inputs, outputs, read_one_file):
     check_file_version(notebook, inputs.path, outputs.path)
 
     outputs = read_one_file(outputs.path, outputs.fmt)
-    combine_inputs_with_outputs(notebook, outputs, fmt=inputs.fmt)
+    notebook = combine_inputs_with_outputs(notebook, outputs, fmt=inputs.fmt)
 
     return notebook

--- a/jupytext/version.py
+++ b/jupytext/version.py
@@ -1,3 +1,3 @@
 """Jupytext's version number"""
 
-__version__ = "1.7.0-rc0"
+__version__ = "1.7.0-rc1"

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -94,7 +94,7 @@ def assert_conversion_same_as_mirror(nb_file, fmt, mirror_name, compare_notebook
 
         compare_notebooks(nb_mirror, notebook, fmt)
 
-        combine_inputs_with_outputs(nb_mirror, notebook)
+        nb_mirror = combine_inputs_with_outputs(nb_mirror, notebook)
         compare_notebooks(nb_mirror, notebook, fmt, compare_outputs=True)
 
 

--- a/tests/test_read_simple_markdown.py
+++ b/tests/test_read_simple_markdown.py
@@ -482,7 +482,7 @@ a raw cell
     for cell in nb_meta.cells:
         cell.metadata = {"key": "value"}
 
-    combine_inputs_with_outputs(nb_source, nb_meta)
+    nb_source = combine_inputs_with_outputs(nb_source, nb_meta)
     for cell in nb_source.cells:
         assert cell.metadata == {"key": "value"}, cell.source
 

--- a/tests/test_read_simple_nomarker.py
+++ b/tests/test_read_simple_nomarker.py
@@ -34,7 +34,7 @@ def h(x):
 
     text = writes(nb1, "py:nomarker")
     nb2 = reads(text, "py:nomarker")
-    combine_inputs_with_outputs(nb2, nb1, "py:nomarker")
+    nb2 = combine_inputs_with_outputs(nb2, nb1, "py:nomarker")
     nb2.metadata.pop("jupytext")
 
     assert len(nb2.cells) == 7
@@ -47,7 +47,7 @@ def h(x):
     with pytest.warns(DeprecationWarning, match="nomarker"):
         nb3 = reads(text, "py:bare")
     with pytest.warns(DeprecationWarning, match="nomarker"):
-        combine_inputs_with_outputs(nb3, nb2, "py:bare")
+        nb3 = combine_inputs_with_outputs(nb3, nb2, "py:bare")
     nb3.metadata.pop("jupytext")
 
     compare(nb3, nb2)


### PR DESCRIPTION
- it now returns the combined notebook (rather than modifying in place the source notebook)
- the output cell is used as the basis for the new cell, in order to preserve additional attributes like 'attachments'

Closes #671 