### PR TITLE
Check nbformat version

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ Jupytext ChangeLog
 
 **Fixed**
 - Indented magic commands are supported ([#694](https://github.com/mwouts/jupytext/issues/694))
-- Jupytext will issue an informative error or warning on notebooks in a version of nbformat that is not known to be supported ([#681](https://github.com/mwouts/jupytext/issues/681))
+- Jupytext will issue an informative error or warning on notebooks in a version of nbformat that is not known to be supported ([#681](https://github.com/mwouts/jupytext/issues/681), [#715](https://github.com/mwouts/jupytext/issues/715))
 
 **Added**
 - We made sure that `py:percent` scripts end with exactly one blank line ([#682](https://github.com/mwouts/jupytext/issues/682))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ Jupytext ChangeLog
 
 **Fixed**
 - Indented magic commands are supported ([#694](https://github.com/mwouts/jupytext/issues/694))
+- Jupytext will issue an informative error or warning on notebooks in a version of nbformat that is not known to be supported ([#681](https://github.com/mwouts/jupytext/issues/681))
 
 **Added**
 - We made sure that `py:percent` scripts end with exactly one blank line ([#682](https://github.com/mwouts/jupytext/issues/682))

--- a/jupytext/jupytext.py
+++ b/jupytext/jupytext.py
@@ -440,7 +440,8 @@ def writes(notebook, fmt, version=nbformat.NO_CONVERT, **kwargs):
     if version < 4:
         raise NotSupportedNBFormatVersion(
             f"Notebooks in nbformat version {version}.{version_minor} are not supported by Jupytext. "
-            f"Please convert your notebooks to nbformat version 4, or call this function with 'version=4'."
+            f"Please convert your notebooks to nbformat version 4 with "
+            f"'jupyter nbconvert --to notebook --inplace', or call this function with 'version=4'."
         )
     if version > 4 or (version == 4 and version_minor > 4):
         warnings.warn(

--- a/jupytext/jupytext.py
+++ b/jupytext/jupytext.py
@@ -431,6 +431,10 @@ def writes(notebook, fmt, version=nbformat.NO_CONVERT, **kwargs):
     :return: the text representation of the notebook
     """
     if version is not nbformat.NO_CONVERT:
+        if not isinstance(version, int):
+            raise TypeError(
+                "The argument 'version' should be either nbformat.NO_CONVERT, or an integer."
+            )
         notebook = nbformat.convert(notebook, version)
     (version, version_minor) = nbformat.reader.get_version(notebook)
     if version < 4:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -509,13 +509,13 @@ def test_sync(nb_file, tmpdir, capsys):
     assert os.path.isfile(tmp_rmd)
     compare_notebooks(read(tmp_rmd), nb, "Rmd")
 
-    write(nb, tmp_rmd, "Rmd")
+    write(nb, tmp_rmd, fmt="Rmd")
     jupytext(["--sync", tmp_ipynb])
 
     nb2 = read(tmp_ipynb)
     compare_notebooks(nb2, nb, "Rmd", compare_outputs=True)
 
-    write(nb, tmp_py, "py")
+    write(nb, tmp_py, fmt="py")
     jupytext(["--sync", tmp_ipynb])
 
     nb2 = read(tmp_ipynb)
@@ -581,7 +581,7 @@ def test_cli_can_infer_jupytext_format(nb_file, ext, tmpdir):
     compare_notebooks(nb2, nb)
 
     # Percent format to Jupyter notebook
-    write(nb, tmp_text, ext + ":percent")
+    write(nb, tmp_text, fmt=ext + ":percent")
     jupytext(["--to", "notebook", tmp_text])
     nb2 = read(tmp_ipynb)
     compare_notebooks(nb2, nb)
@@ -758,7 +758,7 @@ def test_cli_sync_file_with_suffix(tmpdir):
         metadata={"jupytext": {"formats": "ipynb,.pct.py:percent,.lgt.py:light,Rmd"}},
     )
 
-    write(nb, tmp_pct_py, ".pct.py:percent")
+    write(nb, tmp_pct_py, fmt=".pct.py:percent")
     jupytext(["--sync", tmp_pct_py])
     assert os.path.isfile(tmp_lgt_py)
     assert os.path.isfile(tmp_rmd)

--- a/tests/test_nbformat_version.py
+++ b/tests/test_nbformat_version.py
@@ -1,0 +1,67 @@
+import pytest
+from nbformat import writes as nbformat_writes
+from nbformat.v3.nbbase import new_code_cell, new_notebook, new_text_cell, new_worksheet
+from nbformat.v4.nbbase import new_markdown_cell
+from nbformat.v4.nbbase import new_notebook as new_notebook_v4
+
+from jupytext import reads, writes
+from jupytext.jupytext import NotSupportedNBFormatVersion
+
+
+@pytest.fixture()
+def sample_notebook_v3():
+    return new_notebook(
+        worksheets=[
+            new_worksheet(
+                cells=[new_code_cell("1 + 1"), new_text_cell("markdown", "Hi")]
+            )
+        ]
+    )
+
+
+@pytest.fixture()
+def sample_notebook_v3_json(sample_notebook_v3):
+    return nbformat_writes(sample_notebook_v3)
+
+
+@pytest.fixture()
+def sample_notebook_v4_5():
+    nb = new_notebook_v4(cells=[new_markdown_cell("Hi")])
+    nb["nbformat_minor"] = 5
+    nb["cells"][0]["id"] = "unique-id"
+    return nb
+
+
+def test_jupytext_can_read_nbformat_3(
+    sample_notebook_v3_json,
+):
+    with pytest.warns(Warning, match="jupyter nbconvert --to notebook --inplace"):
+        nb = reads(sample_notebook_v3_json, fmt="ipynb")
+        assert nb["nbformat"] == 3
+
+    nb = reads(sample_notebook_v3_json, as_version=4, fmt="ipynb")
+    assert nb["nbformat"] == 4
+
+
+@pytest.mark.parametrize("fmt", ["py:light", "py:percent", "md"])
+def test_jupytext_gives_a_meaningful_error_when_writing_nbformat_3(
+    sample_notebook_v3, fmt
+):
+    with pytest.raises(
+        NotSupportedNBFormatVersion,
+        match="Notebooks in nbformat version 3.0 are not supported by Jupytext",
+    ):
+        writes(sample_notebook_v3, fmt=fmt)
+
+    writes(sample_notebook_v3, version=4, fmt=fmt)
+
+
+@pytest.mark.parametrize("fmt", ["py:light", "py:percent", "md"])
+def test_jupytext_gives_a_meaningful_error_when_writing_nbformat_4_5(
+    sample_notebook_v4_5, fmt
+):
+    with pytest.warns(
+        Warning,
+        match="Notebooks in nbformat version 4.5 have not been tested",
+    ):
+        writes(sample_notebook_v4_5, fmt=fmt)


### PR DESCRIPTION
In this PR we add checks to make sure that Jupytext is used on notebook in versions of nbformat with which it has been tested. See for instance #681 and #715.