### PR TITLE
Test that notebooks can be trusted (2)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - python>=3.6
-  - jupyterlab>=3.0
+  - jupyterlab>=3.0.13
   - nbformat>=5.1.2
   - jupyter-packaging
   - pyyaml

--- a/jupytext/contentsmanager.py
+++ b/jupytext/contentsmanager.py
@@ -343,15 +343,6 @@ def build_jupytext_contents_manager_class(base_contents_manager_class):
             if not outputs.timestamp:
                 set_kernelspec_from_language(model["content"])
 
-            # Trust code cells when they have no output
-            for cell in model["content"].cells:
-                if (
-                    cell.cell_type == "code"
-                    and not cell.outputs
-                    and cell.metadata.get("trusted") is False
-                ):
-                    cell.metadata["trusted"] = True
-
             return model
 
         def new_untitled(self, path="", type="", ext=""):

--- a/tests/test_trust_notebook.py
+++ b/tests/test_trust_notebook.py
@@ -143,3 +143,23 @@ def test_text_notebooks_can_be_trusted(nb_file, tmpdir, no_jupytext_version_numb
     model = cm.get(file)
     for cell in model["content"].cells:
         assert cell.metadata.get("trusted", True)
+
+
+def test_simple_notebook_is_trusted(tmpdir, python_notebook):
+    cm = TextFileContentsManager()
+    cm.root_dir = str(tmpdir)
+
+    nb = python_notebook
+    cm.notary.unsign(nb)
+
+    # All cells are trusted in this notebook
+    assert cm.notary.check_cells(nb)
+    # Yet the notebook is not in the database of trusted notebooks
+    assert not cm.notary.check_signature(nb)
+
+    # Save the notebook using the CM
+    cm.save(dict(type="notebook", content=nb), "test.ipynb")
+
+    # The notebook is safe so it should have been trusted before getting saved to disk
+    nb = cm.get("test.ipynb")["content"]
+    assert cm.notary.check_signature(nb)


### PR DESCRIPTION
This PR adds a test that a simple notebook can be trusted #797 .

Most of the problem with notebooks that cannot be trusted comes from using Jupyter Lab in a version prior to 3.0.13, in which cell ids were not available, so we recommend using a newer version for developing.