### PR TITLE
Do not update source file timestamp when not required

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ Jupytext ChangeLog
 - All text files are opened with an explicit `utf-8` encoding ([#770](https://github.com/mwouts/jupytext/issues/770))
 - Previously `--pipe black` was not always putting two blank lines between functions. To fix that we load the internal Jupytext
   cell metadata like `lines_to_next_cell` from the text file rather than ipynb ([#761](https://github.com/mwouts/jupytext/issues/761))
+- The timestamp of the source file is not updated any more when the destination file is not in the pair ([#765](https://github.com/mwouts/jupytext/issues/765), [#767](https://github.com/mwouts/jupytext/issues/767))
 
 
 1.11.1 (2021-03-26)

--- a/jupytext/config.py
+++ b/jupytext/config.py
@@ -43,7 +43,7 @@ class JupytextConfiguration(Configurable):
     """Jupytext Configuration's options"""
 
     formats = Union(
-        [Unicode(), List(Unicode()), Dict(Unicode)],
+        [Unicode(), List(Unicode()), Dict(Unicode())],
         help="Save notebooks to these file extensions. "
         "Can be any of ipynb,Rmd,md,jl,py,R,nb.jl,nb.py,nb.R "
         "comma separated. If you want another format than the "

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1264,3 +1264,50 @@ def test_jupytext_to_ipynb_suggests_update(tmpdir, cwd_tmpdir, capsys):
     jupytext(["--to", "ipynb", "test.py"])
     capture = capsys.readouterr()
     assert "update" in capture.out
+
+
+@pytest.mark.parametrize("formats", ["", "py:percent", "py", "py:percent,ipynb"])
+def test_jupytext_to_ipynb_does_not_update_timestamp_if_output_not_in_pair(
+    tmpdir, cwd_tmpdir, python_notebook, capsys, formats
+):
+    # Write a text notebook
+    nb = python_notebook
+    if formats:
+        nb.metadata["jupytext"] = {"formats": formats}
+
+    test_py = tmpdir.join("test.py")
+    write(nb, str(test_py))
+
+    # make it read-only
+    test_py.chmod(0o444)
+
+    # py -> ipynb
+    if "ipynb" not in formats:
+        jupytext(["--to", "ipynb", "test.py"])
+    else:
+        jupytext(["--to", "ipynb", "test.py", "-o", "another.ipynb"])
+
+    capture = capsys.readouterr()
+    assert "Updating the timestamp" not in capture.out
+
+
+@pytest.mark.parametrize("formats", ["py:percent", "py", None])
+def test_jupytext_to_ipynb_does_not_update_timestamp_if_not_paired(
+    tmpdir, cwd_tmpdir, python_notebook, capsys, formats
+):
+    # Write a text notebook
+    nb = python_notebook
+    if formats:
+        nb.metadata["jupytext"] = {"formats": formats}
+
+    test_py = tmpdir.join("test.py")
+    write(nb, str(test_py))
+
+    # make it read-only
+    test_py.chmod(0o444)
+
+    # py -> ipynb
+    jupytext(["--to", "ipynb", "test.py"])
+
+    capture = capsys.readouterr()
+    assert "Updating the timestamp" not in capture.out


### PR DESCRIPTION
With this change we won't update the timestamp of source files when the destination file is not in the pair.
As a reminder, the reason why we need to update the timestamp is #335

Fixes #765 and #767
