### PR TITLE
Open links to md files as Notebooks in Jupyter Lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,17 @@ To do that, you will need to change the default viewer for text notebooks by cop
 }
 ```
 
-
 Here is a screencast of the steps to follow:
 
 [![](https://raw.githubusercontent.com/mwouts/jupytext/main/docs/jupyterlab_default_viewer.gif)](https://mybinder.org/v2/gh/mwouts/jupytext/main?urlpath=lab/tree/demo/get_started.ipynb)
 (click on the image above to try this on [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/mwouts/jupytext/main?urlpath=lab/tree/demo/get_started.ipynb))
+
+Another possibility is to activate this with a [default_setting_overrides.json](https://github.com/mwouts/jupytext/blob/main/binder/labconfig/default_setting_overrides.json) file in the `.jupyter/labconfig` folder with e.g.
+```
+wget https://raw.githubusercontent.com/mwouts/jupytext/main/binder/labconfig/default_setting_overrides.json -P  ~/.jupyter/labconfig/
+```
+
+Note: to open links to `.md` files in notebooks with the Notebook editor, use `jupyterlab>=4.0.0a16`.
 </details><details>
   <summary>With a right click and <i>open with notebook</i> in Jupyter Lab</summary>
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 Have you always wished Jupyter notebooks were plain text documents? Wished you could edit them in your favorite IDE? And get clear and meaningful diffs when doing version control? Then... Jupytext may well be the tool you're looking for!
 
 Jupytext is a plugin for Jupyter that can save Jupyter notebooks as either
-- Markdown files (or [MyST Markdown](docs/formats.md#myst-markdown) files, or [R Markdown](docs/formats.md#r-markdown) or [Quarto](docs/formats.md#quarto) text notebooks)
+- Markdown files (or [MyST Markdown](docs/formats.md#MyST-Markdown) files, or [R Markdown](docs/formats.md#R-Markdown) or [Quarto](docs/formats.md#Quarto) text notebooks)
 - Scripts in [many languages](docs/languages.md).
 
 ## Use cases
@@ -99,7 +99,7 @@ To pair a given `.ipynb` or text notebook to an additional notebook format, use 
 <details>
   <summary>the <i>"pair notebook with..."</i> menu entries in Jupyter Notebook</summary>
 
-[![](https://raw.githubusercontent.com/mwouts/jupytext/main/jupytext/nbextension/jupytext_menu.png)](docs/install.md#jupytext-menu-in-jupyter-notebook)
+[![](https://raw.githubusercontent.com/mwouts/jupytext/main/jupytext/nbextension/jupytext_menu.png)](docs/install.md#Jupytext-menu-in-Jupyter-Notebook)
 </details>
 
 <details>
@@ -109,7 +109,7 @@ with e.g.
 ```
 jupytext --set-formats ipynb,py:percent notebook.ipynb
 ```
-see the [documentation](docs/config.md#per-notebook-configuration).
+see the [documentation](docs/config.md#Per-notebook-configuration).
 </details>
 
 <details>
@@ -119,7 +119,7 @@ with e.g. the following content:
 ```
 formats = "ipynb,py:percent"
 ```
-see the [documentation](docs/config.md#configuring-paired-notebooks-globally).
+see the [documentation](docs/config.md#Configuring-paired-notebooks-globally).
 </details>
 </ul>
 
@@ -134,13 +134,13 @@ Alternatively, you can synchronise the two representations by running `jupytext 
 ## Which text format?
 
 Jupytext implements many text [formats](docs/formats.md) for Jupyter Notebooks. If your notebook is mostly made of code, you will probably prefer to save it as a script:
--  Use the [percent format](docs/formats.md#the-percent-format), a format with explicit cell delimiters (`# %%`), supported by many IDE (Spyder, Hydrogen, VS Code, PyCharm and PTVS)
--  Or use the [light format](docs/formats.md#the-light-format), if you prefer to see fewer cell markers.
+-  Use the [percent format](docs/formats.md#The-percent-format), a format with explicit cell delimiters (`# %%`), supported by many IDE (Spyder, Hydrogen, VS Code, PyCharm and PTVS)
+-  Or use the [light format](docs/formats.md#The-light-format), if you prefer to see fewer cell markers.
 
 If your notebook contains more text than code, if you are writing a documentation or a book, you probably want to save your notebook as a Markdown document
-- Use the [Jupytext Markdown format](docs/formats.md#jupytext-markdown) if you wish to render your notebook as a `.md` file (without its outputs) on GitHub
-- Use the [MyST Markdown format](docs/formats.md#myst-markdown), a markdown flavor that “implements the best parts of reStructuredText”, if you wish to render your notebooks using Sphinx or [Jupyter Book](https://jupyterbook.org).
-- Use the [R Markdown format](docs/formats.md#r-markdown) or the [Quarto format](docs/formats.md#quarto) if you want to open your Jupyter Notebooks in RStudio.
+- Use the [Jupytext Markdown format](docs/formats.md#Jupytext-Markdown) if you wish to render your notebook as a `.md` file (without its outputs) on GitHub
+- Use the [MyST Markdown format](docs/formats.md#MyST-Markdown), a markdown flavor that “implements the best parts of reStructuredText”, if you wish to render your notebooks using Sphinx or [Jupyter Book](https://jupyterbook.org).
+- Use the [R Markdown format](docs/formats.md#R-Markdown) or the [Quarto format](docs/formats.md#Quarto) if you want to open your Jupyter Notebooks in RStudio.
 
 ## More resources?
 

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,9 +1,6 @@
 # Stop everything if one command fails
 set -e
 
-# Install JupyterLab 4.O (pre)
-pip install 'jupyterlab>=4.0.0a16'
-
 # Install from sources
 # NB: If you want to use Jupytext on your binder, don't install it from source,
 # just add "jupytext" to your "binder/requirements.txt" instead.

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,4 +1,4 @@
-jupyterlab>=3.0
+jupyterlab>=4.0.0a16
 plotly
 matplotlib
 wordcloud

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,7 +22,7 @@ Jupytext ChangeLog
 
 **Changed**
 - The extension for Jupyter Lab benefited from a series of improvements contributed by [Frédéric Collonval](https://github.com/fcollonval):
-  - A new "Jupytext Notebook" factory offers the option to open text notebooks directly with the notebook view ([#803](https://github.com/mwouts/jupytext/issues/803)). To use it, follow the instructions in the [documentation](https://github.com/mwouts/jupytext/blob/main/docs/index.md#install).
+  - A new "Jupytext Notebook" factory offers the option to open text notebooks directly with the notebook view ([#803](https://github.com/mwouts/jupytext/issues/803)). To use it, follow the instructions in the [documentation](https://github.com/mwouts/jupytext/blob/main/docs/index.md#Install).
   - The ICommandPalette is optional, for compatibility with RISE within JupyterLab [RISE[#605](https://github.com/mwouts/jupytext/issues/605)](https://github.com/damianavila/RISE/pull/605)
   - Added support for translation
 - Branch `master` was renamed to `main` (links in the documentation were updated)

--- a/docs/config.md
+++ b/docs/config.md
@@ -13,7 +13,7 @@ You can pair a notebook to as many text representations as you want (see our _Wo
 where
 - `ext` is one of `ipynb`, `md`, `Rmd`, `jl`, `py`, `R`, `sh`, `cpp`, `q`. Use the `auto` extension to have the script extension chosen according to the Jupyter kernel.
 - `format_name` (optional) is either `light` (default for scripts), `nomarker`, `percent`, `hydrogen`, `sphinx` (Python only), `spin` (R only) &mdash; see the [format specifications](formats.md).
-- `root_folder`, `path`, `prefix` and `suffix` allow to save the text representation to files with different names, or in different folders (see the [configuration files examples](config.md#configuring-paired-notebooks-globally)).
+- `root_folder`, `path`, `prefix` and `suffix` allow to save the text representation to files with different names, or in different folders (see the [configuration files examples](config.md#Configuring-paired-notebooks-globally)).
 
 Jupytext accepts a few additional options. These options should be added to the `"jupytext"` section in the metadata &mdash; use either the metadata editor or the `--opt/--format-options` argument on the command line.
 - `comment_magics`: By default, Jupyter magics are commented when notebooks are exported to any other format than markdown. If you prefer otherwise, use this boolean option, or its global counterpart (see below).
@@ -53,7 +53,7 @@ If `JUPYTEXT_CEILING_DIRECTORIES` is defined, Jupytext will stop searching for c
 
 The examples below assume that you use a `.jupytext`, `jupytext.toml` or `.jupytext.toml` Jupyter configuration file in TOML format. If you use another extension, please adapt the examples. For instance, if you want to use `jupytext.yml` in YAML format, replace the `=` sign with `:` and remove the double quotes. See also [`test_config.py`](https://github.com/mwouts/jupytext/blob/main/tests/test_config.py) for short examples in all the supported formats.
 
-Also, the examples are for Jupytext 1.11.0 or later. If you are using an older version, you should consult the [previous version](https://github.com/mwouts/jupytext/blob/v1.10.3/docs/config.md#configuring-paired-notebooks-globally) of this documentation.
+Also, the examples are for Jupytext 1.11.0 or later. If you are using an older version, you should consult the [previous version](https://github.com/mwouts/jupytext/blob/v1.10.3/docs/config.md#Configuring-paired-notebooks-globally) of this documentation.
 
 Say you want to always associate every `.ipynb` notebook with a `.md` file  (and reciprocally). This is done by adding the following to your `jupytext.toml` or `.jupytext.toml` Jupyter configuration file:
 ```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -27,7 +27,7 @@ In the animation below we propose a quick demo of Jupytext. While the example re
 
 - We start with a Jupyter notebook.
 - The notebook includes a plot of the world population. The plot legend is not in order of decreasing population, we'll fix this.
-- We want the notebook to be saved as both a `.ipynb` and a `.py` file: we select _Pair Notebook with a light Script_ in either the [Jupytext menu](install.md#jupytext-menu-in-jupyter-notebook) in Jupyter Notebook, or in the [Jupytext commands](install.md#jupytext-commands-in-jupyterlab) in JupyterLab. This has the effect of adding a `"jupytext": {"formats": "ipynb,py:light"},` entry to the notebook metadata.
+- We want the notebook to be saved as both a `.ipynb` and a `.py` file: we select _Pair Notebook with a light Script_ in either the [Jupytext menu](install.md#Jupytext-menu-in-Jupyter-Notebook) in Jupyter Notebook, or in the [Jupytext commands](install.md#Jupytext-commands-in-JupyterLab) in JupyterLab. This has the effect of adding a `"jupytext": {"formats": "ipynb,py:light"},` entry to the notebook metadata.
 - The Python script can be opened with PyCharm:
   - Navigating in the code and documentation is easier than in Jupyter.
   - The console is convenient for quick tests. We don't need to create cells for this.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -10,7 +10,7 @@ The text representation only contains the part of the notebook that you wrote (n
 
 ## How do I use Jupytext?
 
-Open the notebook that you want to version control. _Pair_ the notebook to a script or a Markdown file using either the [Jupytext Menu](install.md#jupytext-menu-in-jupyter-notebook) in Jupyter Notebook or the [Jupytext Commands](install.md#jupytext-commands-in-jupyterlab) in JupyterLab.
+Open the notebook that you want to version control. _Pair_ the notebook to a script or a Markdown file using either the [Jupytext Menu](install.md#Jupytext-menu-in-Jupyter-Notebook) in Jupyter Notebook or the [Jupytext Commands](install.md#Jupytext-commands-in-JupyterLab) in JupyterLab.
 
 Save the notebook, and you get two copies of the notebook: the original `*.ipynb` file, together with its paired text representation.
 
@@ -71,7 +71,7 @@ jupytext --to md *.ipynb                         # convert all .ipynb files to .
 
 ## I want a specific cell to be commented out in the paired script
 
-That's possible! See how to [activate or deactivate cells](formats.md#active-and-inactive-cells).
+That's possible! See how to [activate or deactivate cells](formats.md#Active-and-inactive-cells).
 
 ## Which files should I version control?
 

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -26,11 +26,11 @@ jupyter:
 ```
 
 You can add custom notebook metadata like `author` or `title` under the `jupyter:` section, it will be synchronized with the notebook metadata.
-And if you wish to export more metadata from the notebook, have a look at the paragraph on [metadata filtering](#metadata-filtering).
+And if you wish to export more metadata from the notebook, have a look at the paragraph on [metadata filtering](config.md#Metadata-filtering).
 
 In the Markdown format, markdown cells are inserted verbatim and separated with two blank lines.
 
-If you'd like that cell breaks also occurs on Markdown headers, add a `split_at_heading: true` entry in the `jupytext` section in the YAML header, or if you want that option to be the default for all Markdown documents in Jupyter, activate the option in the [`jupytext.toml` configuration file](config.md#jupytext-configuration-file):
+If you'd like that cell breaks also occurs on Markdown headers, add a `split_at_heading: true` entry in the `jupytext` section in the YAML header, or if you want that option to be the default for all Markdown documents in Jupyter, activate the option in the [`jupytext.toml` configuration file](config.md#Jupytext-configuration-file):
 
 ```
 split_at_heading = true
@@ -219,7 +219,7 @@ or
 ```python
 cell_markers = "{{{,}}}"           # Use Vim region folding delimiters
 ```
-to your [`jupytext.toml` configuration file](config.md#jupytext-configuration-file).
+to your [`jupytext.toml` configuration file](config.md#Jupytext-configuration-file).
 
 See how our `World population.ipynb` notebook is [represented](https://github.com/mwouts/jupytext/blob/main/demo/World%20population.lgt.py) in that format.
 
@@ -287,7 +287,7 @@ If you want to use multiline comments for all your paired notebooks, you could a
 ```python
 cell_markers = '"""'
 ```
-to your [`jupytext.toml` configuration file](config.md#jupytext-configuration-file).
+to your [`jupytext.toml` configuration file](config.md#Jupytext-configuration-file).
 
 See how our `World population.ipynb` notebook is [represented](https://github.com/mwouts/jupytext/blob/main/demo/World%20population.pct.py) in the `percent` format.
 
@@ -303,7 +303,7 @@ Comments in Sphinx-Gallery scripts are formatted using reStructuredText rather t
 
 Turn a GitHub repository containing Sphinx-Gallery scripts into a live notebook repository with [Binder](https://mybinder.org/) and Jupytext by adding only two files to the repo:
 - `binder/requirements.txt`, a list of the required packages (including `jupytext`)
-- a [`jupytext.toml` configuration file](config.md#jupytext-configuration-file) with the following contents:
+- a [`jupytext.toml` configuration file](config.md#Jupytext-configuration-file) with the following contents:
 ```
 preferred_jupytext_formats_read = "py:sphinx"
 sphinx_convert_rst2md = true

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,11 +47,17 @@ To do that, you will need to change the default viewer for text notebooks by cop
 }
 ```
 
-
 Here is a screencast of the steps to follow:
 
 [![](https://raw.githubusercontent.com/mwouts/jupytext/main/docs/jupyterlab_default_viewer.gif)](https://mybinder.org/v2/gh/mwouts/jupytext/main?urlpath=lab/tree/demo/get_started.ipynb)
 (click on the image above to try this on [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/mwouts/jupytext/main?urlpath=lab/tree/demo/get_started.ipynb))
+
+Another possibility is to activate this with a [default_setting_overrides.json](https://github.com/mwouts/jupytext/blob/main/binder/labconfig/default_setting_overrides.json) file in the `.jupyter/labconfig` folder with e.g.
+```
+wget https://raw.githubusercontent.com/mwouts/jupytext/main/binder/labconfig/default_setting_overrides.json -P  ~/.jupyter/labconfig/
+```
+
+Note: to open links to `.md` files in notebooks with the Notebook editor, use `jupyterlab>=4.0.0a16`.
 </details>
 <details>
   <summary>With a right click and <i>open with notebook</i> in Jupyter Lab</summary>

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 Have you always wished Jupyter notebooks were plain text documents? Wished you could edit them in your favorite IDE? And get clear and meaningful diffs when doing version control? Then... Jupytext may well be the tool you're looking for!
 
 Jupytext is a plugin for Jupyter that can save Jupyter notebooks as either
-- Markdown files (or [MyST Markdown](formats.md#myst-markdown) files, or [R Markdown](formats.md#r-markdown) or [Quarto](formats.md#quarto) text notebooks)
+- Markdown files (or [MyST Markdown](formats.md#MyST-Markdown) files, or [R Markdown](formats.md#R-Markdown) or [Quarto](formats.md#Quarto) text notebooks)
 - Scripts in [many languages](languages.md).
 
 ## Use cases
@@ -76,13 +76,13 @@ To pair a given `.ipynb` or text notebook to an additional notebook format, use 
 <details>
   <summary>the <i>"pair notebook with..."</i> commands in Jupyter Lab</summary>
 
-[![](https://raw.githubusercontent.com/mwouts/jupytext/main/packages/labextension/jupytext_commands.png)](install.md#jupytext-commands-in-jupyterlab)
+[![](https://raw.githubusercontent.com/mwouts/jupytext/main/packages/labextension/jupytext_commands.png)](install.md#Jupytext-commands-in-JupyterLab)
 </details>
 
 <details>
   <summary>the <i>"pair notebook with..."</i> menu entries in Jupyter Notebook</summary>
 
-[![](https://raw.githubusercontent.com/mwouts/jupytext/main/jupytext/nbextension/jupytext_menu.png)](install.md#jupytext-menu-in-jupyter-notebook)
+[![](https://raw.githubusercontent.com/mwouts/jupytext/main/jupytext/nbextension/jupytext_menu.png)](install.md#Jupytext-menu-in-Jupyter-Notebook)
 </details>
 
 <details>
@@ -92,7 +92,7 @@ with e.g.
 ```
 jupytext --set-formats ipynb,py:percent notebook.ipynb
 ```
-see the [documentation](config.md#per-notebook-configuration).
+see the [documentation](config.md#Per-notebook-configuration).
 </details>
 
 <details>
@@ -102,7 +102,7 @@ with e.g. the following content:
 ```
 formats = "ipynb,py:percent"
 ```
-see the [documentation](config.md#configuring-paired-notebooks-globally).
+see the [documentation](config.md#Configuring-paired-notebooks-globally).
 </details>
 </ul>
 
@@ -117,13 +117,13 @@ Alternatively, you can synchronise the two representations by running `jupytext 
 ## Which text format?
 
 Jupytext implements many text [formats](formats.md) for Jupyter Notebooks. If your notebook is mostly made of code, you will probably prefer to save it as a script:
--  Use the [percent format](formats.md#the-percent-format), a format with explicit cell delimiters (`# %%`), supported by many IDE (Spyder, Hydrogen, VS Code, PyCharm and PTVS)
--  Or use the [light format](formats.md#the-light-format), if you prefer to see fewer cell markers.
+-  Use the [percent format](formats.md#The-percent-format), a format with explicit cell delimiters (`# %%`), supported by many IDE (Spyder, Hydrogen, VS Code, PyCharm and PTVS)
+-  Or use the [light format](formats.md#The-light-format), if you prefer to see fewer cell markers.
 
 If your notebook contains more text than code, if you are writing a documentation or a book, you probably want to save your notebook as a Markdown document
-- Use the [Jupytext Markdown format](formats.md#jupytext-markdown) if you wish to render your notebook as a `.md` file (without its outputs) on GitHub
-- Use the [MyST Markdown format](formats.md#myst-markdown), a markdown flavor that “implements the best parts of reStructuredText”, if you wish to render your notebooks using Sphinx or [Jupyter Book](https://jupyterbook.org).
-- Use the [R Markdown format](formats.md#r-markdown) or the [Quarto format](formats.md#quarto) if you want to open your Jupyter Notebooks in RStudio.
+- Use the [Jupytext Markdown format](formats.md#Jupytext-Markdown) if you wish to render your notebook as a `.md` file (without its outputs) on GitHub
+- Use the [MyST Markdown format](formats.md#MyST-Markdown), a markdown flavor that “implements the best parts of reStructuredText”, if you wish to render your notebooks using Sphinx or [Jupyter Book](https://jupyterbook.org).
+- Use the [R Markdown format](formats.md#R-Markdown) or the [Quarto format](formats.md#Quarto) if you want to open your Jupyter Notebooks in RStudio.
 
 ## More resources?
 

--- a/docs/paired-notebooks.md
+++ b/docs/paired-notebooks.md
@@ -4,11 +4,11 @@ Jupytext can write a given notebook to multiple files. In addition to the origin
 
 ## How to pair a notebook to multiple formats
 
-In Jupyter Notebook, pair your notebook to one or more text formats with the [Jupytext menu](install.md#jupytext-menu-in-jupyter-notebook):
+In Jupyter Notebook, pair your notebook to one or more text formats with the [Jupytext menu](install.md#Jupytext-menu-in-Jupyter-Notebook):
 
 ![](https://raw.githubusercontent.com/mwouts/jupytext/main/jupytext/nbextension/jupytext_menu.png)
 
-In JupyterLab, use the [Jupytext commands](install.md#jupytext-commands-in-jupyterlab):
+In JupyterLab, use the [Jupytext commands](install.md#Jupytext-commands-in-JupyterLab):
 
 ![](https://raw.githubusercontent.com/mwouts/jupytext/main/packages/labextension/jupytext_commands.png)
 
@@ -21,7 +21,7 @@ You can also configure the notebook pairing on the command line, and set a defau
 When saving a paired notebook using Jupytext's contents manager, Jupyter updates both the `.ipynb` and its text representation. The text representation can be edited outside of Jupyter. When the notebook is refreshed in Jupyter, the input cells are read from the text file, and the output cells from the `.ipynb` file.
 
 It is possible (and convenient) to leave the notebook open in Jupyter while you edit its text representation. However, you don't want the two editors to save the notebook simultaneously. To avoid this:
-- deactivate Jupyter's autosave, by either toggling the `"Autosave notebook"` menu entry or run `%autosave 0` in a cell of the notebook (see in the [faq](https://github.com/mwouts/jupytext/blob/main/docs/faq.md#jupyter-warns-me-that-the-file-has-changed-on-disk) how to deactivate autosave permanently)
+- deactivate Jupyter's autosave, by either toggling the `"Autosave notebook"` menu entry or run `%autosave 0` in a cell of the notebook (see in the [faq](https://github.com/mwouts/jupytext/blob/main/docs/faq.md#Jupyter-warns-me-that-the-file-has-changed-on-disk) how to deactivate autosave permanently)
 - and refresh the notebook when you switch back from the editor to Jupyter.
 
 In case you forgot to refresh, and saved the Jupyter notebook while the text representation had changed, no worries: Jupyter will ask you which version you want to keep:
@@ -32,7 +32,7 @@ When that occurs, please choose the version in which you made the latest changes
 
 ## How to open scripts with either the text or notebook view in Jupyter?
 
-With Jupytext's contents manager for Jupyter, scripts and Markdown documents gain a notebook icon. If you don't see the notebook icon, double check the [contents manager configuration](install.md#jupytexts-contents-manager).
+With Jupytext's contents manager for Jupyter, scripts and Markdown documents gain a notebook icon. If you don't see the notebook icon, double check the [contents manager configuration](install.md#Jupytexts-contents-manager).
 
 By default, Jupyter Notebook open scripts and Markdown documents as notebooks. If you want to open them with the text editor, select the document and click on _edit_:
 

--- a/docs/using-cli.md
+++ b/docs/using-cli.md
@@ -66,7 +66,7 @@ If you want to preserve (or filter out) certain notebook or cell metadata, chang
 jupytext --to md --update-metadata '{"jupytext": {"notebook_metadata_filter":"all"}}' notebook.ipynb
 ```
 
-Read more on the default and possible values for the metadata filters in [this section](config.md#metadata-filtering).
+Read more on the default and possible values for the metadata filters in [this section](config.md#Metadata-filtering).
 
 ## Testing the round-trip conversion
 
@@ -84,7 +84,7 @@ jupytext --test --update notebook.ipynb --to py:percent
 Note that `jupytext --test` compares the resulting notebooks according to its expectations. If you wish to proceed to a strict comparison of the two notebooks, use `jupytext --test-strict`, and use the flag `-x` to report with more details on the first difference, if any.
 
 Please note that
-- Scripts opened with Jupyter have a default [metadata filter](config.md#metadata-filtering) that prevents additional notebook or cell
+- Scripts opened with Jupyter have a default [metadata filter](config.md#Metadata-filtering) that prevents additional notebook or cell
 metadata to be added back to the script. Remove the filter if you want to store Jupytext's settings, or the kernel information, in the text file.
 - Cell metadata are available in the `light` and `percent` formats, as well as in the Markdown and R Markdown formats. R scripts in `spin` format support cell metadata for code cells only. Sphinx Gallery scripts in `sphinx` format do not support cell metadata.
-- By default, a few cell metadata are not included in the text representation of the notebook. And only the most standard notebook metadata are exported. Learn more on this in the sections for [notebook specific](config.md#per-notebook-configuration) and [global settings](config.md#metadata-filtering) for metadata filtering.
+- By default, a few cell metadata are not included in the text representation of the notebook. And only the most standard notebook metadata are exported. Learn more on this in the sections for [notebook specific](config.md#Per-notebook-configuration) and [global settings](config.md#Metadata-filtering) for metadata filtering.

--- a/packages/labextension/CHANGELOG.md
+++ b/packages/labextension/CHANGELOG.md
@@ -5,7 +5,7 @@
 # 1.3.7 (2021-11-30)
 
 The extension for Jupyter Lab benefited from a series of improvements contributed by [Frédéric Collonval](https://github.com/fcollonval):
-- A new "Jupytext Notebook" factory offers the option to open text notebooks directly with the notebook view (#803). To use it, follow the instructions in the [documentation](https://github.com/mwouts/jupytext/blob/main/docs/index.md#install).
+- A new "Jupytext Notebook" factory offers the option to open text notebooks directly with the notebook view (#803). To use it, follow the instructions in the [documentation](https://github.com/mwouts/jupytext/blob/main/docs/index.md#Install).
 - The ICommandPalette is optional, for compatibility with RISE within JupyterLab [RISE#605](https://github.com/damianavila/RISE/pull/605)
 - Added support for translation.
 

--- a/packages/labextension/README.md
+++ b/packages/labextension/README.md
@@ -11,7 +11,7 @@ Most users do not need to install this extension, since it is already included i
 
 ## Installation
 
-Please install [Jupytext](https://github.com/mwouts/jupytext/blob/main/README.md#installation) first. As mentioned above, both the `pip` and `conda` packages do include the latest version of the JupyterLab extension, so in most cases you don't need to specifically install this `npm` package.
+Please install [Jupytext](https://github.com/mwouts/jupytext/blob/main/README.md#Install) first. As mentioned above, both the `pip` and `conda` packages do include the latest version of the JupyterLab extension, so in most cases you don't need to specifically install this `npm` package.
 
 In case you're not using JupyterLab 3.x, you will have to install an older version of the extension that is compatible with your version. Please first install `jupytext` using `pip` or `conda`, and then downgrade the extension to a version compatible with your version of Jupyter Lab with:
 ```bash


### PR DESCRIPTION
Continuation of #889
Fix #271

TODO
- [x] Activate .md links as notebooks on Binder
- [x] Explain how to do this in the documentation
- [x] `formats.md` should have cells of type Markdown, not raw
- [x] Test links to an anchor 