### PR TITLE
Allow for markdown-it-py v2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup_args = dict(
         "nbformat",
         "pyyaml",
         "toml",
-        "markdown-it-py~=1.0",
+        "markdown-it-py>=1.0.0,<3.0.0",
         "mdit_py_plugins",
     ],
     python_requires="~=3.6",


### PR DESCRIPTION
Heya, I already did this in #885, but missed out updating this file.

When is `requirements.txt` actually used, as opposed to `install_requires`?