### PR TITLE
Update the hooks used in the documentation and tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,12 +45,12 @@ repos:
       args: ["--profile", "black"]
 
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
     - id: black
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.0
+    rev: v2.31.1
     hooks:
     - id: pyupgrade
       args: ["--py3-plus", "--py36-plus"]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ Jupytext ChangeLog
 **Changed**
 - The Jupytext contents manager is derived from the `LargeFileManager` imported from `jupyter_server` rathen than `notebook` ([#933](https://github.com/mwouts/jupytext/issues/933))
 - Allow for markdown-it-py v2 ([#924](https://github.com/mwouts/jupytext/issues/924))
+- We have updated the hooks used in the test pre-commits (#940, #942)
 
 
 1.13.7 (2022-02-09)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,7 @@ Jupytext ChangeLog
 **Changed**
 - The Jupytext contents manager is derived from the `LargeFileManager` imported from `jupyter_server` rathen than `notebook` ([#933](https://github.com/mwouts/jupytext/issues/933))
 - Allow for markdown-it-py v2 ([#924](https://github.com/mwouts/jupytext/issues/924))
-- We have updated the hooks used in the test pre-commits (#940, #942)
+- We have updated the hooks used in the test pre-commits, to fix an issue on the CI ([#940](https://github.com/mwouts/jupytext/issues/940), [#942](https://github.com/mwouts/jupytext/issues/942))
 
 
 1.13.7 (2022-02-09)

--- a/docs/using-pre-commit.md
+++ b/docs/using-pre-commit.md
@@ -5,7 +5,7 @@ Jupytext works well with the [pre-commit](https://pre-commit.com/) framework. Yo
 ```yaml
 repos:
 -   repo: https://github.com/mwouts/jupytext
-    rev: v1.10.0  # CURRENT_TAG/COMMIT_HASH
+    rev: v1.13.7  # CURRENT_TAG/COMMIT_HASH
     hooks:
     - id: jupytext
       args: [--sync]
@@ -16,7 +16,7 @@ You can provide almost all command line arguments to Jupytext in pre-commit, for
 ```yaml
 repos:
 -   repo: https://github.com/mwouts/jupytext
-    rev: v1.11.0  # CURRENT_TAG/COMMIT_HASH
+    rev: v1.13.7  # CURRENT_TAG/COMMIT_HASH
     hooks:
     - id: jupytext
       args: [--from, ipynb, --to, "py:percent"]
@@ -27,15 +27,15 @@ If you are combining Jupytext with other pre-commit hooks, you must ensure that 
 ```yaml
 repos:
 -   repo: https://github.com/mwouts/jupytext
-    rev: v1.11.0  # CURRENT_TAG/COMMIT_HASH
+    rev: v1.13.7  # CURRENT_TAG/COMMIT_HASH
     hooks:
     - id: jupytext
       args: [--sync, --pipe, black]
       additional_dependencies:
-        - black==20.8b1 # Matches hook
+        - black==22.3.0 # Matches hook
 
 -   repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
     - id: black
       language_version: python3

--- a/tests/test_pre_commit_2_sync_nbstripout.py
+++ b/tests/test_pre_commit_2_sync_nbstripout.py
@@ -31,7 +31,7 @@ repos:
     args: [--sync]
 
 - repo: https://github.com/kynan/nbstripout
-  rev: 0.3.9
+  rev: 0.5.0
   hooks:
   - id: nbstripout
 """

--- a/tests/test_pre_commit_3_sync_black_nbstripout.py
+++ b/tests/test_pre_commit_3_sync_black_nbstripout.py
@@ -29,15 +29,15 @@ repos:
   - id: jupytext
     args: [--sync, --pipe, black]
     additional_dependencies:
-    - black==20.8b1  # Matches hook
+    - black==22.3.0  # Matches hook
 
 - repo: https://github.com/psf/black
-  rev: 20.8b1
+  rev: 22.3.0
   hooks:
   - id: black
 
 - repo: https://github.com/kynan/nbstripout
-  rev: 0.3.9
+  rev: 0.5.0
   hooks:
   - id: nbstripout
 """

--- a/tests/test_pre_commit_5_reformat_markdown.py
+++ b/tests/test_pre_commit_5_reformat_markdown.py
@@ -42,11 +42,11 @@ repos:
   - id: jupytext
     args: [--sync, --pipe, black, --show-changes]
     additional_dependencies:
-    - black==20.8b1  # Matches black hook below
+    - black==22.3.0  # Matches black hook below
     - nbformat==5.0.8  # for compatibility with the pandoc hook above
 
 - repo: https://github.com/psf/black
-  rev: 20.8b1
+  rev: 22.3.0
   hooks:
   - id: black
 """


### PR DESCRIPTION
The CI is failing on the test `test_pre_commit_hook_sync_black_nbstripout`, see also #940 and #942

I cannot reproduce that error locally, so I am trying to update the hooks used by this test.

The details for the error are below:
```
    @skip_pre_commit_tests_on_windows
    @skip_pre_commit_tests_when_jupytext_folder_is_not_a_git_repo
    def test_pre_commit_hook_sync_black_nbstripout(
        tmpdir,
        cwd_tmpdir,
        tmp_repo,
        jupytext_repo_root,
        jupytext_repo_rev,
        notebook_with_outputs,
    ):
        """Here we sync the ipynb notebook with a py:percent file and also apply black and nbstripout."""
        pre_commit_config_yaml = f"""
    repos:
    - repo: {jupytext_repo_root}
      rev: {jupytext_repo_rev}
      hooks:
      - id: jupytext
        args: [--sync, --pipe, black]
        additional_dependencies:
        - black==20.8b1  # Matches hook
    
    - repo: https://github.com/psf/black
      rev: 20.8b1
      hooks:
      - id: black
    
    - repo: https://github.com/kynan/nbstripout
      rev: 0.3.9
      hooks:
      - id: nbstripout
    """
        tmpdir.join(".pre-commit-config.yaml").write(pre_commit_config_yaml)
    
        tmp_repo.git.add(".pre-commit-config.yaml")
        pre_commit(["install", "--install-hooks", "-f"])
    
        tmpdir.join(".jupytext.toml").write('formats = "ipynb,py:percent"')
        tmp_repo.git.add(".jupytext.toml")
        tmp_repo.index.commit("pair notebooks")
    
        # write a test notebook
        write(notebook_with_outputs, "test.ipynb")
    
        # try to commit it, should fail because
        # 1. the py version hasn't been added
        # 2. the first cell is '1+1' which is not black compliant
        # 3. the notebook has outputs
        tmp_repo.git.add("test.ipynb")
        with pytest.raises(
            HookExecutionError,
            match="files were modified by this hook",
        ):
            tmp_repo.index.commit("failing")
    
        # Add the two files
        tmp_repo.git.add("test.ipynb")
>       tmp_repo.git.add("test.py")
```

```
 >           raise GitCommandError(redacted_command, status, stderr_value, stdout_value)
E           git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
E             cmdline: git add test.py
E             stderr: 'fatal: pathspec 'test.py' did not match any files'
```