### PR TITLE
add Tcl as a supported language

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -28,5 +28,6 @@ Jupytext works with notebooks in any of the following languages:
 - Script of Script
 - TypeScript
 - Haskell
+- Tcl
 
 Extending Jupytext to more languages should be easy, see the sections on [contributing to](contributing.md) and [developing](developing.md) Jupytext.

--- a/jupytext/languages.py
+++ b/jupytext/languages.py
@@ -27,6 +27,7 @@ _JUPYTER_LANGUAGES = [
     "sql",
     "cython",
     "haskell",
+    "tcl",
 ]
 
 # Supported file extensions (and languages)
@@ -65,6 +66,7 @@ _SCRIPT_EXTENSIONS = {
         "comment_suffix": "*)",
     },  # OCaml only has block comments
     ".hs": {"language": "haskell", "comment": "--"},
+    ".tcl": {"language": "tcl", "comment": "#"},
 }
 
 _COMMENT_CHARS = [

--- a/tests/notebooks/ipynb_tcl/tcl_test.ipynb
+++ b/tests/notebooks/ipynb_tcl/tcl_test.ipynb
@@ -1,0 +1,86 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Assign Values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a = 1\n"
+     ]
+    }
+   ],
+   "source": [
+    "set a 1\n",
+    "puts \"a = $a\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Loop"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "I inside first loop: 0\n",
+      "I inside first loop: 1\n",
+      "I inside first loop: 2\n",
+      "I inside first loop: 3\n",
+      "I inside first loop: 4\n",
+      "I inside first loop: 5\n",
+      "I inside first loop: 6\n",
+      "I inside first loop: 7\n",
+      "I inside first loop: 8\n",
+      "I inside first loop: 9\n"
+     ]
+    }
+   ],
+   "source": [
+    "for {set i 0} {$i < 10} {incr i} {\n",
+    "    puts \"I inside first loop: $i\"\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Tcl",
+   "language": "tcl",
+   "name": "tcljupyter"
+  },
+  "language_info": {
+   "file_extension": ".tcl",
+   "mimetype": "txt/x-tcl",
+   "name": "tcl",
+   "version": "8.6.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tests/notebooks/mirror/ipynb_to_Rmd/tcl_test.Rmd
+++ b/tests/notebooks/mirror/ipynb_to_Rmd/tcl_test.Rmd
@@ -1,0 +1,26 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Tcl
+    language: tcl
+    name: tcljupyter
+---
+
+# Assign Values
+
+```{tcl}
+set a 1
+puts "a = $a"
+```
+
+# Loop
+
+```{tcl}
+for {set i 0} {$i < 10} {incr i} {
+    puts "I inside first loop: $i"
+}
+```
+
+```{tcl}
+
+```

--- a/tests/notebooks/mirror/ipynb_to_hydrogen/tcl_test.tcl
+++ b/tests/notebooks/mirror/ipynb_to_hydrogen/tcl_test.tcl
@@ -1,0 +1,24 @@
+# ---
+# jupyter:
+#   kernelspec:
+#     display_name: Tcl
+#     language: tcl
+#     name: tcljupyter
+# ---
+
+# %% [markdown]
+# # Assign Values
+
+# %%
+set a 1
+puts "a = $a"
+
+# %% [markdown]
+# # Loop
+
+# %%
+for {set i 0} {$i < 10} {incr i} {
+    puts "I inside first loop: $i"
+}
+
+# %%

--- a/tests/notebooks/mirror/ipynb_to_md/tcl_test.md
+++ b/tests/notebooks/mirror/ipynb_to_md/tcl_test.md
@@ -1,0 +1,26 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Tcl
+    language: tcl
+    name: tcljupyter
+---
+
+# Assign Values
+
+```tcl
+set a 1
+puts "a = $a"
+```
+
+# Loop
+
+```tcl
+for {set i 0} {$i < 10} {incr i} {
+    puts "I inside first loop: $i"
+}
+```
+
+```tcl
+
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/tcl_test.md
+++ b/tests/notebooks/mirror/ipynb_to_myst/tcl_test.md
@@ -1,0 +1,25 @@
+---
+kernelspec:
+  display_name: Tcl
+  language: tcl
+  name: tcljupyter
+---
+
+# Assign Values
+
+```{code-cell}
+set a 1
+puts "a = $a"
+```
+
+# Loop
+
+```{code-cell}
+for {set i 0} {$i < 10} {incr i} {
+    puts "I inside first loop: $i"
+}
+```
+
+```{code-cell}
+
+```

--- a/tests/notebooks/mirror/ipynb_to_percent/tcl_test.tcl
+++ b/tests/notebooks/mirror/ipynb_to_percent/tcl_test.tcl
@@ -1,0 +1,24 @@
+# ---
+# jupyter:
+#   kernelspec:
+#     display_name: Tcl
+#     language: tcl
+#     name: tcljupyter
+# ---
+
+# %% [markdown]
+# # Assign Values
+
+# %%
+set a 1
+puts "a = $a"
+
+# %% [markdown]
+# # Loop
+
+# %%
+for {set i 0} {$i < 10} {incr i} {
+    puts "I inside first loop: $i"
+}
+
+# %%

--- a/tests/notebooks/mirror/ipynb_to_script/tcl_test.tcl
+++ b/tests/notebooks/mirror/ipynb_to_script/tcl_test.tcl
@@ -1,0 +1,20 @@
+# ---
+# jupyter:
+#   kernelspec:
+#     display_name: Tcl
+#     language: tcl
+#     name: tcljupyter
+# ---
+
+# # Assign Values
+
+set a 1
+puts "a = $a"
+
+# # Loop
+
+for {set i 0} {$i < 10} {incr i} {
+    puts "I inside first loop: $i"
+}
+
+


### PR DESCRIPTION
- update languages.py.
- update docs/languages.md
- add tests/notebooks/ipynb_tcl

pytest results: 1 failed, 2592 passed, 147 skipped, 1 xfailed, 4 warnings

```
================================== FAILURES ===================================
_ test_identity_source_write_read[.\\jupytext\\t
ests\\.\\test_pre_commit_scripts.py] _

py_file = '.\\jupytext\\tests\\.\\test_pre_commi
t_scripts.py'

    @pytest.mark.parametrize(
        "py_file",
        [
            py_file
            for py_file in list_notebooks("../jupytext") + list_notebooks(".")
            if py_file.endswith(".py")
            if "folding_markers" not in py_file
        ],
    )
    def test_identity_source_write_read(py_file):
        with open(py_file) as fp:
>           py = fp.read()
E           UnicodeDecodeError: 'gbk' codec can't decode byte 0x80 in position 924
6: illegal multibyte sequence

.\jupytext\tests\test_read_all_py.py:20: UnicodeDec
odeError
============================== warnings summary ===============================
tests/test_cli.py::test_format_prefix_suffix
  [warning] You might have passed a file name to the '--to' option, when a format
description was expected. Maybe you want to use the '-o' option instead?

tests/test_cli.py::test_no_warning
tests/test_cli.py::test_jupytext_to_file_emits_a_warning
tests/test_cli.py::test_jupytext_set_formats_file_gives_an_informative_error
  [warning] Passing None has been deprecated.
  See https://docs.pytest.org/en/latest/how-to/capture-warnings.html#additional-us
e-cases-of-warnings-in-tests for alternatives in common use cases.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ===========================
FAILED tests/test_read_all_py.py::test_identity_source_write_read[.\\jupytext\\tests\\.\\test_pre_commit_scripts.py]
= 1 failed, 2592 passed, 147 skipped, 1 xfailed, 4 warnings in 117.73s (0:01:57) =
```