### PR TITLE
Test that Jupytext works well with symbolic links to folders

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,7 +12,8 @@ Jupytext ChangeLog
 - Indented magic commands are supported ([#694](https://github.com/mwouts/jupytext/issues/694))
 
 **Added**
-- Added a test that ensures that `py:percent` scripts end with exactly one blank line ([#682](https://github.com/mwouts/jupytext/issues/682))
+- We made sure that `py:percent` scripts end with exactly one blank line ([#682](https://github.com/mwouts/jupytext/issues/682))
+- We checked that Jupytext works well with symbolic links to folders (not files!) ([#696](https://github.com/mwouts/jupytext/issues/696))
 - We have added `isort` and `autoflake8` to the `pre-commit` configuration file used for developing the Jupytext project ([#709](https://github.com/mwouts/jupytext/issues/709))
 
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -68,14 +68,10 @@ You can pair notebooks in trees with a `root_prefix` separated with three slashe
 default_jupytext_formats = "notebooks///ipynb,scripts///py:percent"
 ```
 The `root_prefix` is matched with the top-most parent folder of the matching name, not above the Jupytext configuration file.
-A document is not considered a paired notebook when its path does not match the paired path specifications.
 
+For instance, with the pairing above, a notebook with path `/home/user/jupyter/notebooks/project1/example.ipynb` will be paired with the Python file `/home/user/jupyter/scripts/project1/example.py`.
 
-With only two slashes, notebooks are paired in directories but not in subfolders:
-```
-# Pair notebooks in folders named 'notebooks' to folders named 'scripts'
-default_jupytext_formats = "notebooks//ipynb,scripts//py:percent"
-```
+In addition to the `root_prefix`, you can use symbolic links if you wish to distribute your notebook folders at different places. Be sure to use symbolic links on folders, not files ([#696](https://github.com/mwouts/jupytext/issues/696)).
 
 To disable the default pairing for an individual notebook, set formats to a single format, with e.g.:
 ```bash

--- a/tests/test_cm_config.py
+++ b/tests/test_cm_config.py
@@ -1,6 +1,5 @@
 import os
 import sys
-
 import unittest.mock as mock
 
 import pytest


### PR DESCRIPTION
As reported at #696, Jupytext can't work with symbolic links to files, because Jupyter has a wrong timestamp for them.
With this PR we add a test to make sure that it works well with symbolic links to folders.
Closes #696.