### PR TITLE
Jupytext refuses to open a non-unicode file (api, cli & jupyter)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,13 @@
 Jupytext ChangeLog
 ==================
 
+1.13.5 (2021-12-27)
+-------------------
+
+**Fixed**
+- Jupytext refuses to open a text notebook that is not UTF-8 ([#896](https://github.com/mwouts/jupytext/issues/896))
+
+
 1.13.4 (2021-12-12)
 -------------------
 

--- a/jupytext/contentsmanager.py
+++ b/jupytext/contentsmanager.py
@@ -203,7 +203,7 @@ def build_jupytext_contents_manager_class(base_contents_manager_class):
             if ext == ".ipynb":
                 model = self.super.get(path, content, type="notebook", format=format)
             else:
-                model = self.super.get(path, content, type="file", format=format)
+                model = self.super.get(path, content, type="file", format="text")
                 model["type"] = "notebook"
                 if content:
                     # We may need to update these keys, inherited from text files formats

--- a/jupytext/version.py
+++ b/jupytext/version.py
@@ -1,3 +1,3 @@
 """Jupytext's version number"""
 
-__version__ = "1.13.4"
+__version__ = "1.13.5"

--- a/tests/invalid_file_896.md
+++ b/tests/invalid_file_896.md
@@ -1,0 +1,14 @@
+---
+jupytext:
+  formats: ipynb,md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.11.5
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+---
+Et voilà!

--- a/tests/test_invalid_file.py
+++ b/tests/test_invalid_file.py
@@ -1,0 +1,33 @@
+"""Jupytext should refuse to open a file with invalid content"""
+
+from pathlib import Path
+
+import pytest
+from tornado.web import HTTPError
+
+from jupytext import TextFileContentsManager, read
+from jupytext.cli import jupytext as jupytext_cli
+
+
+@pytest.fixture
+def invalid_md_file():
+    return Path(__file__).parent / "invalid_file_896.md"
+
+
+def test_read_invalid_md_file_fails(invalid_md_file):
+    with open(invalid_md_file) as fp:
+        with pytest.raises(UnicodeDecodeError):
+            read(fp)
+
+
+def test_convert_invalid_md_file_fails(invalid_md_file):
+    with pytest.raises(UnicodeDecodeError):
+        jupytext_cli(["--to", "ipynb", str(invalid_md_file)])
+
+
+def test_open_invalid_md_file_fails(invalid_md_file, tmp_path):
+    cm = TextFileContentsManager()
+    cm.root_dir = str(invalid_md_file.parent)
+
+    with pytest.raises(HTTPError, match="invalid_file_896.md is not UTF-8 encoded"):
+        cm.get(invalid_md_file.name)

--- a/tests/test_invalid_file.py
+++ b/tests/test_invalid_file.py
@@ -8,12 +8,15 @@ from tornado.web import HTTPError
 from jupytext import TextFileContentsManager, read
 from jupytext.cli import jupytext as jupytext_cli
 
+from .utils import skip_on_windows
+
 
 @pytest.fixture
 def invalid_md_file():
     return Path(__file__).parent / "invalid_file_896.md"
 
 
+@skip_on_windows
 def test_read_invalid_md_file_fails(invalid_md_file):
     with open(invalid_md_file) as fp:
         with pytest.raises(UnicodeDecodeError):


### PR DESCRIPTION
Fixes #896 