### PR TITLE
Remove dependencies on the Publish step

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -186,7 +186,6 @@ jobs:
 
   publish:
     name: Publish to PyPi
-    needs: [pre-commit, analyse, test-pip, test-conda]
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
(because they are skipped by skip-duplicate when a tag is added)