### PR TITLE
The dependency on `markdown-it-py` is conditional on `python>=3.6`

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2020 Marc Wouts
+Copyright (c) 2018-2021 Marc Wouts
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,12 +1,19 @@
 Jupytext ChangeLog
 ==================
 
+1.8.1 (2021-01-03)
+------------------
+
+**Changed**
+- The dependency on `markdown-it-py` is conditional on `python>=3.6` ([#697](https://github.com/mwouts/jupytext/issues/697))
+
+
 1.8.0 (2020-12-22)
 ------------------
 
 **Changed**
 - Removed support for Python 2.7 and 3.5, a preliminary step towards a JupyterLab 3.0-compatible extension ([#683](https://github.com/mwouts/jupytext/issues/683))
-- The MyST Markdown format uses markdown-it-py~=0.6.0 ([#692](https://github.com/mwouts/jupytext/issues/692))
+- The MyST Markdown format uses `markdown-it-py~=0.6.0` ([#692](https://github.com/mwouts/jupytext/issues/692))
 
 
 1.7.1 (2020-11-16)

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - jupyterlab
   - pyyaml
   - toml
+  - markdown-it-py~=0.6.0
   - nbconvert
   - ipykernel
   - jupyter_contrib_nbextensions
@@ -32,4 +33,3 @@ dependencies:
   - tox-conda
   - pip:
     - sphinx_copybutton
-    - myst_parser

--- a/jupytext/version.py
+++ b/jupytext/version.py
@@ -1,3 +1,3 @@
 """Jupytext's version number"""
 
-__version__ = "1.8.0"
+__version__ = "1.8.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-markdown-it-py~=0.6.0
+#markdown-it-py~=0.6.0
 nbformat>=4.0.0
 pyyaml
 toml

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,12 @@ setup(
     ],
     entry_points={"console_scripts": ["jupytext = jupytext.cli:jupytext"]},
     tests_require=["pytest"],
-    install_requires=["markdown-it-py~=0.6.0", "nbformat>=4.0.0", "pyyaml", "toml"],
+    install_requires=[
+        "markdown-it-py~=0.6.0; python_version >= '3.6'",
+        "nbformat>=4.0.0",
+        "pyyaml",
+        "toml",
+    ],
     extras_require={
         # left for back-compatibility
         "myst": [],


### PR DESCRIPTION
The plan is to deliver a version of Jupytext (version 1.8.1) that will be identified by pypi.org as the last version compatible with Python 2.7 and 3.5, see #697 