### PR TITLE
Implement support for configuration via pyproject.toml

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -34,7 +34,10 @@ list(global_jupytext_configuration_directories())
 ```
 which include `XDG_CONFIG_HOME` (defaults to `$HOME/.config`) and `XDG_CONFIG_DIR`.
 
-The name for the configuration file can be any of `jupytext.config.JUPYTEXT_CONFIG_FILES`, i.e. `.jupytext` (in TOML), `jupytext.toml`, `jupytext.yml`, `jupytext.yaml`, `jupytext.json` or `jupytext.py`, and their dot-file versions.
+The name for the configuration file can be any of `jupytext.config.JUPYTEXT_CONFIG_FILES`, i.e. `.jupytext` (in TOML),
+`jupytext.toml`, `jupytext.yml`, `jupytext.yaml`, `jupytext.json` or `jupytext.py`, and their dot-file versions.
+Alternatively, if you are using it, you can also use your Python project's `pyproject.toml` file by adding
+configuration to a `[tool.jupytext]` table within it.
 
 If you want to know, for a given directory, which configuration file Jupytext is using, please execute:
 ```python
@@ -81,6 +84,8 @@ or alternatively, using a dict to map the prefix path to the format name:
 "notebooks/" = "ipynb"
 "scripts/" = "py:percent"
 ```
+Note that if you are using a `pyproject.toml` file with this dict format, you should make sure the table header is instead `[tool.jupytext.formats]`
+
 The `root_prefix` is matched with the top-most parent folder of the matching name, not above the Jupytext configuration file.
 
 For instance, with the pairing above, a notebook with path `/home/user/jupyter/notebooks/project1/example.ipynb` will be paired with the Python file `/home/user/jupyter/scripts/project1/example.py`.

--- a/jupytext/contentsmanager.py
+++ b/jupytext/contentsmanager.py
@@ -18,6 +18,7 @@ import jupytext
 
 from .config import (
     JUPYTEXT_CONFIG_FILES,
+    PYPROJECT_FILE,
     JupytextConfiguration,
     JupytextConfigurationError,
     find_global_jupytext_configuration_file,
@@ -476,6 +477,10 @@ def build_jupytext_contents_manager_class(base_contents_manager_class):
                 path = directory + "/" + jupytext_config_file
                 if self.file_exists(path):
                     return path
+
+            pyproject_path = directory + "/" + PYPROJECT_FILE
+            if self.file_exists(pyproject_path):
+                return pyproject_path
 
             if not directory:
                 return None

--- a/tests/test_cm_config.py
+++ b/tests/test_cm_config.py
@@ -81,6 +81,7 @@ def test_pairing_through_config_leaves_ipynb_unmodified(tmpdir):
         ("jupytext.toml", "hide_notebook_metadata = False"),
         ("jupytext.toml", 'hide_notebook_metadata = "False"'),
         ("jupytext.toml", "not_a_jupytext_option = true"),
+        ("pyproject.toml", "[tool.jupytext]\nnot_a_jupytext_option = true"),
         ("jupytext.json", '{"notebook_metadata_filter":"-all",}'),
         (".jupytext.py", "c.not_a_jupytext_option = True"),
         (".jupytext.py", "c.hide_notebook_metadata = true"),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,6 +24,16 @@ def test_find_jupytext_configuration_file(tmpdir):
         find_jupytext_configuration_file(str(nested)), str(root_config)
     )
 
+    # Local pyproject file
+    pyproject_config = nested.join("pyproject.toml")
+    pyproject_config.write("[tool.jupytext]\n")
+    assert os.path.samefile(
+        find_jupytext_configuration_file(str(tmpdir)), str(root_config)
+    )
+    assert os.path.samefile(
+        find_jupytext_configuration_file(str(nested)), str(pyproject_config)
+    )
+
     # Local configuration file
     local_config = nested.join(".jupytext")
     local_config.write("\n")
@@ -49,12 +59,27 @@ def test_jupytext_py_is_not_a_configuration_file(tmpdir):
 
 @pytest.mark.parametrize(
     "config_file",
-    ["jupytext", "jupytext.toml", "jupytext.yml", "jupytext.json", "jupytext.py"],
+    [
+        "pyproject.toml",
+        "jupytext",
+        "jupytext.toml",
+        "jupytext.yml",
+        "jupytext.json",
+        "jupytext.py",
+    ],
 )
 def test_load_jupytext_configuration_file(tmpdir, config_file):
     full_config_path = tmpdir.join(config_file)
 
-    if config_file.endswith(("jupytext", ".toml")):
+    if config_file == "pyproject.toml":
+        full_config_path.write(
+            """[tool.jupytext]
+formats = "ipynb,py:percent"
+notebook_metadata_filter = "all"
+cell_metadata_filter = "all"
+"""
+        )
+    elif config_file.endswith(("jupytext", ".toml")):
         full_config_path.write(
             """formats = "ipynb,py:percent"
 notebook_metadata_filter = "all"


### PR DESCRIPTION
Resolves #828.

It's slightly annoying that it's necessary to open the `pyproject.toml` document twice - first to check if it has a valid `[tool.jupytext]` table in `find_jupytext_configuration_file`, and then again to parse it properly in `parse_jupytext_configuration_file`, but I think that rewriting this code to enable a single read would be significantly more complicated, and a rather premature optimisation.

Happy to take comments - hopefully the documentation changes read clearly enough.

And once this is done, I'll open a PR [here](https://github.com/carlosperate/awesome-pyproject) for you :)