### PR TITLE
Add __main__ to allow calling via python -m

### DIFF
--- a/jupytext/__main__.py
+++ b/jupytext/__main__.py
@@ -1,0 +1,13 @@
+""" Main for Jupytext
+
+Call with (e.g.)::
+
+    python -m jupytext my_notebook.ipynb --to Rmd
+"""
+
+import sys
+
+from .cli import jupytext
+
+if __name__ == "__main__":
+    sys.exit(jupytext())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ import unittest.mock as mock
 from argparse import ArgumentTypeError
 from io import StringIO
 from shutil import copyfile
+from subprocess import check_call
 
 import nbformat
 import pytest
@@ -63,6 +64,24 @@ def test_convert_single_file_in_place(nb_file, tmpdir):
     nb2 = read(nb_other)
 
     compare_notebooks(nb2, nb1)
+
+
+def test_convert_single_file_in_place_m(tmpdir):
+    nb_file = list_notebooks("ipynb_py")[0]
+    nb_org = str(tmpdir.join(os.path.basename(nb_file)))
+    copyfile(nb_file, nb_org)
+
+    base, ext = os.path.splitext(nb_org)
+
+    for fmt_ext in ("py", "Rmd"):
+        nb_other = base + "." + fmt_ext
+
+        check_call([sys.executable, "-m", "jupytext", nb_org, "--to", fmt_ext])
+
+        nb1 = read(nb_org)
+        nb2 = read(nb_other)
+
+        compare_notebooks(nb2, nb1)
 
 
 @pytest.mark.parametrize("nb_file", list_notebooks("ipynb") + list_notebooks("Rmd"))


### PR DESCRIPTION
Allows e.g.

```
python -m jupytext my_notebook.ipynb --to Rmd
```

I _think_ this is the correct way to do this, but I don't personally
have much experience with this machinery.