### PR TITLE
Text-only notebooks are always trusted

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@ Jupytext ChangeLog
 -------------------
 
 **Fixed**
+- Text-only notebooks are always trusted (as they don't include any output cells) ([#941](https://github.com/mwouts/jupytext/issues/941))
 - We made sure that our tests also work in absence of a Python kernel ([#906](https://github.com/mwouts/jupytext/issues/906))
 - The coverage of the `tests` folder has been restored at 100%
 - Bash commands like `!{cmd}` are now correctly escaped in the `py:percent` format ([#938](https://github.com/mwouts/jupytext/issues/938))

--- a/jupytext/contentsmanager.py
+++ b/jupytext/contentsmanager.py
@@ -217,6 +217,12 @@ def build_jupytext_contents_manager_class(base_contents_manager_class):
                         model["content"] = reads(
                             model["content"], fmt=fmt, config=config
                         )
+                        # mark all code cells from text notebooks as 'trusted'
+                        # as they don't have any outputs, cf. #941
+                        for cell in model["content"].cells:
+                            if cell.cell_type == "code":
+                                cell["metadata"]["trusted"] = True
+
                     except Exception as err:
                         self.log.error(
                             "Error while reading file: %s %s", path, err, exc_info=True

--- a/tests/test_trust_notebook.py
+++ b/tests/test_trust_notebook.py
@@ -7,7 +7,7 @@ from nbformat.v4.nbbase import new_code_cell, new_output
 from jupytext.compare import compare_notebooks
 from jupytext.contentsmanager import TextFileContentsManager
 
-from .utils import list_notebooks
+from .utils import list_notebooks, requires_myst
 
 
 @pytest.mark.parametrize("nb_file", list_notebooks("python"))
@@ -166,6 +166,7 @@ def test_simple_notebook_is_trusted(tmpdir, python_notebook):
     assert cm.notary.check_signature(nb)
 
 
+@requires_myst
 def test_myst_notebook_is_trusted_941(
     tmp_path,
     myst="""---
@@ -203,6 +204,7 @@ init_notebook_mode(all_interactive=True)
     assert cm.notary.check_cells(nb)
 
 
+@requires_myst
 def test_paired_notebook_with_outputs_is_not_trusted_941(tmp_path, python_notebook):
     cm = TextFileContentsManager()
     cm.root_dir = str(tmp_path)


### PR DESCRIPTION
(as they don't include any output cells)

Fixes #941 