### PR TITLE
Do not override test.ipynb when doing 'jupytext --set-formats' on test.py

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,11 +1,14 @@
 Jupytext ChangeLog
 ==================
 
-1.13.9 (2022-06-30)
+1.13.9 (2022-07-??)
 -------------------
 
 **Changed**
 - Hidden configuration files like `.jupytext.toml` or `.jupytext.py` are now ignored by Jupytext's contents manager when `allow_hidden=False` (that option was introduced in `jupyter_server==2.0.0a1`) ([#964](https://github.com/mwouts/jupytext/issues/964)).
+
+**Changed**
+- `jupytext --set-formats ipynb,py test.py` will not override `test.ipynb` if the file exists already ([#969](https://github.com/mwouts/jupytext/issues/969)).
 
 
 1.13.8 (2022-04-04)

--- a/jupytext/cli.py
+++ b/jupytext/cli.py
@@ -629,27 +629,24 @@ def jupytext_single_file(nb_file, args, log):
 
         recursive_update(notebook.metadata, args.update_metadata)
 
-    # Read paired notebooks, except if the pair is being created
+    # Read paired notebooks
     nb_files = [nb_file, nb_dest]
     if args.sync:
         formats = notebook_formats(
             notebook, config, nb_file, fallback_on_current_fmt=False
         )
         set_prefix_and_suffix(fmt, formats, nb_file)
-        if args.set_formats is None:
-            try:
-                notebook, inputs_nb_file, outputs_nb_file = load_paired_notebook(
-                    notebook, fmt, config, formats, nb_file, log, args.pre_commit_mode
-                )
-                nb_files = [inputs_nb_file, outputs_nb_file]
-            except NotAPairedNotebook as err:
-                sys.stderr.write("[jupytext] Warning: " + str(err) + "\n")
-                return 0
-            except InconsistentVersions as err:
-                sys.stderr.write("[jupytext] Error: " + str(err) + "\n")
-                return 1
-        else:
-            nb_files = [nb_file]
+        try:
+            notebook, inputs_nb_file, outputs_nb_file = load_paired_notebook(
+                notebook, fmt, config, formats, nb_file, log, args.pre_commit_mode
+            )
+            nb_files = [inputs_nb_file, outputs_nb_file]
+        except NotAPairedNotebook as err:
+            sys.stderr.write("[jupytext] Warning: " + str(err) + "\n")
+            return 0
+        except InconsistentVersions as err:
+            sys.stderr.write("[jupytext] Error: " + str(err) + "\n")
+            return 1
 
     # II. ### Apply commands onto the notebook ###
     # Pipe the notebook into the desired commands

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,7 +76,7 @@ def notebook_with_outputs():
                 execution_count=1,
                 outputs=[
                     new_output(
-                        data={"text/plain": ["2"]},
+                        data={"text/plain": "2"},
                         execution_count=1,
                         output_type="execute_result",
                     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1459,3 +1459,24 @@ def test_set_shebang_with_update_metadata(tmp_path, python_notebook):
     )
 
     assert tmp_py.read_text().startswith("#!/usr/bin/python")
+
+
+@pytest.mark.parametrize("compare_ids", [False, True])
+@pytest.mark.parametrize("compare_outputs", [False, True])
+def test_set_formats_does_not_override_existing_ipynb(
+    tmp_path, notebook_with_outputs, compare_ids, compare_outputs
+):
+    tmp_py = tmp_path / "nb.py"
+    tmp_ipynb = tmp_path / "nb.ipynb"
+    write(notebook_with_outputs, tmp_ipynb)
+
+    jupytext([str(tmp_ipynb), "--set-formats", "ipynb,py:percent"])
+    jupytext([str(tmp_py), "--set-formats", "ipynb,py:percent"])
+
+    nb = read(tmp_ipynb)
+    compare_notebooks(
+        nb,
+        notebook_with_outputs,
+        compare_ids=compare_ids,
+        compare_outputs=compare_outputs,
+    )


### PR DESCRIPTION
Closes #969 