### PR TITLE
Mark a test as requiring black

### DIFF
--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -287,6 +287,7 @@ def test_pipe_black_uses_warn_only_781(
     compare_notebooks(actual, nb)
 
 
+@requires_black
 def test_pipe_black_preserve_outputs(notebook_with_outputs, tmpdir, cwd_tmpdir, capsys):
     write(notebook_with_outputs, "test.ipynb")
     jupytext(["--pipe", "black", "test.ipynb"])


### PR DESCRIPTION
I hit this test failure in an environment where `black` was not installed. The other tests were skipped, but this last one was missing the `@requires_black` decorator.