### PR TITLE
Add a test for the recursive glob pattern

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@ Jupytext ChangeLog
 -------------------
 
 **Added**
+- The recursive glob pattern `**/*.ipynb` is now supported by Jupytext - Thanks to Banst for this contribution ([#731](https://github.com/mwouts/jupytext/issues/731))
 - Sage notebooks are supported. They can be converted to `.sage` and `.md` files and back. Thanks to Lars Franke for suggesting this! ([#727](https://github.com/mwouts/jupytext/issues/727))
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1183,3 +1183,12 @@ def test_skip_execution(tmpdir, cwd_tmpdir, tmp_repo, python_notebook, capsys):
     jupytext(["--execute", "--pre-commit-mode", "test.ipynb"])
     captured = capsys.readouterr()
     assert "skipped" in captured.out
+
+
+def test_glob_recursive(tmpdir, cwd_tmpdir):
+    tmpdir.mkdir("subfolder").join("test.py").write("1 + 1\n")
+    tmpdir.join("test.py").write("2 + 2\n")
+    jupytext(["--to", "ipynb", "**/*.py"])
+
+    assert tmpdir.join("test.ipynb").isfile()
+    assert tmpdir.join("subfolder").join("test.ipynb").isfile()


### PR DESCRIPTION
We test that `jupytext [...] **/*.py` has the expected effect (see #731)