### PR TITLE
Ignore non-coverage of (gone) exception

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1172,7 +1172,7 @@ def no_warning():
             "Passing a schema to Validator.iter_errors is deprecated "
             "and will be removed in a future release" in str(record.message)
         ):
-            continue
+            continue  # pragma: no cover
         raise RuntimeError(record)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1167,7 +1167,8 @@ def no_warning():
 
     # There should be no warning
     for record in records:
-        # Temporary exception for for this one, see #865
+        # Temporary exception for this one, see #865
+        # (does not seem to not occur anymore, as of April 2022, see #947)
         if (
             "Passing a schema to Validator.iter_errors is deprecated "
             "and will be removed in a future release" in str(record.message)


### PR DESCRIPTION
The exception/warning does not seem to occur any more on the CI, so the "continue" instruction is not covered.
Rather than dismissing the exception for this warning, I prefer to ignore the "continue" line in the coverage.