### PR TITLE
New ignore argument & config option

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,16 @@
 Jupytext ChangeLog
 ==================
 
+1.14.2 (2022-07-??)
+-------------------
+
+**Added**
+- New `ignore` option for both the command line version of `jupytext` and the configuration files. The value of `ignore` can be a glob or a list of glob expressions ([#986](https://github.com/mwouts/jupytext/issues/986))
+
+**Changed**
+- `jupytext --sync` won't issue a warning when an unpaired file is passed as an argument (except if no paired file is found at all) ([#986](https://github.com/mwouts/jupytext/issues/986))
+
+
 1.14.1 (2022-07-29)
 -------------------
 

--- a/jupytext/cli.py
+++ b/jupytext/cli.py
@@ -4,6 +4,7 @@ import argparse
 import glob
 import json
 import os
+import pathlib
 import re
 import shlex
 import subprocess
@@ -38,6 +39,10 @@ from .paired_paths import (
 )
 from .pairs import latest_inputs_and_outputs, read_pair, write_pair
 from .version import __version__
+
+
+class IgnoredFile(ValueError):
+    pass
 
 
 def system(*args, **kwargs):
@@ -75,6 +80,12 @@ def parse_jupytext_args(args=None):
         "notebooks",
         help="One or more notebook(s). "
         "Notebook is read from stdin when this argument is empty.",
+        nargs="*",
+    )
+    parser.add_argument(
+        "--ignore",
+        "-i",
+        help="One or more glob that should be ignored",
         nargs="*",
     )
     parser.add_argument(
@@ -484,23 +495,30 @@ def jupytext(args=None):
     # Count how many file have round-trip issues when testing
     exit_code = 0
     unpaired_files = []
+    ignored_files = []
     for nb_file in notebooks:
         if not args.warn_only:
             try:
                 exit_code += jupytext_single_file(nb_file, args, log)
+            except IgnoredFile:
+                ignored_files.append(nb_file)
             except NotAPairedNotebook:
                 log(f"[jupytext] {nb_file} is not a paired notebook")
                 unpaired_files.append(nb_file)
         else:
             try:
                 exit_code += jupytext_single_file(nb_file, args, log)
+            except IgnoredFile:
+                ignored_files.append(nb_file)
             except NotAPairedNotebook:
                 log(f"[jupytext] {nb_file} is not a paired notebook")
                 unpaired_files.append(nb_file)
             except Exception as err:
                 sys.stderr.write(f"[jupytext] Error: {str(err)}\n")
 
-    if len(unpaired_files) == len(notebooks):
+    if len(ignored_files) == len(notebooks):
+        sys.stderr.write("Warning: all input files were ignored\n")
+    elif len(unpaired_files) + len(ignored_files) == len(notebooks):
         sys.stderr.write(
             f"[jupytext] Warning: no paired file was found among {unpaired_files}\n"
         )
@@ -538,6 +556,20 @@ def jupytext_single_file(nb_file, args, log):
             nb_dest = full_path(bp, args.output_format)
 
     config = load_jupytext_config(os.path.abspath(nb_file))
+
+    for pattern in args.ignore or config.ignore:
+        if "*" in pattern or "?" in pattern:
+            ignored_files = glob.glob(pattern, recursive=True)
+        else:
+            ignored_files = pattern
+
+        nb_file_path = pathlib.Path(nb_file)
+        for ignored in ignored_files:
+            if (
+                nb_file_path.exists() and nb_file_path.samefile(ignored)
+            ) or nb_file_path == ignored:
+                log(f"[jupytext] Ignoring {nb_file}")
+                raise IgnoredFile()
 
     # Just acting on metadata / pipe => save in place
     save_in_place = not nb_dest and not args.sync

--- a/jupytext/config.py
+++ b/jupytext/config.py
@@ -54,6 +54,13 @@ class JupytextConfiguration(Configurable):
         "documentation at https://jupytext.readthedocs.io/en/latest/config.html",
         config=True,
     )
+
+    ignore = List(
+        Unicode(),
+        help="A list of glob patterns. Any file among these patterns will be ignored.",
+        config=True,
+    )
+
     default_jupytext_formats = Unicode(
         help="Deprecated. Use 'formats' instead", config=True
     )

--- a/jupytext/config.py
+++ b/jupytext/config.py
@@ -47,12 +47,11 @@ class JupytextConfiguration(Configurable):
 
     formats = Union(
         [Unicode(), List(Unicode()), Dict(Unicode())],
-        help="Save notebooks to these file extensions. "
-        "Can be any of ipynb,Rmd,md,jl,py,R,nb.jl,nb.py,nb.R "
-        "comma separated. If you want another format than the "
-        "default one, append the format name to the extension, "
-        "e.g. ipynb,py:percent to save the notebook to "
-        "hydrogen/spyder/vscode compatible scripts",
+        help="The formats to which notebooks should be saved - a coma separated list."
+        "Use ipynb,py:percent to pair ipynb notebooks to py files in the percent format,"
+        "ipynb,md,auto:percent to pair ipynb notebooks to both md files and scripts in "
+        "the percent format. The option also accept file prefix and suffix, see the full"
+        "documentation at https://jupytext.readthedocs.io/en/latest/config.html",
         config=True,
     )
     default_jupytext_formats = Unicode(

--- a/jupytext/version.py
+++ b/jupytext/version.py
@@ -1,3 +1,3 @@
 """Jupytext's version number"""
 
-__version__ = "1.14.1"
+__version__ = "1.14.2-dev"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import unittest.mock as mock
 from pathlib import Path
 
@@ -41,8 +42,12 @@ def cwd_tmpdir(tmpdir):
 @pytest.fixture()
 def cwd_tmp_path(tmp_path):
     # Run the whole test from inside tmp_path
-    with tmp_path.cwd():
-        yield tmp_path
+    prev_cwd = Path.cwd()
+    os.chdir(tmp_path)
+    try:
+        yield
+    finally:
+        os.chdir(prev_cwd)
 
 
 @pytest.fixture

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -517,7 +517,7 @@ def test_sync(nb_file, tmpdir, cwd_tmpdir, capsys):
     # Test that sync issues a warning when the notebook is not paired
     jupytext(["--sync", tmp_ipynb])
     _, err = capsys.readouterr()
-    assert "is not a paired notebook" in err
+    assert "no paired file was found" in err
 
     # Now with a pairing information
     nb.metadata.setdefault("jupytext", {})["formats"] = "py,Rmd,ipynb"
@@ -570,7 +570,7 @@ def test_sync_pandoc(nb_file, tmpdir, cwd_tmpdir, capsys):
     # Test that sync issues a warning when the notebook is not paired
     jupytext(["--sync", tmp_ipynb])
     _, err = capsys.readouterr()
-    assert "is not a paired notebook" in err
+    assert "no paired file was found" in err
 
     # Now with a pairing information
     nb.metadata.setdefault("jupytext", {})["formats"] = "ipynb,md:pandoc"

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -1,0 +1,59 @@
+import pytest
+
+from jupytext import TextFileContentsManager
+from jupytext.cli import jupytext
+
+
+def test_ignore_works_on_a_non_existing_file(tmp_path, cwd_tmp_path, capsys):
+    jupytext(["test.py", "--to", "ipynb", "--ignore", "test*.py"])
+
+
+def test_warning_when_all_files_ignored(tmp_path, cwd_tmp_path, capsys):
+    (tmp_path / "test.py").write_text("# to be ignored\n")
+    jupytext(["test.py", "--to", "ipynb", "--ignore", "test*.py"])
+    _, err = capsys.readouterr()
+    assert "Warning: all input files were ignored" in err
+
+    jupytext(["test.py", "--set-formats", "ipynb,py:percent", "--ignore", "test*.py"])
+    _, err = capsys.readouterr()
+    assert "Warning: all input files were ignored" in err
+
+
+@pytest.mark.parametrize(
+    "command", [["--to", "ipynb"], ["--set-formats", "ipynb,py:percent"]]
+)
+def test_ignored_files_are_ignored_at_the_cli(tmp_path, cwd_tmp_path, command):
+    (tmp_path / "nb.py").write_text("# %%\n1 + 1\n")
+    (tmp_path / "test.py").write_text("# to be ignored\n")
+
+    jupytext(["nb.py", "test.py", "--ignore", "test*.py"] + command)
+    assert (tmp_path / "nb.ipynb").exists()
+    assert not (tmp_path / "test.ipynb").exists()
+
+
+@pytest.mark.parametrize(
+    "command", [["--to", "ipynb"], ["--set-formats", "ipynb,py:percent"]]
+)
+def test_ignore_files_through_config(tmp_path, cwd_tmp_path, command):
+    (tmp_path / "jupytext.toml").write_text('ignore = ["test*.py"]')
+    (tmp_path / "nb.py").write_text("# %%\n1 + 1\n")
+    (tmp_path / "test.py").write_text("# to be ignored\n")
+
+    jupytext(["nb.py", "test.py"] + command)
+    assert (tmp_path / "nb.ipynb").exists()
+    assert not (tmp_path / "test.ipynb").exists()
+
+
+def test_ignored_files_are_not_notebooks(tmp_path, cwd_tmp_path):
+    (tmp_path / "jupytext.toml").write_text('ignore = ["test*.py"]')
+    (tmp_path / "nb.py").write_text("# %%\n1 + 1\n")
+    (tmp_path / "test.py").write_text("# to be ignored\n")
+
+    cm = TextFileContentsManager()
+    cm.root_dir = str(tmp_path)
+
+    model = cm.get("nb.py")
+    assert model["type"] == "notebook"
+
+    model = cm.get("test.py")
+    assert model["type"] == "text"


### PR DESCRIPTION
Closes #986
Closes #974 

TODO
- [ ] Find a more efficient way to determine if `nb_file` matches a glob than listing all the files in the glob
- [ ] We want the method to work also when `nb_file` does not exists!
- [ ] Find out how to do so in the context of the contents manager (path separator is always `/`, and there might be no underlying file system)