### PR TITLE
Mark fmt as optional in reads

### DIFF
--- a/jupytext/jupytext.py
+++ b/jupytext/jupytext.py
@@ -355,7 +355,7 @@ class TextNotebookConverter(NotebookReader, NotebookWriter):
         return "\n".join(header + lines)
 
 
-def reads(text, fmt, as_version=nbformat.NO_CONVERT, config=None, **kwargs):
+def reads(text, fmt=None, as_version=nbformat.NO_CONVERT, config=None, **kwargs):
     """
     Read a notebook from a string
 


### PR DESCRIPTION
The docstring and code act like it is optional, but the function
signature is not optional.