### PR TITLE
Jupytext 1.8.2 depends on `python>=3.6`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,13 @@
 Jupytext ChangeLog
 ==================
 
+1.8.2 (2021-01-04)
+------------------
+
+**Changed**
+- Jupytext 1.8.2 depends on `python>=3.6`. The last version of Jupytext explicitly tested with Python 2.7 and 3.5 was Jupytext 1.7.1, cf. [#697](https://github.com/mwouts/jupytext/issues/697).
+
+
 1.8.1 (2021-01-03)
 ------------------
 

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - defaults
   - conda-forge
 dependencies:
-  - python
+  - python>=3.6
   - jupyter
   - jupyterlab
   - pyyaml

--- a/jupytext/version.py
+++ b/jupytext/version.py
@@ -1,3 +1,3 @@
 """Jupytext's version number"""
 
-__version__ = "1.8.1"
+__version__ = "1.8.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-#markdown-it-py~=0.6.0
 nbformat>=4.0.0
 pyyaml
 toml
+markdown-it-py~=0.6.0

--- a/setup.py
+++ b/setup.py
@@ -58,12 +58,8 @@ setup(
     ],
     entry_points={"console_scripts": ["jupytext = jupytext.cli:jupytext"]},
     tests_require=["pytest"],
-    install_requires=[
-        "markdown-it-py~=0.6.0; python_version >= '3.6'",
-        "nbformat>=4.0.0",
-        "pyyaml",
-        "toml",
-    ],
+    install_requires=["nbformat>=4.0.0", "pyyaml", "toml", "markdown-it-py~=0.6.0"],
+    python_requires="~=3.6",
     extras_require={
         # left for back-compatibility
         "myst": [],


### PR DESCRIPTION
Add an explicit dependency to fix #697 