### PR TITLE
Comment variables created from magic commands

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@ Jupytext ChangeLog
 
 **Fixed**
 - Dependencies of the JupyterLab extension have been upgraded to fix a security vulnerability ([#783](https://github.com/mwouts/jupytext/issues/783))
+- Variables assigned from a magic command are commented out in `py` scripts ([#781](https://github.com/mwouts/jupytext/issues/781))
+
 
 1.11.2 (2021-05-02)
 -------------------

--- a/jupytext/cli.py
+++ b/jupytext/cli.py
@@ -832,24 +832,17 @@ def jupytext_single_file(nb_file, args, log):
 
         lazy_write(nb_dest, fmt=dest_fmt, action=action)
 
-        formats = notebook.metadata.get("jupytext", {}).get("formats")
-        nb_dest_in_pair = formats is not None and any(
+        nb_dest_in_pair = formats and any(
             os.path.exists(alt_path) and os.path.samefile(nb_dest, alt_path)
             for alt_path, _ in paired_paths(nb_file, fmt, formats)
         )
 
-        if formats is not None and not nb_dest_in_pair:
-            # We remove the formats if the destination is not in the pair (and rewrite,
-            # this is not great, but samefile above requires that the file exists)
-            notebook.metadata.get("jupytext", {}).pop("formats")
-            lazy_write(nb_dest, fmt=dest_fmt, action=action)
-
         if (
-            os.path.isfile(nb_file)
+            nb_dest_in_pair
+            and os.path.isfile(nb_file)
             and not nb_file.endswith(".ipynb")
             and os.path.isfile(nb_dest)
             and nb_dest.endswith(".ipynb")
-            and nb_dest_in_pair
         ):
             # If the destination is an ipynb file and is in the pair, then we
             # update the original text file timestamp, as required by our Content Manager

--- a/jupytext/cli.py
+++ b/jupytext/cli.py
@@ -832,17 +832,24 @@ def jupytext_single_file(nb_file, args, log):
 
         lazy_write(nb_dest, fmt=dest_fmt, action=action)
 
-        nb_dest_in_pair = formats and any(
+        formats = notebook.metadata.get("jupytext", {}).get("formats")
+        nb_dest_in_pair = formats is not None and any(
             os.path.exists(alt_path) and os.path.samefile(nb_dest, alt_path)
             for alt_path, _ in paired_paths(nb_file, fmt, formats)
         )
 
+        if formats is not None and not nb_dest_in_pair:
+            # We remove the formats if the destination is not in the pair (and rewrite,
+            # this is not great, but samefile above requires that the file exists)
+            notebook.metadata.get("jupytext", {}).pop("formats")
+            lazy_write(nb_dest, fmt=dest_fmt, action=action)
+
         if (
-            nb_dest_in_pair
-            and os.path.isfile(nb_file)
+            os.path.isfile(nb_file)
             and not nb_file.endswith(".ipynb")
             and os.path.isfile(nb_dest)
             and nb_dest.endswith(".ipynb")
+            and nb_dest_in_pair
         ):
             # If the destination is an ipynb file and is in the pair, then we
             # update the original text file timestamp, as required by our Content Manager

--- a/jupytext/magics.py
+++ b/jupytext/magics.py
@@ -58,6 +58,10 @@ _PYTHON_MAGIC_CMD = re.compile(
 # Python help commands end with ?
 _IPYTHON_MAGIC_HELP = re.compile(r"^\s*(# )*[^\s]*\?\s*$")
 
+_PYTHON_MAGIC_ASSIGN = re.compile(
+    r"^(# |#)*\s*([a-zA-Z_][a-zA-Z_$0-9]*)\s*=\s*(%|%%|%%%)[a-zA-Z](.*)"
+)
+
 _SCRIPT_LANGUAGES = [_SCRIPT_EXTENSIONS[ext]["language"] for ext in _SCRIPT_EXTENSIONS]
 
 
@@ -75,6 +79,8 @@ def is_magic(line, language, global_escape_flag=True, explicitly_code=False):
     if language != "python":
         return False
     if _PYTHON_HELP_OR_BASH_CMD.match(line):
+        return True
+    if _PYTHON_MAGIC_ASSIGN.match(line):
         return True
     if explicitly_code and _IPYTHON_MAGIC_HELP.match(line):
         return True

--- a/tests/test_escape_magics.py
+++ b/tests/test_escape_magics.py
@@ -3,7 +3,13 @@ from nbformat.v4.nbbase import new_code_cell, new_notebook
 
 import jupytext
 from jupytext.compare import compare, compare_notebooks
-from jupytext.magics import comment_magic, is_magic, uncomment_magic, unesc
+from jupytext.magics import (
+    _PYTHON_MAGIC_ASSIGN,
+    comment_magic,
+    is_magic,
+    uncomment_magic,
+    unesc,
+)
 
 from .utils import notebook_model
 
@@ -276,3 +282,11 @@ def test_indented_magic():
     assert uncomment_magic(["    # !rm file"]) == ["    !rm file"]
     assert comment_magic(["    %cd"]) == ["    # %cd"]
     assert uncomment_magic(["    # %cd"]) == ["    %cd"]
+
+
+def test_magic_assign_781():
+    assert _PYTHON_MAGIC_ASSIGN.match("name = %magic")
+    assert _PYTHON_MAGIC_ASSIGN.match("# name = %magic")
+    assert not _PYTHON_MAGIC_ASSIGN.match("# not a name = %magic")
+    assert not _PYTHON_MAGIC_ASSIGN.match("# 0name = %magic")
+    assert is_magic("result = %sql SELECT * FROM quickdemo WHERE value > 25", "python")


### PR DESCRIPTION
Variables created with magic commands like e.g.
```
result = %sql SELECT * FROM quickdemo WHERE value > 25
```
should be commented out in the `.py` representation.

Cf. #781 