### PR TITLE
Remove the mention of '--update' in 'jupytext --pipe' since outputs are preserved already

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ Jupytext ChangeLog
 - The prefix in the Jupytext formats always use /, while paths might use either / or \ ([#806](https://github.com/mwouts/jupytext/issues/806))
 - Fixed an `InconsistentPath` issue with notebooks paired with scripts in a folder ([#806](https://github.com/mwouts/jupytext/issues/806))
 - The pre-commit tests are skipped when the Jupytext folder is not a git repository ([#814](https://github.com/mwouts/jupytext/issues/814))
+- Remove the mention of '--update' in 'jupytext --pipe' since outputs are preserved already
 
 
 1.11.3 (2021-06-10)

--- a/jupytext/cli.py
+++ b/jupytext/cli.py
@@ -475,7 +475,8 @@ def jupytext_single_file(nb_file, args, log):
     config = load_jupytext_config(os.path.abspath(nb_file))
 
     # Just acting on metadata / pipe => save in place
-    if not nb_dest and not args.sync:
+    save_in_place = not nb_dest and not args.sync
+    if save_in_place:
         nb_dest = nb_file
 
     if nb_dest == "-":
@@ -818,7 +819,9 @@ def jupytext_single_file(nb_file, args, log):
             base_path(nb_dest, dest_fmt)
 
         # Describe what jupytext is doing
-        if os.path.isfile(nb_dest) and args.update:
+        if save_in_place:
+            action = ""
+        elif os.path.isfile(nb_dest) and args.update:
             if not nb_dest.endswith(".ipynb"):
                 raise ValueError("--update is only for ipynb files")
             action = " (destination file updated)"

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1,4 +1,5 @@
 import os
+from copy import deepcopy
 from shutil import copyfile
 
 import pytest
@@ -284,3 +285,20 @@ def test_pipe_black_uses_warn_only_781(
     # If black fails the notebook should be left unchanged
     actual = read("notebook.ipynb")
     compare_notebooks(actual, nb)
+
+
+def test_pipe_black_preserve_outputs(notebook_with_outputs, tmpdir, cwd_tmpdir, capsys):
+    write(notebook_with_outputs, "test.ipynb")
+    jupytext(["--pipe", "black", "test.ipynb"])
+
+    # Outputs are preserved
+    nb = read("test.ipynb")
+    expected = deepcopy(notebook_with_outputs)
+    expected.cells[0].source = "1 + 1"
+    compare_notebooks(nb, expected)
+
+    # No mention of --update
+    out, err = capsys.readouterr()
+    assert not err
+    assert "replaced" not in out
+    assert "--update" not in out


### PR DESCRIPTION
In Jupytext 1.11.3 the logs for `jupytext --pipe black test.ipynb` are
```
[jupytext] Reading test.ipynb in format ipynb
[jupytext] Executing black -
[jupytext] Writing test.ipynb (destination file replaced [use --update to preserve cell outputs and ids])
```
which wrongly suggest that outputs are lost.

This PR changes the log to just
```
[jupytext] Reading test.ipynb in format ipynb
[jupytext] Executing black -
[jupytext] Writing test.ipynb
```