### PR TITLE
Require Pandoc >= 2.11 in the tests

### DIFF
--- a/jupytext/pandoc.py
+++ b/jupytext/pandoc.py
@@ -15,7 +15,7 @@ class PandocError(OSError):
 
 def pandoc(args, filein=None, fileout=None):
     """Execute pandoc with the given arguments"""
-    cmd = [u"pandoc"]
+    cmd = ["pandoc"]
 
     if filein:
         cmd.append(filein)
@@ -35,16 +35,16 @@ def pandoc(args, filein=None, fileout=None):
     return out.decode("utf-8")
 
 
-def is_pandoc_available():
+def is_pandoc_available(min_version="2.7.2"):
     """Is Pandoc>=2.7.2 available?"""
     try:
-        raise_if_pandoc_is_not_available()
+        raise_if_pandoc_is_not_available(min_version=min_version)
         return True
     except PandocError:
         return False
 
 
-def raise_if_pandoc_is_not_available():
+def raise_if_pandoc_is_not_available(min_version="2.7.2"):
     """Raise with an informative error message if pandoc is not available"""
     try:
         from pkg_resources import parse_version
@@ -54,14 +54,14 @@ def raise_if_pandoc_is_not_available():
     version = pandoc_version()
     if version == "N/A":
         raise PandocError(
-            "The Pandoc Markdown format requires 'pandoc>=2.7.2', "
+            f"The Pandoc Markdown format requires 'pandoc>={min_version}', "
             "but pandoc was not found"
         )
 
-    if parse_version(version) < parse_version("2.7.2"):
+    if parse_version(version) < parse_version(min_version):
         raise PandocError(
-            "The Pandoc Markdown format requires 'pandoc>=2.7.2', "
-            "but pandoc version {} was not found".format(version)
+            f"The Pandoc Markdown format requires 'pandoc>={min_version}', "
+            f"but pandoc version {version} was not found"
         )
 
     return version
@@ -70,7 +70,7 @@ def raise_if_pandoc_is_not_available():
 def pandoc_version():
     """Pandoc's version number"""
     try:
-        return pandoc(u"--version").splitlines()[0].split()[1]
+        return pandoc("--version").splitlines()[0].split()[1]
     except (IOError, OSError):
         return "N/A"
 
@@ -83,7 +83,7 @@ def md_to_notebook(text):
     tmp_file.close()
 
     pandoc(
-        u"--from markdown --to ipynb -s --atx-headers --wrap=preserve --preserve-tabs",
+        "--from markdown --to ipynb -s --atx-headers --wrap=preserve --preserve-tabs",
         tmp_file.name,
         tmp_file.name,
     )
@@ -103,7 +103,7 @@ def notebook_to_md(notebook):
     tmp_file.close()
 
     pandoc(
-        u"--from ipynb --to markdown -s --atx-headers --wrap=preserve --preserve-tabs",
+        "--from ipynb --to markdown -s --atx-headers --wrap=preserve --preserve-tabs",
         tmp_file.name,
         tmp_file.name,
     )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -52,8 +52,10 @@ requires_sphinx_gallery = pytest.mark.skipif(
     not rst2md, reason="sphinx_gallery is not available"
 )
 requires_pandoc = pytest.mark.skipif(
-    not is_pandoc_available() or sys.version_info < (3,),
-    reason="pandoc>=2.7.2 is not available",
+    # The mirror files changed slightly when Pandoc 2.11 was introduced
+    # https://github.com/mwouts/jupytext/commit/c07d919702999056ce47f92b74f63a15c8361c5d
+    not is_pandoc_available(min_version="2.11") or sys.version_info < (3,),
+    reason="pandoc>=2.11 is not available",
 )
 requires_no_pandoc = pytest.mark.skipif(
     is_pandoc_available(), reason="Pandoc is installed"


### PR DESCRIPTION
As the mirror files changed slightly when Pandoc 2.11 was introduced
https://github.com/mwouts/jupytext/commit/c07d919702999056ce47f92b74f63a15c8361c5d

Relates to #814 