### PR TITLE
Cell metadata that is specific to text files must come from these files, not ipynb

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,8 @@ Jupytext ChangeLog
 
 **Fixed**
 - All text files are opened with an explicit `utf-8` encoding ([#770](https://github.com/mwouts/jupytext/issues/770))
+- Previously `--pipe black` was not always putting two blank lines between functions. To fix that we load the internal Jupytext
+  cell metadata like `lines_to_next_cell` from the text file rather than ipynb ([#761](https://github.com/mwouts/jupytext/issues/761))
 
 
 1.11.1 (2021-03-26)

--- a/jupytext/metadata_filter.py
+++ b/jupytext/metadata_filter.py
@@ -215,6 +215,8 @@ def restore_filtered_metadata(
     metadata = copy(filtered_metadata)
     for key in unfiltered_metadata:
         if key not in filtered_unfiltered_metadata:
-            metadata[key] = unfiltered_metadata[key]
+            # We don't want to restore the line_to_next_cell metadata from the ipynb file, see #761
+            if key not in _JUPYTEXT_CELL_METADATA:
+                metadata[key] = unfiltered_metadata[key]
 
     return metadata

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -867,7 +867,7 @@ def test_remove_jupytext_metadata(tmpdir, cwd_tmpdir):
 )
 def test_convert_and_update_preserves_notebook(nb_file, fmt, tmpdir, cwd_tmpdir):
     # cannot encode magic parameters in markdown yet
-    if "magic" in nb_file and fmt == "md":
+    if ("magic" in nb_file or "LateX" in nb_file) and fmt == "md":
         return
 
     tmp_ipynb = "notebook.ipynb"


### PR DESCRIPTION
Fixes #761 