### PR TITLE
Add a new test that documents how to use the pre-commit hook with '--set-formats'

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,11 +1,14 @@
 Jupytext ChangeLog
 ==================
 
-1.13.9 (2022-06-30)
+1.13.9 (2022-07-??)
 -------------------
 
 **Changed**
 - Hidden configuration files like `.jupytext.toml` or `.jupytext.py` are now ignored by Jupytext's contents manager when `allow_hidden=False` (that option was introduced in `jupyter_server==2.0.0a1`) ([#964](https://github.com/mwouts/jupytext/issues/964)).
+
+**Changed**
+- `jupytext --set-formats ipynb,py test.py` will not override `test.ipynb` if the file exists already ([#969](https://github.com/mwouts/jupytext/issues/969)).
 
 
 1.13.8 (2022-04-04)

--- a/jupytext/cli.py
+++ b/jupytext/cli.py
@@ -629,27 +629,24 @@ def jupytext_single_file(nb_file, args, log):
 
         recursive_update(notebook.metadata, args.update_metadata)
 
-    # Read paired notebooks, except if the pair is being created
+    # Read paired notebooks
     nb_files = [nb_file, nb_dest]
     if args.sync:
         formats = notebook_formats(
             notebook, config, nb_file, fallback_on_current_fmt=False
         )
         set_prefix_and_suffix(fmt, formats, nb_file)
-        if args.set_formats is None:
-            try:
-                notebook, inputs_nb_file, outputs_nb_file = load_paired_notebook(
-                    notebook, fmt, config, formats, nb_file, log, args.pre_commit_mode
-                )
-                nb_files = [inputs_nb_file, outputs_nb_file]
-            except NotAPairedNotebook as err:
-                sys.stderr.write("[jupytext] Warning: " + str(err) + "\n")
-                return 0
-            except InconsistentVersions as err:
-                sys.stderr.write("[jupytext] Error: " + str(err) + "\n")
-                return 1
-        else:
-            nb_files = [nb_file]
+        try:
+            notebook, inputs_nb_file, outputs_nb_file = load_paired_notebook(
+                notebook, fmt, config, formats, nb_file, log, args.pre_commit_mode
+            )
+            nb_files = [inputs_nb_file, outputs_nb_file]
+        except NotAPairedNotebook as err:
+            sys.stderr.write("[jupytext] Warning: " + str(err) + "\n")
+            return 0
+        except InconsistentVersions as err:
+            sys.stderr.write("[jupytext] Error: " + str(err) + "\n")
+            return 1
 
     # II. ### Apply commands onto the notebook ###
     # Pipe the notebook into the desired commands

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,7 +76,7 @@ def notebook_with_outputs():
                 execution_count=1,
                 outputs=[
                     new_output(
-                        data={"text/plain": ["2"]},
+                        data={"text/plain": "2"},
                         execution_count=1,
                         output_type="execute_result",
                     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1459,3 +1459,24 @@ def test_set_shebang_with_update_metadata(tmp_path, python_notebook):
     )
 
     assert tmp_py.read_text().startswith("#!/usr/bin/python")
+
+
+@pytest.mark.parametrize("compare_ids", [False, True])
+@pytest.mark.parametrize("compare_outputs", [False, True])
+def test_set_formats_does_not_override_existing_ipynb(
+    tmp_path, notebook_with_outputs, compare_ids, compare_outputs
+):
+    tmp_py = tmp_path / "nb.py"
+    tmp_ipynb = tmp_path / "nb.ipynb"
+    write(notebook_with_outputs, tmp_ipynb)
+
+    jupytext([str(tmp_ipynb), "--set-formats", "ipynb,py:percent"])
+    jupytext([str(tmp_py), "--set-formats", "ipynb,py:percent"])
+
+    nb = read(tmp_ipynb)
+    compare_notebooks(
+        nb,
+        notebook_with_outputs,
+        compare_ids=compare_ids,
+        compare_outputs=compare_outputs,
+    )

--- a/tests/test_pre_commit_1_sync_with_no_config.py
+++ b/tests/test_pre_commit_1_sync_with_no_config.py
@@ -1,0 +1,95 @@
+from copy import deepcopy
+
+import pytest
+from git.exc import HookExecutionError
+from nbformat.v4.nbbase import new_markdown_cell
+from pre_commit.main import main as pre_commit
+
+import jupytext
+from jupytext import TextFileContentsManager
+from jupytext.compare import compare_notebooks
+
+from .utils import (
+    skip_pre_commit_tests_on_windows,
+    skip_pre_commit_tests_when_jupytext_folder_is_not_a_git_repo,
+)
+
+
+@skip_pre_commit_tests_on_windows
+@skip_pre_commit_tests_when_jupytext_folder_is_not_a_git_repo
+def test_pre_commit_hook_sync_with_no_config(
+    tmpdir,
+    cwd_tmpdir,
+    tmp_repo,
+    jupytext_repo_root,
+    jupytext_repo_rev,
+    notebook_with_outputs,
+):
+    """In this test we reproduce the setting from https://github.com/mwouts/jupytext/issues/967"""
+    pre_commit_config_yaml = f"""
+repos:
+- repo: {jupytext_repo_root}
+  rev: {jupytext_repo_rev}
+  hooks:
+  - id: jupytext
+    args: [
+      '--sync',
+      '--set-formats',
+      'ipynb,py:percent',
+      '--show-changes',
+      '--'
+    ]
+    files: ^notebooks/
+"""
+    # Save a sample notebook with outputs in Jupyter
+    nb = deepcopy(notebook_with_outputs)
+    (tmpdir / "notebooks").mkdir()
+    cm = TextFileContentsManager()
+    cm.root_dir = str(tmpdir)
+    cm.save(dict(type="notebook", content=nb), "notebooks/nb.ipynb")
+
+    # Add it to git
+    tmp_repo.git.add("notebooks/nb.ipynb")
+    tmp_repo.index.commit("Notebook with outputs")
+
+    # Configure the pre-commit hook
+    tmpdir.join(".pre-commit-config.yaml").write(pre_commit_config_yaml)
+    tmp_repo.git.add(".pre-commit-config.yaml")
+    pre_commit(["install", "--install-hooks", "-f"])
+
+    # Modify and save the notebook
+    nb.cells.append(new_markdown_cell("New markdown cell"))
+    cm.save(dict(type="notebook", content=nb), "notebooks/nb.ipynb")
+
+    # No .py file at the moment
+    assert not (tmpdir / "notebooks" / "nb.py").exists()
+
+    # try to commit it, should fail as the py version hasn't been added
+    tmp_repo.git.add("notebooks/nb.ipynb")
+    with pytest.raises(
+        HookExecutionError,
+        match="git add notebooks/nb.py",
+    ):
+        tmp_repo.index.commit("failing")
+
+    # Now the .py file is present
+    assert "New markdown cell" in tmpdir.join("notebooks/nb.py").read()
+
+    # add the ipynb and the py file, now the commit will succeed
+    tmp_repo.git.add("notebooks/nb.ipynb")
+    tmp_repo.git.add("notebooks/nb.py")
+    tmp_repo.index.commit("passing")
+    assert "notebooks/nb.ipynb" in tmp_repo.tree()
+    assert "notebooks/nb.py" in tmp_repo.tree()
+
+    # The notebook on disk is the same as the original, except for the new cell added
+    nb = jupytext.read(tmpdir / "notebooks" / "nb.ipynb")
+    extra_cell = nb.cells.pop()
+    assert extra_cell.cell_type == "markdown"
+    assert extra_cell.source == "New markdown cell"
+    compare_notebooks(
+        nb,
+        notebook_with_outputs,
+        compare_ids=True,
+        compare_outputs=True,
+    )

--- a/tests/test_pre_commit_1_sync_with_no_config.py
+++ b/tests/test_pre_commit_1_sync_with_no_config.py
@@ -39,17 +39,17 @@ repos:
       '--show-changes',
       '--'
     ]
-    files: ^notebooks/
+    files: \\.ipynb$
 """
     # Save a sample notebook with outputs in Jupyter
     nb = deepcopy(notebook_with_outputs)
     (tmpdir / "notebooks").mkdir()
     cm = TextFileContentsManager()
     cm.root_dir = str(tmpdir)
-    cm.save(dict(type="notebook", content=nb), "notebooks/nb.ipynb")
+    cm.save(dict(type="notebook", content=nb), "nb.ipynb")
 
     # Add it to git
-    tmp_repo.git.add("notebooks/nb.ipynb")
+    tmp_repo.git.add("nb.ipynb")
     tmp_repo.index.commit("Notebook with outputs")
 
     # Configure the pre-commit hook
@@ -59,31 +59,31 @@ repos:
 
     # Modify and save the notebook
     nb.cells.append(new_markdown_cell("New markdown cell"))
-    cm.save(dict(type="notebook", content=nb), "notebooks/nb.ipynb")
+    cm.save(dict(type="notebook", content=nb), "nb.ipynb")
 
     # No .py file at the moment
-    assert not (tmpdir / "notebooks" / "nb.py").exists()
+    assert not (tmpdir / "nb.py").exists()
 
     # try to commit it, should fail as the py version hasn't been added
-    tmp_repo.git.add("notebooks/nb.ipynb")
+    tmp_repo.git.add("nb.ipynb")
     with pytest.raises(
         HookExecutionError,
-        match="git add notebooks/nb.py",
+        match="git add nb.py",
     ):
         tmp_repo.index.commit("failing")
 
     # Now the .py file is present
-    assert "New markdown cell" in tmpdir.join("notebooks/nb.py").read()
+    assert "New markdown cell" in tmpdir.join("nb.py").read()
 
     # add the ipynb and the py file, now the commit will succeed
-    tmp_repo.git.add("notebooks/nb.ipynb")
-    tmp_repo.git.add("notebooks/nb.py")
+    tmp_repo.git.add("nb.ipynb")
+    tmp_repo.git.add("nb.py")
     tmp_repo.index.commit("passing")
-    assert "notebooks/nb.ipynb" in tmp_repo.tree()
-    assert "notebooks/nb.py" in tmp_repo.tree()
+    assert "nb.ipynb" in tmp_repo.tree()
+    assert "nb.py" in tmp_repo.tree()
 
     # The notebook on disk is the same as the original, except for the new cell added
-    nb = jupytext.read(tmpdir / "notebooks" / "nb.ipynb")
+    nb = jupytext.read(tmpdir / "nb.ipynb")
     extra_cell = nb.cells.pop()
     assert extra_cell.cell_type == "markdown"
     assert extra_cell.source == "New markdown cell"

--- a/tests/test_pre_commit_1_sync_with_no_config.py
+++ b/tests/test_pre_commit_1_sync_with_no_config.py
@@ -39,7 +39,6 @@ repos:
       '--show-changes',
       '--'
     ]
-    files: \\.ipynb$
 """
     # Save a sample notebook with outputs in Jupyter
     nb = deepcopy(notebook_with_outputs)


### PR DESCRIPTION
The test works without filtering on `.ipynb` files thanks to the resolution of #969 that has been integrated in this branch.

Closes #967 .