### PR TITLE
Import `LargeFileManager` from `jupyter_server` if available

### DIFF
--- a/jupytext/contentsmanager.py
+++ b/jupytext/contentsmanager.py
@@ -575,7 +575,12 @@ try:
 
     TextFileContentsManager = build_jupytext_contents_manager_class(LargeFileManager)
 except ImportError:
-    # Older versions of notebook do not have the LargeFileManager #217
-    from notebook.services.contents.filemanager import FileContentsManager
+    try:
+        # Older versions of notebook do not have the LargeFileManager #217
+        from notebook.services.contents.filemanager import FileContentsManager
 
-    TextFileContentsManager = build_jupytext_contents_manager_class(FileContentsManager)
+        TextFileContentsManager = build_jupytext_contents_manager_class(FileContentsManager)
+    except ImportError:
+        from jupyter_server.services.contents.largefilemanager import LargeFileManager
+
+        TextFileContentsManager = build_jupytext_contents_manager_class(LargeFileManager)


### PR DESCRIPTION
Attempt at fixing the issue noticed in https://github.com/jupyter/notebook/pull/6315#issuecomment-1073040427.

The next major version of Notebook (v7) will be based off JupyterLab components and will be running on a Jupyter Server:

This is already the case on the `main` branch in the Notebook repo: https://github.com/jupyter/notebook. The first pre-release is out so it can also be installed with `pip install --pre -U notebook`.

The new `notebook` package doesn't expose `LargeFileManager` since it relies on `jupyter_server` now. This PR proposes to support multiple cases of users:

- running Notebook v6 only (on the Classic Notebook Server)
- running JupyterLab (on Jupyter Server) only
- running Notebook v7 pre-release (on Jupyter Server)