### PR TITLE
Python magic commands may be indented

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,9 @@ Jupytext ChangeLog
 **Changed**
 - Jupytext does not work properly with the new cell ids of the version 4.5 of `nbformat>=5.1.0` yet, so we added the requirement `nbformat<=5.0.8` (#715)
 
+**Fixed**
+- Indented magic commands are supported (#694)
+
 
 1.9.1 (2021-01-06)
 ------------------

--- a/jupytext/magics.py
+++ b/jupytext/magics.py
@@ -7,13 +7,13 @@ from .languages import _SCRIPT_EXTENSIONS, _COMMENT, usual_language_name
 # A magic expression is a line or cell or metakernel magic (#94, #61) escaped zero, or multiple times
 _MAGIC_RE = {
     _SCRIPT_EXTENSIONS[ext]["language"]: re.compile(
-        r"^({0} |{0})*(%|%%|%%%)[a-zA-Z]".format(_SCRIPT_EXTENSIONS[ext]["comment"])
+        r"^\s*({0} |{0})*(%|%%|%%%)[a-zA-Z]".format(_SCRIPT_EXTENSIONS[ext]["comment"])
     )
     for ext in _SCRIPT_EXTENSIONS
 }
 _MAGIC_FORCE_ESC_RE = {
     _SCRIPT_EXTENSIONS[ext]["language"]: re.compile(
-        r"^({0} |{0})*(%|%%|%%%)[a-zA-Z](.*){0}\s*escape".format(
+        r"^\s*({0} |{0})*(%|%%|%%%)[a-zA-Z](.*){0}\s*escape".format(
             _SCRIPT_EXTENSIONS[ext]["comment"]
         )
     )
@@ -21,7 +21,7 @@ _MAGIC_FORCE_ESC_RE = {
 }
 _MAGIC_NOT_ESC_RE = {
     _SCRIPT_EXTENSIONS[ext]["language"]: re.compile(
-        r"^({0} |{0})*(%|%%|%%%)[a-zA-Z](.*){0}\s*noescape".format(
+        r"^\s*({0} |{0})*(%|%%|%%%)[a-zA-Z](.*){0}\s*noescape".format(
             _SCRIPT_EXTENSIONS[ext]["comment"]
         )
     )

--- a/tests/test_escape_magics.py
+++ b/tests/test_escape_magics.py
@@ -270,5 +270,8 @@ def test_configure_magic(no_jupytext_version_number):
 def test_indented_magic():
     assert is_magic("    !rm file", "python")
     assert is_magic("    # !rm file", "python")
+    assert is_magic("    %cd", "python")
     assert comment_magic(["    !rm file"]) == ["    # !rm file"]
     assert uncomment_magic(["    # !rm file"]) == ["    !rm file"]
+    assert comment_magic(["    %cd"]) == ["    # %cd"]
+    assert uncomment_magic(["    # %cd"]) == ["    %cd"]


### PR DESCRIPTION
Fix #694 