### PR TITLE
Update contributing.md link

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -27,4 +27,4 @@ Jupytext works with notebooks in any of the following languages:
 - Script of Script
 - TypeScript
 
-Extending Jupytext to more languages should be easy, see [CONTRIBUTING.md](https://github.com/mwouts/jupytext/blob/master/CONTRIBUTING.md).
+Extending Jupytext to more languages should be easy, see [contributing.md](https://github.com/mwouts/jupytext/blob/master/docs/contributing.md).


### PR DESCRIPTION
When I click the link, it returns 404 because it looks like the contributing.md was in the main folder (and, by the way, was uppercase and now it is not) and now is in the docs/ folder.