### PR TITLE
Text notebooks have the same format and mimetype as ipynb notebooks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,13 @@
 Jupytext ChangeLog
 ==================
 
+1.7.1 (2020-11-16)
+------------------
+
+**Fixed**
+- Text notebooks have the same format and mimetype as ipynb notebooks. This fixes the _File Load Error - content.indexOf is not a function_ error on text notebooks ([#659](https://github.com/mwouts/jupytext/issues/659))
+
+
 1.7.0 (2020-11-14)
 ------------------
 

--- a/jupytext/contentsmanager.py
+++ b/jupytext/contentsmanager.py
@@ -201,6 +201,10 @@ def build_jupytext_contents_manager_class(base_contents_manager_class):
                 model["type"] = "notebook"
                 config.set_default_format_options(fmt, read=True)
                 if content:
+                    # We may need to update these keys, inherited from text files formats
+                    # Cf. https://github.com/mwouts/jupytext/issues/659
+                    model["format"] = "json"
+                    model["mimetype"] = None
                     try:
                         model["content"] = jupytext.reads(model["content"], fmt=fmt)
                     except Exception as err:

--- a/jupytext/version.py
+++ b/jupytext/version.py
@@ -1,3 +1,3 @@
 """Jupytext's version number"""
 
-__version__ = "1.7.0"
+__version__ = "1.7.1"

--- a/tests/test_contentsmanager.py
+++ b/tests/test_contentsmanager.py
@@ -303,6 +303,32 @@ def test_load_save_py_freeze_metadata(script, tmpdir):
     compare(text_py2, text_py)
 
 
+def test_load_text_notebook(tmpdir):
+    cm = jupytext.TextFileContentsManager()
+    cm.root_dir = str(tmpdir)
+
+    nbpy = "text.py"
+    with open(str(tmpdir.join(nbpy)), "w") as fp:
+        fp.write("# %%\n1 + 1\n")
+
+    py_model = cm.get(nbpy, content=False)
+    assert py_model["type"] == "notebook"
+    assert py_model["content"] is None
+
+    py_model = cm.get(nbpy, content=True)
+    assert py_model["type"] == "notebook"
+    assert "cells" in py_model["content"]
+
+    # The model returned by the CM should match that of a classical ipynb notebook
+    nb_model = dict(
+        type="notebook", content=new_notebook(cells=[new_markdown_cell("A cell")])
+    )
+    cm.save(nb_model, "notebook.ipynb")
+    nb_model = cm.get("notebook.ipynb", content=True)
+    for key in ["format", "mimetype", "type"]:
+        assert nb_model[key] == py_model[key], key
+
+
 @skip_if_dict_is_not_ordered
 @pytest.mark.parametrize("nb_file", list_notebooks("ipynb_py"))
 def test_load_save_rename_notebook_with_dot(nb_file, tmpdir):


### PR DESCRIPTION
This fixes #659 