### PR TITLE
Add "launch on renku" badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![pyversions](https://img.shields.io/pypi/pyversions/jupytext.svg)](https://pypi.python.org/pypi/jupytext)
 [![Binder:notebook](https://img.shields.io/badge/binder-notebook-0172B2.svg)](https://mybinder.org/v2/gh/mwouts/jupytext/main?filepath=demo)
 [![Binder:lab](https://img.shields.io/badge/binder-jupyterlab-0172B2.svg)](https://mybinder.org/v2/gh/mwouts/jupytext/main?urlpath=lab/tree/demo/get_started.ipynb)
+[![launch - renku](https://renkulab.io/renku-badge.svg)](https://renkulab.io/projects/best-practices/jupytext/sessions/new?autostart=1)
 [![](https://img.shields.io/badge/YouTube-JupyterCon%202020-red.svg)](https://www.youtube.com/watch?v=SDYdeVfMh48)
 
 Have you always wished Jupyter notebooks were plain text documents? Wished you could edit them in your favorite IDE? And get clear and meaningful diffs when doing version control? Then... Jupytext may well be the tool you're looking for!


### PR DESCRIPTION
This PR proposes to add a "launch on [renku](https://renkulab.io/)" badge to the README.

Like binder, renku provides interactive jupyter sessions for user to try notebooks and code examples.
In addition, renku sessions are tied to a gitlab repository, which logged in users can fork to modify the code and save their changes.

The badge starts a session from a [renku gitlab repository](https://renkulab.io/projects/best-practices/jupytext). When a session is started, it builds a docker image from the repository and gives you access to a jupyterlab interface. 

For this particular example, I have setup a gitlab repository which imports this repository as a git submodule. A Gitlab CI schedule  executed every week updates the submodule. In addition, a post-init hook automatically pulls demo notebooks from the latest commit on the master branch of this github repository whenever a session is started.