### PR TITLE
Fix `cat notebook.md | jupytext --execute`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ Jupytext ChangeLog
 
 **Fixed**
 - The Jupytext CLI only suggest --update when the target is an .ipynb file ([#905](https://github.com/mwouts/jupytext/issues/905)) - thanks to [st--](https://github.com/st--) for this contribution
+- We made sure that commands like `cat notebook.md | jupytext --execute` work ([#908](https://github.com/mwouts/jupytext/issues/908))
 
 **Added**
 - Added Haskell as supported language ([#909](https://github.com/mwouts/jupytext/issues/909)) - thanks to [codeweber](https://github.com/codeweber) for this contribution

--- a/jupytext/cli.py
+++ b/jupytext/cli.py
@@ -507,7 +507,7 @@ def jupytext_single_file(nb_file, args, log):
     nb_dest = None
     if args.output:
         nb_dest = args.output
-    elif args.output_format and nb_file == "-":
+    elif nb_file == "-":
         nb_dest = "-"
     else:
         try:

--- a/jupytext/jupytext.py
+++ b/jupytext/jupytext.py
@@ -395,6 +395,9 @@ def read(fp, as_version=nbformat.NO_CONVERT, fmt=None, config=None, **kwargs):
 
     if fp == "-":
         text = sys.stdin.read()
+        # Update the input format by reference if missing
+        if isinstance(fmt, dict) and not fmt:
+            fmt.update(long_form_one_format(divine_format(text)))
         return reads(text, fmt)
 
     if not hasattr(fp, "read"):


### PR DESCRIPTION
Closes #908 