### PR TITLE
Use config in read and write functions

### DIFF
--- a/jupytext/combine.py
+++ b/jupytext/combine.py
@@ -49,12 +49,19 @@ def combine_inputs_with_outputs(nb_source, nb_outputs, fmt=None):
     ext = fmt.get("extension") or text_repr.get("extension")
     format_name = fmt.get("format_name") or text_repr.get("format_name")
 
-    nb_metadata = restore_filtered_metadata(
-        nb_source.metadata,
-        nb_outputs.metadata,
-        nb_source.metadata.get("jupytext", {}).get("notebook_metadata_filter"),
-        _DEFAULT_NOTEBOOK_METADATA,
+    notebook_metadata_filter = nb_source.metadata.get("jupytext", {}).get(
+        "notebook_metadata_filter"
     )
+    if notebook_metadata_filter == "-all":
+        nb_metadata = nb_outputs.metadata
+
+    else:
+        nb_metadata = restore_filtered_metadata(
+            nb_source.metadata,
+            nb_outputs.metadata,
+            notebook_metadata_filter,
+            _DEFAULT_NOTEBOOK_METADATA,
+        )
 
     source_is_md_version_one = (
         ext in [".md", ".markdown", ".Rmd"] and text_repr.get("format_version") == "1.0"

--- a/jupytext/jupytext.py
+++ b/jupytext/jupytext.py
@@ -59,21 +59,14 @@ class TextNotebookConverter(NotebookReader, NotebookWriter):
     def update_fmt_with_notebook_options(self, metadata, read=False):
         """Update format options with the values in the notebook metadata, and record those
         options in the notebook metadata"""
+        # The settings in the Jupytext configuration file have precedence over the metadata in the notebook
+        # when the notebook is saved. This is because the metadata in the notebook might not be visible
+        # in the text representation when e.g. notebook_metadata_filter="-all", which makes them hard to edit.
+        if not read and self.config is not None:
+            self.config.set_default_format_options(self.fmt, read)
+
         # format options in notebook have precedence over that in fmt, and precedence over the config
         for opt in _VALID_FORMAT_OPTIONS:
-            if self.config is not None:
-                # We use the config filters if provided
-                if (
-                    opt == "notebook_metadata_filter"
-                    and self.config.default_notebook_metadata_filter
-                ):
-                    continue
-                if (
-                    opt == "cell_metadata_filter"
-                    and self.config.default_cell_metadata_filter
-                ):
-                    continue
-
             if opt in metadata.get("jupytext", {}):
                 self.fmt.setdefault(opt, metadata["jupytext"][opt])
 

--- a/jupytext/version.py
+++ b/jupytext/version.py
@@ -1,3 +1,3 @@
 """Jupytext's version number"""
 
-__version__ = "1.10.3"
+__version__ = "1.10.4-dev"

--- a/tests/test_contentsmanager.py
+++ b/tests/test_contentsmanager.py
@@ -1682,10 +1682,7 @@ def test_multiple_pairing(tmpdir):
     assert model_py["last_modified"] <= model_md["last_modified"]
 
 
-@pytest.mark.parametrize("nb_file", list_notebooks("ipynb_py"))
-def test_filter_jupytext_version_information_416(nb_file, tmpdir):
-    tmp_py = str(tmpdir.join("notebook.py"))
-
+def test_filter_jupytext_version_information_416(python_notebook, tmpdir, cwd_tmpdir):
     cm = jupytext.TextFileContentsManager()
     cm.root_dir = str(tmpdir)
     cm.default_notebook_metadata_filter = (
@@ -1693,17 +1690,17 @@ def test_filter_jupytext_version_information_416(nb_file, tmpdir):
     )
 
     # load notebook
-    notebook = jupytext.read(nb_file)
+    notebook = python_notebook
     notebook.metadata["jupytext_formats"] = "ipynb,py"
     model = notebook_model(notebook)
 
     # save to ipynb and py
     cm.save(model=model, path="notebook.ipynb")
 
-    assert os.path.isfile(tmp_py)
+    assert os.path.isfile("notebook.py")
 
     # read py file
-    with open(tmp_py) as fp:
+    with open("notebook.py") as fp:
         text = fp.read()
 
     assert "---" in text

--- a/tests/test_contentsmanager.py
+++ b/tests/test_contentsmanager.py
@@ -1541,21 +1541,25 @@ def test_save_file_with_default_cell_markers(tmpdir):
     nb = cm.get("nb.py")["content"]
     assert len(nb.cells) == 1
 
-    nb.metadata["jupytext"]["cell_markers"] = "+,-"
-    del nb.metadata["jupytext"]["notebook_metadata_filter"]
     cm.save(model=notebook_model(nb), path="nb.py")
 
     with open(tmp_py) as fp:
         text2 = fp.read()
 
     compare(
-        "\n".join(text2.splitlines()[-len(text.splitlines()) :]),
-        "\n".join(text.splitlines()),
+        text2,
+        """# region
+# this is a unique code cell
+1 + 1
+
+2 + 2
+# endregion
+""",
     )
 
     nb2 = cm.get("nb.py")["content"]
     compare_notebooks(nb2, nb)
-    assert nb2.metadata["jupytext"]["cell_markers"] == "+,-"
+    assert nb2.metadata["jupytext"]["cell_markers"] == "region,endregion"
 
 
 def test_notebook_extensions(tmpdir):

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -87,7 +87,7 @@ def test_metadata_and_cell_to_header(no_jupytext_version_number):
         metadata=metadata, cells=[new_raw_cell(source="---\ntitle: Sample header\n---")]
     )
     header, lines_to_next_cell = metadata_and_cell_to_header(
-        nb, metadata, get_format_implementation(".md"), ".md"
+        nb, metadata, get_format_implementation(".md"), {"extension": ".md"}
     )
     assert (
         "\n".join(header)
@@ -105,7 +105,7 @@ jupyter:
 def test_metadata_and_cell_to_header2(no_jupytext_version_number):
     nb = new_notebook(cells=[new_markdown_cell(source="Some markdown\ntext")])
     header, lines_to_next_cell = metadata_and_cell_to_header(
-        nb, {}, get_format_implementation(".md"), ".md"
+        nb, {}, get_format_implementation(".md"), {"extension": ".md"}
     )
     assert header == []
     assert len(nb.cells) == 1
@@ -169,10 +169,13 @@ jupyter:
 
 
 def test_header_to_html_comment(no_jupytext_version_number):
-    metadata = {"jupytext": {"mainlanguage": "python", "hide_notebook_metadata": True}}
+    metadata = {"jupytext": {"mainlanguage": "python"}}
     nb = new_notebook(metadata=metadata, cells=[])
     header, lines_to_next_cell = metadata_and_cell_to_header(
-        nb, metadata, get_format_implementation(".md"), ".md"
+        nb,
+        metadata,
+        get_format_implementation(".md"),
+        {"extension": ".md", "hide_notebook_metadata": True},
     )
     compare(
         "\n".join(header),
@@ -181,7 +184,6 @@ def test_header_to_html_comment(no_jupytext_version_number):
 ---
 jupyter:
   jupytext:
-    hide_notebook_metadata: true
     mainlanguage: python
 ---
 

--- a/tests/test_metadata_filters_from_config.py
+++ b/tests/test_metadata_filters_from_config.py
@@ -44,6 +44,4 @@ default_cell_metadata_filter = "-all"
 
     jupytext_cli([str(md_file), "--to", "notebook", "--update"])
     nb2 = nbformat.read(str(nb_file), as_version=4)
-
-    del nb2.metadata["jupytext"]
     compare_notebooks(nb2, nb)


### PR DESCRIPTION
This PR adds a `config` argument to the `jupytext.read(s)` and `jupytext.write(s)` functions.
This should help fixing #752 

What remains to be done:
- [x] ~~The `config` is used only when _saving_ (except for the rst2md conversion which has to be used when reading the file)~~ that is not a good idea - the notebooks with no metadata don't store the format options, so for these notebook at least it makes sense to use the config also when reading them.
- [x] We should deprecate `default_metadata_filter` in favor of `metadata_filter`, etc, and also `default_jupytext_formats` in favor of `formats` (and provide backward compatibility) => The PR for that is at #754 