### PR TITLE
The cell_markers option are more conveniently set in the jupytext config file

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,13 @@
 Jupytext ChangeLog
 ==================
 
+1.11.4 (2021-07-??)
+-------------------
+
+**Changed**
+- (Documentation) the `cell_markers` option (and the other ones) can be set directly in the `jupytext.toml` config file ([#809](https://github.com/mwouts/jupytext/issues/809)).
+
+
 1.11.3 (2021-06-10)
 -------------------
 

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -205,13 +205,13 @@ Metadata can be associated to a given cell using a key/value representation:
 
 The `light` format can use custom cell markers instead of `# +` or `# -`. If you prefer to mark cells with VS Code/PyCharm (resp. Vim) folding markers, set `"cell_markers": "region,endregion"` (resp. `"{{{,}}}"`) in the jupytext section of the notebook metadata. If you want to configure this as a global default, add either
 ```python
-c.ContentsManager.cell_markers = "region,endregion"  # Use VS Code/PyCharm region folding delimiters
+cell_markers = "region,endregion"  # Use VS Code/PyCharm region folding delimiters
 ```
 or
 ```python
-c.ContentsManager.cell_markers = "{{{,}}}"           # Use Vim region folding delimiters
+cell_markers = "{{{,}}}"           # Use Vim region folding delimiters
 ```
-to your `.jupyter/jupyter_notebook_config.py` file.
+to your [`jupytext.toml` configuration file](config.md#jupytext-configuration-file).
 
 See how our `World population.ipynb` notebook is [represented](https://github.com/mwouts/jupytext/blob/master/demo/World%20population.lgt.py) in that format.
 
@@ -277,9 +277,9 @@ jupytext --update-metadata '{"jupytext": {"cell_markers": "\"\"\""}}' notebook.i
 
 If you want to use multiline comments for all your paired notebooks, you could also add
 ```python
-c.ContentsManager.cell_markers = '"""'
+cell_markers = '"""'
 ```
-to your `.jupyter/jupyter_notebook_config.py` file.
+to your [`jupytext.toml` configuration file](config.md#jupytext-configuration-file).
 
 See how our `World population.ipynb` notebook is [represented](https://github.com/mwouts/jupytext/blob/master/demo/World%20population.pct.py) in the `percent` format.
 

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -30,10 +30,10 @@ And if you wish to export more metadata from the notebook, have a look at the pa
 
 In the Markdown format, markdown cells are inserted verbatim and separated with two blank lines.
 
-If you'd like that cell breaks also occurs on Markdown headers, add a `split_at_heading: true` entry in the `jupytext` section in the YAML header, or if you want that option to be the default for all Markdown documents in Jupyter, activate the option on Jupytext's content manager:
+If you'd like that cell breaks also occurs on Markdown headers, add a `split_at_heading: true` entry in the `jupytext` section in the YAML header, or if you want that option to be the default for all Markdown documents in Jupyter, activate the option in the [`jupytext.toml` configuration file](config.md#jupytext-configuration-file):
 
-```python
-c.ContentsManager.split_at_heading = True
+```
+split_at_heading = true
 ```
 
 Code cells are encoded using the classical triple backticks, followed by the notebook language. Cell metadata are appended after the language information, with a `key=value` syntax, where `value` is encoded in JSON format. For instance, in a Python notebook, a simple code cell with a `parameters` tag is represented as:
@@ -291,15 +291,14 @@ By default, [Jupyter magics](#magic-commands) are commented in the `percent` rep
 
 Another popular notebook-like format for Python scripts is the Sphinx-gallery [format](https://sphinx-gallery.readthedocs.io/en/latest/tutorials/plot_notebook.html). Scripts that contain at least two lines with more than twenty hash signs are classified as Sphinx-Gallery notebooks by Jupytext.
 
-Comments in Sphinx-Gallery scripts are formatted using reStructuredText rather than markdown. They can be converted to markdown for a nicer display in Jupyter by adding a `c.ContentsManager.sphinx_convert_rst2md = True` line to your Jupyter configuration file. Please note that this is a non-reversible transformation—use this only with Binder. Revert to the default value `sphinx_convert_rst2md = False` when you edit Sphinx-Gallery files with Jupytext.
+Comments in Sphinx-Gallery scripts are formatted using reStructuredText rather than markdown. They can be converted to markdown for a nicer display in Jupyter by adding a `sphinx_convert_rst2md = True` line to your Jupytext configuration file. Please note that this is a non-reversible transformation—use this only with Binder. Revert to the default value `sphinx_convert_rst2md = False` when you edit Sphinx-Gallery files with Jupytext.
 
 Turn a GitHub repository containing Sphinx-Gallery scripts into a live notebook repository with [Binder](https://mybinder.org/) and Jupytext by adding only two files to the repo:
 - `binder/requirements.txt`, a list of the required packages (including `jupytext`)
-- `.jupyter/jupyter_notebook_config.py` with the following contents:
-```python
-c.NotebookApp.contents_manager_class = "jupytext.TextFileContentsManager"
-c.ContentsManager.preferred_jupytext_formats_read = "py:sphinx"
-c.ContentsManager.sphinx_convert_rst2md = True
+- a [`jupytext.toml` configuration file](config.md#jupytext-configuration-file) with the following contents:
+```
+preferred_jupytext_formats_read = "py:sphinx"
+sphinx_convert_rst2md = true
 ```
 
 Our sample notebook is also represented in `sphinx` format [here](https://github.com/mwouts/jupytext/blob/master/demo/World%20population.spx.py).

--- a/jupytext/version.py
+++ b/jupytext/version.py
@@ -1,3 +1,3 @@
 """Jupytext's version number"""
 
-__version__ = "1.11.3"
+__version__ = "1.11.4-dev"

--- a/tests/test_read_simple_percent.py
+++ b/tests/test_read_simple_percent.py
@@ -340,8 +340,8 @@ some text, and a fake cell marker
 
 
 def test_cell_markers_option_in_contents_manager(tmpdir):
-    tmp_ipynb = str(tmpdir.join("notebook.ipynb"))
-    tmp_py = str(tmpdir.join("notebook.py"))
+    tmp_ipynb = tmpdir / "notebook.ipynb"
+    tmp_py = tmpdir / "notebook.py"
 
     cm = jupytext.TextFileContentsManager()
     cm.root_dir = str(tmpdir)
@@ -382,9 +382,33 @@ cell
     compare_notebooks(nb, nb2)
 
 
+def test_cell_markers_in_config(tmpdir, python_notebook):
+    (tmpdir / "jupytext.toml").write('''cell_markers = '"""'\n''')
+
+    cm = jupytext.TextFileContentsManager()
+    cm.root_dir = str(tmpdir)
+    nb = python_notebook
+    nb.metadata["jupytext"] = {"formats": "ipynb,py:percent"}
+
+    cm.save(model=notebook_model(nb), path="notebook.ipynb")
+
+    text = (tmpdir / "notebook.py").read()
+    assert (
+        '''# %% [markdown]
+"""
+A short notebook
+"""
+'''
+        in text
+    )
+
+    nb2 = jupytext.read(tmpdir / "notebook.py")
+    compare_notebooks(nb, nb2)
+
+
 def test_cell_markers_in_contents_manager(tmpdir):
-    tmp_ipynb = str(tmpdir.join("notebook.ipynb"))
-    tmp_py = str(tmpdir.join("notebook.py"))
+    tmp_ipynb = tmpdir / "notebook.ipynb"
+    tmp_py = tmpdir / "notebook.py"
 
     cm = jupytext.TextFileContentsManager()
     cm.root_dir = str(tmpdir)
@@ -426,8 +450,8 @@ cell
 
 
 def test_cell_markers_in_contents_manager_does_not_impact_light_format(tmpdir):
-    tmp_ipynb = str(tmpdir.join("notebook.ipynb"))
-    tmp_py = str(tmpdir.join("notebook.py"))
+    tmp_ipynb = tmpdir / "notebook.ipynb"
+    tmp_py = tmpdir / "notebook.py"
 
     cm = jupytext.TextFileContentsManager()
     cm.root_dir = str(tmpdir)


### PR DESCRIPTION
(than on the contents manager)

Closes #809 