### PR TITLE
At the moment Jupytext requires nbformat<=5.0.8

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -191,7 +191,7 @@ jobs:
           run: |
             python -m pip install --upgrade pip
             # All dependencies but markdown-it-py
-            pip install nbformat pyyaml toml
+            pip install 'nbformat<=5.0.8' pyyaml toml
             pip install -r requirements-dev.txt
         - name: Install a Jupyter Kernel
           run: python -m ipykernel install --name python_kernel --user

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,13 @@
 Jupytext ChangeLog
 ==================
 
+1.9.2-dev (???)
+---------------
+
+**Changed**
+- Jupytext does not work properly with the new cell ids of the version 4.5 of `nbformat>=5.1.0` yet, so we added the requirement `nbformat<=5.0.8` (#715)
+
+
 1.9.1 (2021-01-06)
 ------------------
 

--- a/environment-ci.yml
+++ b/environment-ci.yml
@@ -9,6 +9,7 @@ dependencies:
   - jupyter
   - ipykernel
   - nbconvert
+  - nbformat<=5.0.8
   - pyyaml
   - toml
   - pip

--- a/environment.yml
+++ b/environment.yml
@@ -4,8 +4,8 @@ channels:
   - conda-forge
 dependencies:
   - python>=3.6
-  - jupyter
   - jupyterlab>=3.0
+  - nbformat<=5.0.8
   - jupyter-packaging
   - pyyaml
   - toml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-nbformat>=4.0.0
+nbformat>=4.0.0,<=5.0.8
 pyyaml
 toml
 markdown-it-py~=0.6.0


### PR DESCRIPTION
Jupytext does not work well with the new cell ids yet - see #715 