### PR TITLE
System assigns of the form `var = !cmd` are commented out

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ Jupytext ChangeLog
 - (Documentation) the `cell_markers` option (and the other ones) can be set directly in the `jupytext.toml` config file ([#809](https://github.com/mwouts/jupytext/issues/809)).
 
 **Fixed**
+- System assigns of the form `var = !cmd` are commented out ([#816](https://github.com/mwouts/jupytext/issues/816))
 - The prefix in the Jupytext formats always use /, while paths might use either / or \ ([#806](https://github.com/mwouts/jupytext/issues/806))
 - Fixed an `InconsistentPath` issue with notebooks paired with scripts in a folder ([#806](https://github.com/mwouts/jupytext/issues/806))
 - The pre-commit tests are skipped when the Jupytext folder is not a git repository ([#814](https://github.com/mwouts/jupytext/issues/814))

--- a/jupytext/magics.py
+++ b/jupytext/magics.py
@@ -59,7 +59,7 @@ _PYTHON_MAGIC_CMD = re.compile(
 _IPYTHON_MAGIC_HELP = re.compile(r"^\s*(# )*[^\s]*\?\s*$")
 
 _PYTHON_MAGIC_ASSIGN = re.compile(
-    r"^(# |#)*\s*([a-zA-Z_][a-zA-Z_$0-9]*)\s*=\s*(%|%%|%%%)[a-zA-Z](.*)"
+    r"^(# |#)*\s*([a-zA-Z_][a-zA-Z_$0-9]*)\s*=\s*(%|%%|%%%|!)[a-zA-Z](.*)"
 )
 
 _SCRIPT_LANGUAGES = [_SCRIPT_EXTENSIONS[ext]["language"] for ext in _SCRIPT_EXTENSIONS]

--- a/tests/test_escape_magics.py
+++ b/tests/test_escape_magics.py
@@ -290,3 +290,10 @@ def test_magic_assign_781():
     assert not _PYTHON_MAGIC_ASSIGN.match("# not a name = %magic")
     assert not _PYTHON_MAGIC_ASSIGN.match("# 0name = %magic")
     assert is_magic("result = %sql SELECT * FROM quickdemo WHERE value > 25", "python")
+
+
+def test_magic_assign_816():
+    assert _PYTHON_MAGIC_ASSIGN.match("flake8_version = !flake8 --version")
+    assert _PYTHON_MAGIC_ASSIGN.match("# flake8_version = !flake8 --version")
+    assert _PYTHON_MAGIC_ASSIGN.match("name = %time 2+2")
+    assert _PYTHON_MAGIC_ASSIGN.match("# name = %time 2+2")


### PR DESCRIPTION
This is a quick regexp implementation for #816 