### PR TITLE
Open md links as notebooks (doc + Binder)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![CI](https://github.com/mwouts/jupytext/workflows/CI/badge.svg)
 [![Documentation Status](https://readthedocs.org/projects/jupytext/badge/?version=latest)](https://jupytext.readthedocs.io/en/latest/?badge=latest)
-[![codecov.io](https://codecov.io/github/mwouts/jupytext/coverage.svg?branch=master)](https://codecov.io/gh/mwouts/jupytext/branch/master)
+[![codecov.io](https://codecov.io/github/mwouts/jupytext/coverage.svg?branch=main)](https://codecov.io/gh/mwouts/jupytext/branch/main)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/mwouts/jupytext.svg)](https://lgtm.com/projects/g/mwouts/jupytext/context:python)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![GitHub language count](https://img.shields.io/github/languages/count/mwouts/jupytext)](docs/languages.md)
@@ -44,7 +44,7 @@ When Jupytext is installed, `.py` and `.md` files have a notebook icon. And you 
 <details>
   <summary>With a click on the text file in Jupyter Notebook</summary>
 
-[![](https://raw.githubusercontent.com/mwouts/jupytext-screenshots/master/JupytextDocumentation/TextNotebooks.png)](https://mybinder.org/v2/gh/mwouts/jupytext/main?filepath=demo)
+[![](https://raw.githubusercontent.com/mwouts/jupytext-screenshots/main/JupytextDocumentation/TextNotebooks.png)](https://mybinder.org/v2/gh/mwouts/jupytext/main?filepath=demo)
 (click on the image above to try this on [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/mwouts/jupytext/main?filepath=demo))
 </details>
 <details>
@@ -68,12 +68,12 @@ To do that, you will need to change the default viewer for text notebooks by cop
 
 Here is a screencast of the steps to follow:
 
-[![](https://raw.githubusercontent.com/mwouts/jupytext/main/docs/jupyterlab_default_viewer.gif)](https://mybinder.org/v2/gh/mwouts/jupytext/master?urlpath=lab/tree/demo/get_started.ipynb)
-(click on the image above to try this on [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/mwouts/jupytext/master?urlpath=lab/tree/demo/get_started.ipynb))
+[![](https://raw.githubusercontent.com/mwouts/jupytext/main/docs/jupyterlab_default_viewer.gif)](https://mybinder.org/v2/gh/mwouts/jupytext/main?urlpath=lab/tree/demo/get_started.ipynb)
+(click on the image above to try this on [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/mwouts/jupytext/main?urlpath=lab/tree/demo/get_started.ipynb))
 </details><details>
   <summary>With a right click and <i>open with notebook</i> in Jupyter Lab</summary>
 
-[![](https://raw.githubusercontent.com/mwouts/jupytext-screenshots/master/JupytextDocumentation/ContextMenuLab.png)](https://mybinder.org/v2/gh/mwouts/jupytext/main?urlpath=lab/tree/demo/get_started.ipynb)
+[![](https://raw.githubusercontent.com/mwouts/jupytext-screenshots/main/JupytextDocumentation/ContextMenuLab.png)](https://mybinder.org/v2/gh/mwouts/jupytext/main?urlpath=lab/tree/demo/get_started.ipynb)
 (click on the image above to try this on [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/mwouts/jupytext/main?urlpath=lab/tree/demo/get_started.ipynb))
 </details>
 </ul>

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,6 +1,9 @@
 # Stop everything if one command fails
 set -e
 
+# Install JupyterLab 4.O (pre)
+pip install 'jupyterlab>=4.0.0a16'
+
 # Install from sources
 # NB: If you want to use Jupytext on your binder, don't install it from source,
 # just add "jupytext" to your "binder/requirements.txt" instead.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,13 @@
 Jupytext ChangeLog
 ==================
 
+1.13.4-dev (2021-12-??)
+-----------------------
+
+**Fixed**
+- The parsing of notebooks that don't have a YAML header (like `docs/formats.md`) was improved.
+
+
 1.13.3 (2021-12-04)
 -------------------
 

--- a/jupytext/header.py
+++ b/jupytext/header.py
@@ -163,7 +163,8 @@ def header_to_metadata_and_cell(
 ):
     """
     Return the metadata, a boolean to indicate if a jupyter section was found,
-     the first cell of notebook if some metadata is found outside of the jupyter section, and next loc in text
+    the first cell of notebook if some metadata is found outside
+    the jupyter section, and next loc in text
     """
 
     header = []
@@ -224,6 +225,10 @@ def header_to_metadata_and_cell(
             ended = True
             if in_html_div:
                 continue
+            break
+
+        # Stop if there is something else than a YAML header
+        if not started and line.strip():
             break
 
         if _JUPYTER_RE.match(line):

--- a/jupytext/version.py
+++ b/jupytext/version.py
@@ -1,3 +1,3 @@
 """Jupytext's version number"""
 
-__version__ = "1.13.3"
+__version__ = "1.13.4-dev"

--- a/tests/test_doc_files_are_notebooks.py
+++ b/tests/test_doc_files_are_notebooks.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+import pytest
+
+from jupytext import read
+
+
+def documentation_files():
+    for path in (Path(__file__).parent.parent / "docs").iterdir():
+        if path.suffix == ".md":
+            yield path
+
+
+@pytest.mark.parametrize(
+    "doc_file",
+    documentation_files(),
+    ids=[doc_file.stem for doc_file in documentation_files()],
+)
+def test_doc_files_are_notebooks(doc_file):
+    nb = read(doc_file)
+
+    # count how many cell types
+    counts = {"markdown": 0, "raw": 0, "code": 0}
+    for cell in nb.cells:
+        counts[cell.cell_type] += 1
+
+    assert counts["raw"] <= 1

--- a/tests/test_read_empty_text_notebook.py
+++ b/tests/test_read_empty_text_notebook.py
@@ -8,7 +8,7 @@ from jupytext.myst import myst_extensions
 from .utils import is_myst_available, is_quarto_available
 
 
-@pytest.mark.parametrize("ext", set(NOTEBOOK_EXTENSIONS) - {".ipynb"})
+@pytest.mark.parametrize("ext", sorted(set(NOTEBOOK_EXTENSIONS) - {".ipynb"}))
 def test_read_empty_text_notebook(ext, tmp_path):
     if ext == ".qmd" and not is_quarto_available(min_version="0.2.0"):
         pytest.skip("quarto is not available")


### PR DESCRIPTION
The purpose of this PR is to document how to open links to .md files in notebooks as notebooks (will close #271)

A requirement is `jupyterlab>=4.0.0a16`, which I have added to Binder with this PR.

It might be the only one - at least, if I open the README.md at https://mybinder.org/v2/gh/mwouts/jupytext/open_md_links_as_notebooks_271 then the links seem to all open with the notebook viewer !

I am not 100% sure that anchors like `[MyST Markdown](docs/formats.md#myst-markdown)` work, but anyway in this example the rendering of the `formats.md` file as a notebook is not great - I'll investigate

- [x] Activate .md links as notebooks on Binder
- [ ] Explain how to do this in the documentation
- [x] `formats.md` should have cells of type Markdown, not raw
- [ ] Test links to an anchor 