### PR TITLE
feat: add recursive glob option

### DIFF
--- a/jupytext/cli.py
+++ b/jupytext/cli.py
@@ -416,7 +416,7 @@ def jupytext(args=None):
     for pattern in args.notebooks:
         if "*" in pattern or "?" in pattern:
             # Exclude the .jupytext.py configuration file
-            notebooks.extend(glob.glob(pattern))
+            notebooks.extend(glob.glob(pattern, recursive=True))
         else:
             notebooks.append(pattern)
 


### PR DESCRIPTION
This add the Recursive option which is [supported since version 3.5](https://docs.python.org/3.6/library/glob.html). That way we can use cli with `**/` pattern.