### PR TITLE
WIP Cell ids for text notebooks are deterministic

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@ Jupytext ChangeLog
 -------------------
 
 **Fixed**
+- Cell ids for text notebooks are deterministic (allowing one to trust text notebooks) ([#941](https://github.com/mwouts/jupytext/issues/941))
 - We made sure that our tests also work in absence of a Python kernel ([#906](https://github.com/mwouts/jupytext/issues/906))
 - The coverage of the `tests` folder has been restored at 100%
 - Bash commands like `!{cmd}` are now correctly escaped in the `py:percent` format ([#938](https://github.com/mwouts/jupytext/issues/938))

--- a/jupytext/cell_ids.py
+++ b/jupytext/cell_ids.py
@@ -1,0 +1,18 @@
+import hashlib
+import random
+import uuid
+
+
+def random_cell_id_with_fixed_seed(text):
+    """Returns a generator of cell ids that
+    takes the notebook source as the initial seed"""
+    m = hashlib.md5()
+    m.update(text.encode("utf-8"))
+
+    rd = random.Random()
+    rd.seed(m.hexdigest())
+
+    def cell_id():
+        return uuid.UUID(int=rd.getrandbits(128)).hex[:8]
+
+    return cell_id

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 import pytest
 from git import Repo
-from nbformat.v4 import nbbase
 from nbformat.v4.nbbase import (
     new_code_cell,
     new_markdown_cell,
@@ -91,17 +90,3 @@ def notebook_with_outputs():
             }
         },
     )
-
-
-"""To make sure that cell ids are distinct we use a global counter.
-    This solves https://github.com/mwouts/jupytext/issues/747"""
-global_cell_count = 0
-
-
-def generate_corpus_id():
-    global global_cell_count
-    global_cell_count += 1
-    return f"cell-{global_cell_count}"
-
-
-nbbase.random_cell_id = generate_corpus_id

--- a/tests/test_cell_id.py
+++ b/tests/test_cell_id.py
@@ -1,10 +1,25 @@
-from nbformat.v4.nbbase import new_code_cell
+import pytest
+
+from jupytext import reads
+from jupytext.compare import compare_notebooks
 
 
-def test_cell_id_is_not_random():
-    id1 = new_code_cell().id
-    id2 = new_code_cell().id
+@pytest.fixture()
+def text_notebook():
+    return """# %% [markdown]
+# Some text
 
-    n1 = int(id1.split("-")[1])
-    n2 = int(id2.split("-")[1])
-    assert n2 == n1 + 1
+# %%
+1 + 1
+"""
+
+
+def test_cell_ids_are_distinct(text_notebook):
+    nb = reads(text_notebook, "py:percent")
+    assert nb.cells[0].id != nb.cells[1].id
+
+
+def test_cell_ids_are_deterministic(text_notebook):
+    nb = reads(text_notebook, "py:percent")
+    nb2 = reads(text_notebook, "py:percent")
+    compare_notebooks(nb2, nb, compare_ids=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1321,6 +1321,7 @@ def test_jupytext_to_ipynb_suggests_update(tmpdir, cwd_tmpdir, capsys):
     capture = capsys.readouterr()
     assert "update" not in capture.out
 
+    tmpdir.join("test.py").write("2 + 2\n")
     jupytext(["--to", "ipynb", "test.py"])
     capture = capsys.readouterr()
     assert "update" in capture.out
@@ -1409,10 +1410,14 @@ def test_use_source_timestamp(tmpdir, cwd_tmpdir, python_notebook, capsys, forma
     cm.get("test.ipynb")
 
     # But now if we don't use --use-source-timestamp
+    test_ipynb.remove()
     jupytext(["--to", "ipynb", "test.py"])
+
+    # And restore the original timestamp of the py file
     os.utime(test_py, (src_timestamp, src_timestamp))
 
-    # Then we can't open paired notebooks
+    # Then ipynb is more recent than py
+    # and we can't open paired notebooks
     if formats == "ipynb,py":
         from tornado.web import HTTPError
 


### PR DESCRIPTION
This PR was initially motivated by #941, but in the end it has been superseded by #945 which is a way more direct solution.
Nevertheless the need for non-random cell ids on text documents may still be there, see e.g. #922