### PR TITLE
Allow for markdown-it-py v2.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - jupyter-packaging
   - pyyaml
   - toml
-  - markdown-it-py~=1.0
+  - markdown-it-py>=1.0.0,<3.0.0
   - mdit-py-plugins
   - nbconvert
   - ipykernel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 nbformat
 pyyaml
 toml
-markdown-it-py~=1.0
+markdown-it-py>=1.0.0,<3.0.0
 mdit_py_plugins


### PR DESCRIPTION
This implements some internal changes, but won't affect jupytext
(see https://github.com/executablebooks/markdown-it-py/releases/tag/v2.0.0)