### PR TITLE
Use BUILD_JUPYTERLAB_EXTENSION in the PyPi-publish step

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -214,7 +214,7 @@ jobs:
       - name: Build package
         run: |
           pip install wheel jupyter-packaging jupyterlab>=3
-          python setup.py sdist bdist_wheel
+          BUILD_JUPYTERLAB_EXTENSION=1 python setup.py sdist bdist_wheel
       - name: Publish
         uses: pypa/gh-action-pypi-publish@v1.1.0
         with:

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup_args = dict(
     ],
 )
 
-build_labextension = environ.get("BUILD_JUPYTERLAB_EXTENSION") or environ.get("CI")
+build_labextension = environ.get("BUILD_JUPYTERLAB_EXTENSION")
 if build_labextension in ["0", "False", "false", "No", "no", "N", "n"]:
     build_labextension = False
 


### PR DESCRIPTION
Follow-up on #706 - with this we gain a few minutes on the CI (13 min instead of 17 min)