### PR TITLE
Add support for Wolfram Language

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -30,5 +30,7 @@ Jupytext works with notebooks in any of the following languages:
 - TypeScript
 - Haskell
 - Tcl
+- Wolfram Language
+  - Note that Jupytext uses the non-standard `.wolfram` file extension for Wolfram Language files to avoid conflicts with Matlab.
 
 Extending Jupytext to more languages should be easy, see the sections on [contributing to](contributing.md) and [developing](developing.md) Jupytext.

--- a/jupytext/cell_metadata.py
+++ b/jupytext/cell_metadata.py
@@ -256,6 +256,10 @@ def parse_rmd_options(line):
 def rmd_options_to_metadata(options, use_runtools=False):
     """Parse rmd options and return a metadata dictionary"""
     options = re.split(r"\s|,", options, 1)
+    # Special case Wolfram Language, which sadly has a space in the language
+    # name.
+    if options[0:2] == ["wolfram", "language"]:
+        options[0:2] = ["wolfram language"]
     if len(options) == 1:
         language = options[0]
         chunk_options = []

--- a/jupytext/languages.py
+++ b/jupytext/languages.py
@@ -29,6 +29,7 @@ _JUPYTER_LANGUAGES = [
     "haskell",
     "tcl",
     "gnuplot",
+    "wolfram language",
 ]
 
 # Supported file extensions (and languages)
@@ -47,6 +48,14 @@ _SCRIPT_EXTENSIONS = {
     ".ps1": {"language": "powershell", "comment": "#"},
     ".q": {"language": "q", "comment": "/"},
     ".m": {"language": "matlab", "comment": "%"},
+    # Unfortunately, Wolfram Mathematica also uses the .m extension which
+    # conflicts with Matlab. To work around this problem we arbitrarily use a
+    # made-up .wolfram extension.
+    ".wolfram": {
+        "language": "wolfram language",
+        "comment": "(*",
+        "comment_suffix": "*)",
+    },
     ".pro": {"language": "idl", "comment": ";"},
     ".js": {"language": "javascript", "comment": "//"},
     ".ts": {"language": "typescript", "comment": "//"},

--- a/tests/notebooks/ipynb_wolfram/wolfram.ipynb
+++ b/tests/notebooks/ipynb_wolfram/wolfram.ipynb
@@ -1,0 +1,122 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f48fe6fa",
+   "metadata": {},
+   "source": [
+    "**Note:** The `language_info` `file_extension` in this notebook should be `.m`, but it was deliberately changed to `.wolfram` to avoid conflicts with Matlab which is using the same extension."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19ffc137",
+   "metadata": {},
+   "source": [
+    "We start with..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17c5b20c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Print[\"Hello, World!\"];"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b9e8c46",
+   "metadata": {},
+   "source": [
+    "Then we draw the first example plot from the [ListPlot](https://reference.wolfram.com/language/ref/ListPlot.html) reference:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7c4dfdc2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><img alt=\"Output\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAfQAAAE5CAIAAADpwkW3AAAAzXpUWHRSYXcgcHJvZmlsZSB0eXBlIGV4aWYAAHjaXU9bjsQgDPvnFHsE8sCB49ApleYGc/xNJmhXrStsY5IUyvq8r/ITYKpFm3UMoDp06ODpptdEKtXx5S8u3Y7ueZGRlqZr+z/ASqXjnhtSuT8GVU4j8Qf3orthDxLOnGbuj13Ps/f7oAewB/3d7LFXMUYDmTorVzMM9724dUHj2gwXXoAXEk6u+nJdMPM2WFTIjMYAL7tXrwLx4IwnSCyWKeRfsHGmczNJ48NdeGd/zi9jh1q06NM3aAAAAAlwSFlzAAAPYQAAD2EBqD+naQAAADx0RVh0U29mdHdhcmUAQ3JlYXRlZCB3aXRoIHRoZSBXb2xmcmFtIExhbmd1YWdlIDogd3d3LndvbGZyYW0uY29tXKKmhQAAACF0RVh0Q3JlYXRpb24gVGltZQAyMDIyOjExOjE3IDIwOjIwOjE10OBifwAAIABJREFUeJzt3Xt8VNWh9vE1l2QmO5NMbkAmYCAECBPuRAIqQYkCEotIJYABK2L7pmq1sZ/2k/MeEWyPR7G0R7DKOZEXazki2KKtFyKIIghSQIxAgk64h0m4JlySzCSTzOX9Y+wYQ4AAM7Nndn7fv2Yv945P0+FxsWbP2iqPxyMAAMqi9uPPKiws9ONPAwBcN3+WOwAgRHxf7ps2bRo0aJDv0GKx5OTkSJKUmZm5adMm72BjY2NBQYHRaDSZTEuWLAl2WABA56iFEG63e9myZVOnTnW5XN5Rl8t133335eXlnT9//plnnpk+fXpDQ4MQoqioyG63W63W0tLSRYsWbd26Vc7sAIDLUAshnn766ZUrVy5YsMA3umvXrtOnTxcXF+t0ugceeGDIkCFvv/220+lcvXr1woULY2NjR4wYUVhYWFJSIl9yAMBlqYUQTzzxxI4dO8xms2/UYrFkZGSo1d8t2pjN5vLycqvVarfbfad5B4OfGABwVVohREpKSrtRm80WHR3tO5Qkqb6+3mazqdVqvV7vG7TZbO0ubHfDDFN7AJCFtsNRSZKampp8h3a73WAwSJLkdrsdDodOp/MNtruQNgeAUNDxrZADBw48cOCA7/tNFoslMzMzNTVVkqTKysq2g0GKCQC4Fh2X+5gxY4xG4/PPP9/S0rJ27dqysrJp06Zptdr8/Pz58+c3NDRUVFSUlJTMmTMnyHEBAJ3Rcbmr1ep169Zt3LgxKSlp4cKF7777brdu3YQQS5cujYuLS0tLmzhxYnFxcV5eXnDTAgA6ReXHvWW4ORIAgsMjhOqKJ3T8gSoAIDTVnG18c/3+Q9YL3eKjpt0+YFRmcoensbcMAIQNW3Pr7/935zdH61qcrpqzja+sLbMcq+vwTModAMJG+eGzFxodbUc+31Pd4ZmUOwCEjVan+6ojXpQ7AISNQWlJughN25Gbzay5A0CYS4jVP5E/0mjQCSG0GvWP7xiQPcjU4ZncLQMA4WRIv25Ln8qtvdAUF6OP0F52gk65A0CYUalU3eKlK5/j53L37QrJt5kAQEZ+Lnc6HQBCAR+oAoACUe4AoECUOwAoEOUOAApEuQOAAlHuAKBAlDsAKBDlDgAKRLkDgAJR7gCgQJQ7ACgQ5Q4ACkS5A4BsnC53S6srED+ZLX8BQAaOVtdbG77ZtrfG5fYM7Zc0b8rQOIPOjz+fLX8BQAZ/+7Ryc5nV+3rvwbP//c7X//ehMX78+SzLAECweYTYUXGi7Yil6tzFRocf/xWUOwCEBpU/fxjlDgDBphLi1iE9246Y+yQao0N4zR0A0BnTcwe0ulzb9ta4XO6h/bs/fM9g//58yh0AZBAZoXkob/Ccuwe53Z4Irf8XUSh3AJCNRq3SqP261v4vrLkDgAJR7gCgQJQ7ACgQ5Q4ACkS5A4ACUe4AoEDsCgkACsSukACgQCzLAIAC8Q1VALghJ2ob3/7EcvxUfUqSIf/OjD4mo9yJhKDcAeBG1Ntann9jR4O9RQhxrr75oPX8fz6a0y1OkjsXyzIAcAN27j/hbXYvR6tr294aGfP4UO4AcP1sza3tR5raj8iCcgeA6zesX/d2mzoO699Nnig/RLkDwPVLSzHOvjtTq1ELIVQq1bQ7+g9JD4ly5wNVALghE7L73Dq056laW/cEKUaKlDvOdy47c9+9e/eYMWMMBkO/fv1ef/1172BjY2NBQYHRaDSZTEuWLAlWSAAIadH6iPRecaHT7OIK5X7//fcXFhbW19e/9dZbjz322P79+4UQRUVFdrvdarWWlpYuWrRo69atQYwKAOisjpdlmpqarFarSqUSQqjV6oiIiIiICKfTuXr16m3btsXGxo4YMaKwsLCkpCQnJye4gQEAV9fxzD0qKurXv/71vHnzIiMjR40a9cILLwwYMMBqtdrtdrPZ7D3HbDaXl5cHMSoAoLM6nrl7PJ7IyMiVK1fOmDHj888/nz59elZWVkxMjFqt1uv13nMkSbLZbO0u9O0K6cU+YgDCyIVGx96DZ9Qq1dD+3YzROrnj3JCOy33Dhg2lpaXPPfecEOKuu+6aMWPGG2+8UVxc7Ha7HQ6HTqcTQtjtdoPB0O5C2hxAmLIcq1vy9ldNDqcQQtJH/OqBm/vfFC93qOvX8bLM8ePHHQ6H79C75p6amipJUmVlpXfQYrFkZmYGIyMABN7rH5Z7m10IYW9ufWNdhbx5blDH5Z6bm3vkyJFXX33V7Xbv2LHjrbfemjFjhlarzc/Pnz9/fkNDQ0VFRUlJyZw5c4IcFwACwd7cevqcve1I9ZmGVqdbrjw3ruNy79ev3/vvv//nP/85Pj7+4YcfXrZs2bhx44QQS5cujYuLS0tLmzhxYnFxcV5eXnDTAkBAROkjovURbUeMBp1WG8bf4b/sN1QnTJgwYcKEdoNGo3HlypUBjgQAwaYSYvqdGX9psxSTf2eG6goXhDy2HwAAIYTIzUpNMkbt3H9SpRK3DE4Z1DdJ7kQ3hHIHgO8M7ddtaL+Q2PbrxoXxihIA4HIodwBQIModABSIcgcABaLcAUCBKHcAUCDKHQAUyM/3ufu2/GV7SACQkZ/LnU4HgFDAsgwABTpX32w5Vldva5E7iGzYfgCAoniEWP3xtxt2HBVCaNSqByaaJ2T3kTuUDJi5A1CUr7495W12IYTL7Vm1/puqU/XyRpIF5Q5AUfYdOtv20CNExZFaucLIiHIHoCgxUmS7EUNURIdnKhvlDkBRbh95U2SExncYH6MfZU6WMY9c+EAVQOg6euLinoNn9JGa0YNSEmL1nbmke7w0/+Fb3t184HSdrXeyMf/ODEnfFWfulDuAELW57PgbH1Z4hBBC/GPLoX/7yei0FGNnLuydHPvUrJsDmi30sSwDIBS1tLreXP+N51+HzS3ONRu/lTNQuKHcAYSiM+ftrU5325HjpxvkChOOKHcAoahbvKTV/KCgenYzyBUmHFHuAEKRLkIz464M32GkVjPzroEy5gk7Ko/Hc/WzOse3JaRgBzEA/lBZde7rA2f0kZpbhvTskSDJHSecsCskgNCV0Tsho3eC3CnCEssyAKBAlDsAKBDlDgAKRLkDCAa3x2NrapU7RRfC9gMAAssjxPp/HvnHlkPNLc6e3QyPTBma3itO7lDKx8wdQGDt2n9yzUZLc4tTCFFztvG/Vu9usHfdp98FDeUOILB2VJxoe9jY1PLtsTq5wnQdlDuAwFKrVe1HVO1H4HeUO4DAunVIz7aHRoPOnJYoV5iug3IHEFhZA3s8dM9go0GnEqJvz7hfF4yK7pJPzwgy7pYBEHC5Wanjs1KdTneElgllkPCLBhAMKiFo9mDy88zdtzEkO4gBgIzYFRIAFIi/JQGAAlHuAKBAlDsAKBDlDgAKRLkDgAJR7gCgQJQ7ACgQ2w8A6KwGe8vbGy0VR2pjoyMnjUm7bWjPq18DmVDuADrF7fG8tGb34eoLQojzDc2v/WNvhFadnWmSOxc6dtllmZqamilTphgMhp49e7700kvewcbGxoKCAqPRaDKZlixZEqyQAOR3/FS9t9l9PvvquFxhcFUdl7vH45k6dWp6enpdXd2GDRuee+65zZs3CyGKiorsdrvVai0tLV20aNHWrVuDGhaAfJocznYj9ub2IwgdHS/L7Ny502q1Ll68OCIiYvDgwZ999ln37t2dTufq1au3bdsWGxs7YsSIwsLCkpKSnJycICcGIIu0lLjY6Mh62/ePPx3ev7uMeXBlHc/cy8rKsrKyXnzxxYyMjOzsbIvFkpycbLVa7Xa72Wz2nmM2m8vLy4MYFYA/NdhbTtY2uj2eTp6vj9Q8Pn2k0aDzHmZnmn40Nj1g6XCjOp65nzt3bvPmzQMHDvzwww/37Nkzd+7c5OTkhIQEtVqt1+u950iSZLPZ2l3o2/LXi00igRDkdLlXvF++vbxGCJFojHr8/hHpveI6c+HA3gn/9cvxJ842GqTIhFh9gGPihnRc7jqdLi4u7o9//KNKperfv/+GDRvWrl1bVFTkdrsdDodOpxNC2O12g8HQ7kLaHAh9H2w77G12IUTdxaaX/1b2+1/crovQdOZarUadmhwbyHTwj46XZQYOHOhwOHyHWq3W5XKlpqZKklRZWekdtFgsmZmZwcgIwK/2HDjT9vBCQ/PRExflCoMA6bjcJ0yYIEnSggULmpqadu3atWbNmpkzZ2q12vz8/Pnz5zc0NFRUVJSUlMyZMyfIcQHcOF1k+0m6/pIRhLuOy12v12/ZsmX37t0pKSn5+fmLFy8eN26cEGLp0qVxcXFpaWkTJ04sLi7Oy8sLbloAfjA+K7XtYXqvOFZalOey31Dt27fvRx991G7QaDSuXLkywJEABNaYwSmtTvdH24802FsGpycVTMxUq1Ryh4Kfsf0A0OWohBg3vNe44b3kDoIAYldIAFAgyh0AFIhyBwAFotwBQIEodwBQIModABSIcgcABfLzfe6+XSHZQQwAZOTncqfTASAUsCwDhL3OP3ADXQfbDwBhrPpMw19KKw5XX4iP0d93R/+cYewogO9Q7kC4anI4F6/68kJDsxCi9mLT/3tvX6wUOYznmkIIwbIMEL72H6n1NrvPF/tq5AqDUEO5A+HK6XJfMsLiO75DuQPhKjMtSdJHtB0ZZU6WKwxCDeUOhKvY6MhfzhjZLU4SQkRo1fePHzBmSIrcoRAq+EAVCGMD+yQufvKOi42OGClSo+ZpSvge5Q6EN5UQcQad3CkQcliWAQAFotwBQIEodwBQIHaFBAAFYldIAFAglmUAQIEodwBQIModABSIcgcABeIbqoD8PELsqDix+avjzS2urIE98m7tq9Uw8cINodwB+W3dU73i/X3e18dOXjx73v7IvUPljYRwx+wAkN9H24+0Pfx8T7WtqVWuMFAGyh2QX72tpf2Ivf0IcE0od0B+g/smtT1MMkb1SJDkCgNloNwB+T0wydzHZPS+Nhp0P//xcLWKzdlxQ/hAFZBfnEG34JFbj5+qb25xpqUY9ZH8wcSN4j0EhASNWpWWYpQ7BZSDXSEBQIHYFRIAFIgPVAFAgVhzB/zMerqh6tRFU6Khb684bnmBXCh3wJ/WbLR89M/vvm46epDp0R8PV3FTI+TAsgzgN5aqc75mF0Ls3H/yi301MuZBV0a5A35z0Hr+qiNAcFDugN/Ex+guGdHLkgSg3AG/yc40mZIMvsMYKXL8zaky5kFXxgeqQMcsx+p27j/pEWL0IJO5T2JnLomM0Dzz8C0fbDtcdepicmL0lLH9jNHt5/JAcFDuQAe+2Ffz2j/2el9/9tXxn947NGd4r85cGB0VMWvCwEBGAzrlKssy9fX1aWlpb775pvewsbGxoKDAaDSaTKYlS5YEPh4gA48Qf/3E0nbkr59aPHKlAa7LVWbuTz755PHjx32HRUVFdrvdarUePnx48uTJWVlZOTk5AU4IBFtLq+tCo6PtSL2tpdnhjNLxN12EjSvN3N95551jx45lZWV5D51O5+rVqxcuXBgbGztixIjCwkJ2koEi6SI0KW0+FxVCJCdG0+wIL5ct95MnT/7mN79544031OrvzrFarXa73Ww2ew/NZnN5eXkwMgJBN/eewb5N1fWRmrn3DJY3D3CtLjsZmTdv3oIFC/r06eMbsdlsarVar//uvl1Jkmw2W7urfFv+ejG1R5jK6J3wwmPj9hw44xGe4f27Jxqj5E4EXJuOy/2VV17R6/Vz585tOyhJktvtdjgcOp1OCGG32w0GQ7sLaXMoRkKsPpe71BG2Oi73FStWHDhwIC4uTgjR2NhYWFi4ffv2l19+WZKkysrKoUOHCiEsFktmZmZQwwIAOqfjcl+3bl1LS4v39bRp0x566KE5c+Zotdr8/Pz58+evWrWqqqqqpKRkxYoVQYwKAOisjss9JSXF91qn0yUlJSUlJQkhli5d+sQTT6SlpUVGRhYXF+fl5QUpJgDgWlz97q4dO3b4XhuNxpUrVwYyD+B/TQ7n2fP2HonRugiN3FmAIOHWXSjcui8Ov/PZAZfbE6nVzL7bfMdIPiNFl8CukFCy8sNn//pppcvtEUK0OF1vrNt/7ORFuUMBwUC5Q8n2Hjzb9tDj8ew7dPZyJwNKQrlDyfSR7RfZ2UUAXQTlDiUbO6xXpPb7fo/WR2RnmmTMAwQN5Q4lS06MLv5JdkZqQowUOTg96d/njjEaeHoGugT+igqF69cr/t/njpE7BRBszNwBQIH8PHP37QrJDmIAICM/lzudDgChgGUZAFAgyh0AFIhyBwAFotwBQIEodwBQIModABSIckc4cbk9Ho9H7hRAGGD7AYSHBnvLytL9Xx84rdWobx9xU/6dGVoNUxPgsih3hIf/eXdPxZFaIUSr071+x1GNWjXjroFyhwJCF3MfhIELjQ5vs/t8UX5CrjBAWKDcEQbc7vbr7G63W5YkQLig3BEG4mP1/W+KbzvCMzeAK1P58d4D35aQgh3EcEU1ZxtrLzT1McV2/tEZ5+qbl7+395ujdWqV6pYhKT/JG3zpI/QA+LArJILK7fGU/H3vjooTQgitRv3g5EF3jLypMxcmxOqLHxxtb27VatSREdQ6cBUsyyCoNu0+7m12IYTT5V5ZWnH6nL3zl0v6CJod6AzKHUG1/4c3vbjcHktVnVxhAAWj3BFUsdGRl4zwxGrA/yh3BNWE7D4atcp32Kt7zJD0JBnzAErFN1QRVL26xzwz79b3th6qu9jUr2fcj8cPYBcBIBAodwRbWoqxaGaW3CkAhWPSBAAKRLkDgAJR7gCgQJQ7ACgQ5Q4ACkS5A4ACUe4AoEB+vs/dt+sv20MCgIzY8hcAFIhlGVw/jxAXGx0tTpfcQQC0x/YDuE7VZxr++9091Wca1CrV+KzU2Xdntt0RDIC8mLnjejhd7iVvf1V9pkEI4fZ4Pt1dte6Lw3KHAvA9yh3Xo+pU/dnzP3iC0u5vT8kVBsClKHdcj0v36WXnXiCk8AcS16NX95jeybFtR8YO6yVXGACXotxxPTRqVdGsm0cM6K7VqI0G3Yw7M8Zn3SR3KADf424ZXKeEWH3RrJvdHo9KpeIuGSDUXHbmvnnz5lGjRhkMhvT09GXLlnkHGxsbCwoKjEajyWRasmRJsEIidKlpdiAkdTxzr62tnTp16rJly2bOnFlWVnb33Xenp6dPmjSpqKjIbrdbrdbDhw9Pnjw5KysrJycnyIkBAFfV8czdarXOnDlz9uzZWq02Ozt7/Pjxu3btcjqdq1evXrhwYWxs7IgRIwoLC9lsAABCU8flPmLEiNdee837+uLFi9u2bcvOzrZarXa73Ww2e8fNZnN5eXmQYgIArsVVPlBtaGiYMmXKhAkTJk2aVFFRoVar9Xq99x9JkmSz2dqd79sV0oupfVg4VWf7dHdVg63FnJY4bngvVtEBBbhSuR89enTKlCm33377yy+/LISQJMntdjscDp1OJ4Sw2+0Gg6HdJbR52LGebvjdiu3ezb/+WXHiwPHzP5s6VO5QAG7UZe+W+fLLL2+77bbHHnvs1Vdf1Wg0QojU1FRJkiorK70nWCyWzMzMIMVEwLy39WDbbR237a2uOdsoYx4AftFxuZ88eTIvL6+4uPjee++trq6urq6+ePGiVqvNz8+fP39+Q0NDRUVFSUnJnDlzghwXfnf6nL3dSO2F9iMAwk7H5b58+fLa2tqioqKb/mXhwoVCiKVLl8bFxaWlpU2cOLG4uDgvLy+4aeF/6T3j2h5q1KqbesRe7mQA4ULl8Xj89bO4OTIcXbQ5/vPPO06fswkhVEIUTMqcOLqP3KEA3Ci2H1COsxfsb234trLqXIJRP2Vsv9GDTJ25yhite65wbFnl6Ys2h7lPYirTdkARKHeFaGl1LX5zl3cB3dbcuuydryW9dkh6t85cGxmhGTM4JcABAQQVu0IqxLfHzrX7aHTL11a5wgCQHeWuEI5WZ7uR5haeWw10XZS7QmT0TojS/WCRbeSAHnKFASA7yl0hjNG6X0wfaYzWCSFUQkzI7sPTM4CujA9UlWNwetJLT+WePmeLj9G3m8UD6GqoAEXRqFUpSe03/AHQBfm53H27QvJtJgCQkZ/LnU4HgFDAB6oAoECsuYeiBnvL7m9PNTmcQ/t169U9Ru44AMIP5R5yas42vvCXHQ32FiHE3z6tnHfvkJxhveQOBSDMsCwTclZ//K232YUQbo9nZen+lla+awrg2lDuIef4qfq2hy2trlN17Z9VCwBXRrmHnO4JUttDtUrVLV663MkA0CHKPeTk35mh1Xz//8t9t/fn66YArhWtEUC2ptb3Pj909OSFHgnRU3P6dXICnpGa8Lv/M3bb3uomh3PEgO7D+ncPdE4AykO5B0qr0/3cn/95orZRCHHg+PmvLKeffzQnPkbfmWt7djPMvGtggAMCUDKWZQJlt+WUt9m97M2tn35ZJWMeAF0K5R4o5+ub242cu2QEAAKEcg+UjN4J7UbMfRJlSQKgC6LcAyW9Z9x9t/f3HY4eZBo7rKeMeQB0KSqPx+Ovn+Xb71ewPeS/nKyzHT9V3z1e6pNiVMkdBkDXwZa/gWVKjDYlRsudAkCXw7IMACgQ5Q4ACkS5A4AC8Q3VTml1ug9Vn3e7Pf1uitdFaOSOAwBXQblf3elztj++tfv0OZsQItEY9dSsm2/qwdORAIQ0lmWu7vUPyr3NLoSou9j02j/2ypsHAK6Kcr8Kp8t94Pj5tiPHT9f7npQEAKGJcr8KjUYdHRXRdiRCq5b0EZc7HwBCAeV+FSoh8m7t23Zk8i19NWq+bQogpHWtD1Rbne4tX1tP1jb27B4zbnivtg88uoLJt/aNkSK3l9e43J7Rg0y5WamBzgkAN6gLlbv36RnHTl70Hn6xt+bf547pzBxcJUTO8F45w3sFOCAA+E0XWpbZuqfa1+xCiEPV5/9ZXiNjHgAIHD/P3H0bQ4bgDmI1ZxvajZyotcmSBAACrQvtCpmaHNtuhO8iAVCqLrQsM3ZYr4zU75+OlJmWOHqQScY8ABA4YfmBqtPl/nDb4S+/PRWhVecM75WblapSXf1zUY1aVfyT0bv2n6w+03BTckx2pkndiasAIByFZbn/70f7N5dZva+PnrjY3OK654e3ol+ORq26ZUhKIKMBQEgIiWWZa3rUn6PVteXr6rYjn+w65udAABDmZJ657/rm5NpNlbUXmvr2jPvJ5EGXfuZ5KXtza7v/GDQ2tXo8ns6szABAFyHnzN1Sde7VtV+fPmd3uT0HrecXr9rVmQ254mL0vbr/4C6XIendaHYAaEvOcv9i7w9WV+ptLeWHz171KpUQP582vFuc5D3sYzI+ODkzIPkAIGzJWe5OV/ul9ktHOnRTj5gXHhu34JFb/6Nw7IJHbo2P0Qcgnd/4vtiFtvi1dIhfy6X4nXToqr8WOct9VGZy20N9pGZw36ROXhuhVaf3jEvtEcsGjQBwKTnLfWRGj1kTzJFajb7mvfgY/RMzshJir2EOft3/PQ/+hcH81wX5f11Y/E6Cf6Gyfy38CQqRC69M5lshJ9+S9j//NlEI8dJTuZ2ftgMArkz++9y96yqsrQCAH6mu6QtEgg83ACDklZSUXHO5X0FhYWEo7woJAF2H/MsyAAC/o9wBQIEodwBQIModABSIcgcABfLn3TIAgBDBzD2A7rnnHlUbzc3NcieS2ZYtWzIyMnyHjY2NBQUFRqPRZDItWbJExmDyeu65537605/6DhcvXtz2bbN+/XoZswWfw+F4/PHHTSZTfHz8lClTqqqqvOPvv/9+RkaGJEl33nmnb7DrqKqqmjJlSnx8vMlk+sUvfuEtE7fbHRsb63urjBkzpu0llHugeDyeHTt2bNiwwfoven1I714ZUB6Pp6SkZMqUKS6XyzdYVFRkt9utVmtpaemiRYu2bt0qY0JZNDQ0FBUVPfPMM20Ht2/f/uyzz/reNuPHj5crniyeffbZvXv3lpWVVVdXJycnz5o1Swhx5MiR2bNnv/rqq7W1tYMHD543b57cMYNt1qxZvXv3rqmp2b17965du377298KIcrLy7VabVVVlfet8sEHH/zgGg8C45tvvomKipo1a1Z6evrUqVMPHz4sdyI5zZ8/f9SoUX/4wx/S09O9I62trZIklZWVeQ8XLFgwe/Zs+QLKY9y4cQUFBT/72c8eeeQR32CPHj2mT5+ekZFx2223ffzxxzLGk0VxcfGnn37qfb1v3z6tVutyuZ5//vl7773XO2i32/V6/cGDB+XLGGzNzc3Tpk07e/as9/Dll1/Ozc31eDzLli3LzMzMzc0dMGDA448/3tjY2PYqZu6BsnPnzoiIiIKCgtLS0uTk5Nzc3KamJrlDyeaxxx7btWvXoEGDfCNWq9Vut5vNZu+h2WwuLy+XKZ1sVq9evWrVqoSEBN/IsWPHzpw5M2rUqNLS0tmzZ//oRz/at2+fjAmDb9GiRbm5ud7XH3744c0336xWqy0Wi++tEhUV1bt37y71btHpdO+++25S0ndbK65bty47O1sIsXPnTo1G8/vf/37NmjVlZWUPP/xw26tkfoaqgs2dO3fmzJlRUVFCiFdeeSU1NbW0tPT++++XO5c8TCZTuxGbzaZWq31LVZIk2Wy2oOeSWUpKSruRPn362Gw279vm0Ucf3bRp0/Lly//0pz/JkU5ma9euXbx48SeffCKEsNls0dHRvn/UNd8tQgiPx/OrX/3KarW+/fbbQojXX3+9tbVVp9MJIZYvXz548OC6urrExETvyczcA8j7R1QIodVq09LSTpw4IW+ekCJJktvtdjgc3kO73W4wGOSNFCJ8bxshxIABA7rm2+bFF1986qmnNm7cOHLkSCGEJElt/+LbNd8tdrt9xowZX3755ZYtW4xGoxBCrVZ7m10IMWDAACFE23cL5R4ozz777C9/+Uvva6fTeeTIkfT0dHkjhZTU1FRJkiorK72HFoslM5Nn4Yr169ePHj3ad3gf7UE7AAABoklEQVTgwIGu9rZxu92PPPLI2rVrd+7cmZWV5R0cOHCgxWLxvm5ubq6qqupq75a6urpx48bFxMRs2rTJtz4zceLENWvWeF8fOHBAq9X27t3bdwnlHihjx45dsWLFzp07HQ7H008/HRcXN2nSJLlDhRCtVpufnz9//vyGhoaKioqSkpI5c+bIHUp+WVlZBw8eXLZsmcvl+vvf/15aWvrzn/9c7lBB9cwzz2zfvn3VqlVut7u6urq6utrj8eTn52/cuPHjjz/2/mkaOnSod6LaRXg8nvvuu69fv36/+93vzpw5U11dfebMGSFEdnb2888/f+LEibq6uieffHLu3LmxsbE/uAwBsnz58r59+0qSlJube+jQIbnjyO+jjz7y3S3j8XguXLjw4IMPJiYmmkyml156ScZg8iouLm57t8y2bdtGjRoVHR2dmZm5fv16GYMFn8Ph8K0z+Jw/f97j8bz//vtms9lgMIwfP/7o0aNyJw2qLVu2tPudDBs2zOPxOByOoqKiHj16GI3GefPm2Wy2tlfxDVUAUCCWZQBAgSh3AFCg/w8PpAziswBqfAAAAABJRU5ErkJggg==\"></div>"
+      ],
+      "text/plain": [
+       "-Graphics-"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {
+      "text/html": [],
+      "text/plain": []
+     },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ListPlot[Prime[Range[25]]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e549b21",
+   "metadata": {},
+   "source": [
+    "We also test the math outputs as in the [Simplify](https://reference.wolfram.com/language/ref/Simplify.html) example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "5c2010aa",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><img alt=\"Output\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAbMAAABBCAIAAADUot12AAAAzXpUWHRSYXcgcHJvZmlsZSB0eXBlIGV4aWYAAHjaXZBrEoMgDIT/c4oegTzYwHFQcaY36PEbJNOOLmOyfiYBTOPzPtNriiknLVbRgOzSpo27m5qXVqbcrnhpk3B050nDUHdU/h8wgm93bliZ62NQ5mVk7uBeNBpikPDi1ONEUc+91vughxCDfid7vKsYo4BMPSpnMzT3Nbn1hMK5GE7sgBcSDs66ex4w8zbYrJA+G6d42L16JIiDY15B5sPShXzNaLxoD67S2P/1RTz6db5Ry1qwcBCnKwAAAAlwSFlzAAAPYQAAD2EBqD+naQAAADx0RVh0U29mdHdhcmUAQ3JlYXRlZCB3aXRoIHRoZSBXb2xmcmFtIExhbmd1YWdlIDogd3d3LndvbGZyYW0uY29tXKKmhQAAACF0RVh0Q3JlYXRpb24gVGltZQAyMDIyOjExOjE3IDIwOjIyOjQ5DigSmgAAFDlJREFUeJztnXlcE8f7xyfh0giGQ0TA0kpfgqCA8EI8gtYCCor1tjYGEA+UWusFCsVoORSxtFVbEWssoijVvrSiFZFDJQqKCjVWEVEUQbDgwR2OBLK/P7bf/NIcm825Qef9VzL7zDOfZGefmd2dg4QgCIBAIBCICGSiBUAgEIjOASMjBAKBiAMjIwQCgYgDIyMEAoGIAyMjBAKBiAMjIwQCgYgDI2M/g8/nX716ddu2bTY2Nt7e3mr0XFNTExISYmVlZWxs7OnpmZmZqUbnEEj/gpjIWFtbe+zYscDAQDKZXFBQQIiGfkptbW1wcPCRI0eamprU6LasrMzNza2xsfHw4cPnzp2bMmVKUFAQi8VSYxEQXQC2fzjRJ6TU3bt3nzt3jsfjwXHmivLxxx/X1dUBAAICAjo6OtTl1tnZOSkpadWqVWQyGQDg6+v76tWruLi4sLAwdRUBIZyysjJfX9/x48cfPnyYQqFkZ2cHBQVxuVx4lqWAEMfNmzcBAPn5+QRq6L/4+/vTaDTN+d+3bx+JROrr65N6dOfOnYaGhvfu3UO/CgQCHx+fcePG8fl8zUmCqEhnZ2dqaqroOWUwGLa2tgRK0lngc8b3gvT0dEWzVFRUjBw5Eu1CShIdHT1hwoSgoKCenh4AQGpqaklJyfHjx/X1ibkLgeBh4MCB4eHhoufUy8vr5cuXAoGAQFW6CYyM7wUXLlxQyL6uri4jI+Orr76SZUAmkzMyMmpra2NjY1+8eBEVFZWcnOzg4KCyUohWwW7/3mdgCw8Rh8/nMxgMV1fXNWvWYJjZ2dmlpqYGBwfn5uZ6e3tjG0N0ELT9S0xMJFqILgIjow6Rm5vL5/PFEidMmDBkyBAVHTY0NAi7jdgOBQJBaGjo06dPb9++LffWeN68eRYWFnfv3i0uLlZOIYQocLZ/7y0wMuoQra2tPB5PLLG3t1d1hzwer6WlRa7Dvr6+5cuX5+fns9lsGxsbuf4jIyNNTU0dHR03btxYVFRkYGCgtFSINlGo/XtPIfDtD3w3rQoKvZtesGCBXBsej7do0SIbG5uHDx/i8XnhwgUymXz9+vWamhoqlRoZGYlTDIRYent7Q0JCLC0tcZ7o9xPYXPQzbty4gb5JbGlp6ezsLCoqAgBQqVQXFxdV3HZ2ds6fP5/NZv/yyy9v375F3QIALC0tHR0dJe0bGxuXLVu2adMmdB4Oi8VavHixj4/PjBkzVJEB0TToTXRxcTGbzXZyciJaju5CQGSsq6t7/vw5AODhw4cAgAcPHgwYMAAA4OLiQqVSta+nf+Hj44MOlEGZPHkyAIBGowljmVSmTJmC7TY9PT03NxcAsHTpUtH0xYsXnzx5UswYQZDQ0NBhw4bt2LEDTVm0aNGVK1eWLl3K4XDw3IZDCEHR9u99hoRofRZKUlLSN998I5men5/v5+enZTEQyPvDgQMHpI7Ektr+vecQEBkhEAhEx4EjPCEQCEQcGBkhEAhEHBgZIRAIRBwYGSEQCEQcGBkhEAhEHBgZIf2Y+vr6/Px8olVA3kFgZIT0Y16/fn3r1i2iVUDeQf6dA1NVVfX69WtipWgHGxubDz/8UC2uurq6OByOWlxBxKBQKG5uburyVlZWJrlUBwQiiliV+zcyPnv27NGjRwRJ0ipjx47FiIwKrQPW1dV1584dNeuDAAAAsLCwwIiM1dXV5eXl6IfKykp0gTVzc/NJkyZJtb97925nZ6eGpELeDcSq3L+Rcfr06dOnTydIkg6h0Dpg5ubm69at07woiDg9PT3oomrt7e3d3d3oZ0NDQ1n2K1eu1J44yDsBnB0I6cdwOJwLFy4wmUyihUDeNeAbGAgEAhEHRkZIP8bc3FzFhSkhEKnAu2kIBAIRB/YZIRAIRBwYGSEQyLtGc3Mzg8Fwc3MbM2bMzz//rIQHGBmJh8fjiW5g8L7R3t5OtAS8aFkqgiBMJtPZ2Tk8PFw5D/3ov1UCjF/HZrPpdPq9e/dKSkpSU1Pv37+PM6MQGBmJZ/fu3U1NTUSr0CDYDfjmzZsJUaUo7e3twn1vtMbUqVOV3nSMEMHa5Mcff2xoaJB6aO7cubNmzQIAGBsbe3p6VlVViR7FU+VgZCSYvr6+uro6a2trooVoEOwG3MPD48aNG0Rpw09mZuaCBQu0WSKJRPLz81N6hz/tC9YydDr9yJEj2DZcLvf27dtiO8ThqXIwMhJMTk7O1KlTiVahWbAb8MWLF2dkZBAkTQHYbLaXlxfRKhSg3wlWFAcHh/v372OMrkEQZPXq1RERERYWFqLpeKqceGS8efPmzJkzzczMTExMPDw8UlJSFBrW8/jxY7EUDoezb98+Nzc3Eokka5qdJuDz+ejerdoBQZCUlBQ3N7cBAwYMHTp02bJl//zzD56Mp0+flrxdamlpycrKCgsLo1Ao79IED6kNOJVK7ejokJyurgkyMjK8vLwoFMqQIUP8/Pzy8vJwZqyqqpLcLZbP51+9enXbtm02Njbovtu6g1TBONHQNcvlcplMpr29/cCBA52cnGJjY7u7u1X06enpWVpaKuvounXrhg8fHhYWJpaOq8ohIhQWFhoYGKxZsyYvL+/KlSsREREAgO3btyP4aG5u3rhxo1iiu7u7ra3t4MGDAQB8Ph+nK7XAYDB6enq0U9bKlSsNDQ0jIyNzc3OPHDlCo9HCw8Pl5uLz+bNnz5ZMz8jIsLW1tbW1BQBs3bpVA3oJQCAQMBiMQ4cOSR7au3fv5cuXNS0gPj7e1NQ0MTHx2rVr2dnZgYGBenp6eXl5ePJ+//33BQUFYolVVVXoaTIyMqLRaBqQjCAIwmKxVq9erWguqYJxoolrtqWlxdnZ2cHB4ejRo2w2e8+ePVQqdcmSJSq65XA427Ztk0zv6+sLCwvbsmWLrIxyqxwQ+/706VPRr/PmzbO1tcWpMiYm5tGjR1IP7dq1S/uR8ezZs8nJyVooKCcnBwCQmZkpTBEIBHh+bGFhYWxsLIaBkZHROxMZ165dGxUVJfXQgwcPIiIiNC2Ay+U2NDQIv/L5fEtLSwaDgSevv78/Rivr7++va5ERWzAe1H7NHj58uKWlRfiVxWIBAJ48eaKKT4FAEBAQIJnOZDL19PTc/kdwcLCYgdwqJ343bW9vL/q1s7PTysoKT7e2oaGhsrLS0dERj7GKvH371sbGhk6nC1MKCwvJZPL58+dFzebMmZOTk6N6j10uBw8edHd3F9VDIpH09fXlZrx165a7u7smpf2HxMREIyOjv//+G/2KIIivr6+Xl5fqd0zYngUCwapVqygUSlJSktTso0ePRlcV0ygUCkW0Mvf19fF4PDzVG0GQzs5OjLV8NERycvLYsWPj4+NPnz6NfsCZkSjB2KxYsYJKpQq/os9A6+rqpBoXFRXp6+sfPHhQmBIXF2dqalpbWytqRiKRjIyMJK/xhISE3t5ezv84duyYmIH8Kic1Xvb19T1+/Hj9+vVUKpXNZuMJ3jExMWfOnJF1VKH2p7Cw8NmzZ9g2eXl5JBIJ7aZ1dHSMGDFixYoVkmYpKSnHjh3DU6gqWFhYMJlMJTLS6fTnz59jGKi3z9jX1zdlyhQXF5fu7m4EQVJSUigUSmVlJXauuro6ubec2J7lNuAIgkydOlUgECjzqxSnu7v71q1bfn5+o0aNEu1FyqKysjI0NBTDQKE+45EjR3BaKo1cwXhQ+zUrxsmTJ0kkUn19vSyDrVu3Dho0CO1UcjgcAwODjIwMSbOIiIg7d+4oVDQKdpWTEhn/+OMPEokEABgxYgT66gcP7u7uXC5X1lGF/uU9e/Zcv35drtmGDRvMzMxevny5fv16e3v79vZ2SZv6+voFCxbgKVRpuFwuAOD48ePp6eleXl6mpqYuLi5JSUk8Hk9u3gkTJmAbqP1uuqamhkqlRkdH19bWGhsbo2/YsLl7925CQoImPIvCYDCwGwl1sX79erRPMG3atObmZjxZsrKydu3ahWGgUGTUdIVEcAjGgyauWSG9vb3u7u7z5s3DsOHz+ePGjZs0aVJPT4+Hh8eiRYukmrFYrPT0dPxFC8GuclLu+Pz8/EpLS6urq8+ePUuj0dLS0uSOimppaTE1NaVQKNhm6iUpKeny5cuzZs26f//+1atXjY2NJW1sbGzq6+s1KgNdLDo+Pt7BwSE2NtbKyqqoqCgmJubNmzfJycnYeRGtL+dhZ2eXmpoaHBycm5vr7e29Zs0aHfFsYWHx5s0bdW1EgUFUVBSdTi8vL09LS/P09Dx//ryzszN2lqamJjMzM00LE+Xly5eVlZWS6RMnThwwYIDc7NoXrChMJrOmpkbs8ZcY+vr6J06ccHd3p9FoDQ0NsrZCs7CwePbsmRIasKuclMiIjtfx8PBYsGBBbGxsSEiIt7c39uOY+vp61et0aWkpOqL94cOHPB4PXah55MiRsp5dGhkZhYaGRkRETJs2jUajyXKrr6/f29uL56mfcgwePJhEIvn7+//0009oioeHR1tb244dOxISErDrMdo3VwXhuv+iYKz7DwCYN2+ehYXF3bt3i4uL8XjGuaMAfs9SGTx4MHrGNY21tbW1tfX48eNDQ0P9/PyCg4PLysqws7S2tqo+FF+4kUZDQwP6ZwLZG2m0trY+efJEMn3cuHF4ypIlWKHNPPCg6DWLcvDgwR9++OHixYvDhw/H9j9y5EgfH58///xz586d5ubmUm2UrjnYGeXEixkzZsTFxZWWlgYGBmKYIQiieujhcrmo0K6uro6ODvQzxvuT6urquLi45cuXp6ennzt3bs6cOVLNyGSyRrtmhoaGDg4OAwcOFE10cnLq6elpbm7W9OQW4br/YpIwskRGRpqamjo6Om7cuLGoqMjAwADbM84dBfB7loqhoaGWJ4+TyWR/f//o6OiOjg6pNxxCenp68PTUsBFupCGMIED2RhpOTk5KT30BsgUrtJkHHhS9ZgEALBZr3bp1GRkZfn5+cv2fOXMmLy8vKCgoOTmZwWBI7X4pXXOwM/4nnOXn59vY2IwePVqYgjb+6MA6DKytrWVNYMTPJ598gn548+aNp6cn9tDZ3t5eBoMxYcKEX3/9lUqlLl++nMPhfPDBB5KWAoFAoUtUCb744gsWi8VkMk1MTNCUa9eumZubDx06FDuj6s3JqFGjRo0ahd8+Ozs7NTWVzWbb2dm5urrGxMTIuuUXeuZwOAKBICgoSF2epdLW1mZqaorfXgmOHj06e/Zs0dvMGzdumJmZyX0KhA4MVrH0zz//HP2QlZUl989UEVmChRrUhULXLABg7969UVFRmZmZCxculOu8rq4uLCzs22+/3bx5M41Go9Pp165dk7xklK452Bn/U0xaWlpWVtbXX3+N/uArV67s378/NDR07Nix2GVYWFhIXROhvLy8ubkZAFBTUwMAKC4u1tPTAwCoPmEgPj6+oqICnYG7a9euwsJCOp3OZrNR/0La29vFJgZpgsjIyFOnTk2dOpXJZA4bNuzixYspKSnp6eliYiSRGhnb29vv3buHfkYQ5MWLF0VFRQAAOzs7Ozs7VXQ2NjYuW7Zs06ZN6P/PYrEWL17s4+Oj9JoFavTc1tYm63ZJLXC53ISEBCaTuWHDBldX17a2thMnTpw/fz49PZ1MljNH1szMTOpt140bNwQCAQCgpaWls7MTPU1UKpXwZcZlCcaD5q7Z7du3JyQkREdHDxs2DP2vAACGhoZSpzAKBILg4GBHR8ctW7bo6ellZmZ6eHgwmUzJgV9K1xw5GUVfx/T19aWlpdFoNCqVamxs7OHhceDAATzvWBEEWbt27V9//SWW6O/vL7VQ7Bdely5dwh5KUlRUhP5ZwpTHjx+bmJjExMSIWZ45c+bAgQN49KvIq1evwsLCrKysDA0NPT09L1y4gCdXYGCg5HDcmzdvSv3TVHxJjY6JFQ6sQQkPD7e0tMQYOYEgSE1NTVZWliY8izJr1qyOjg6cxsrR3t7+7bffOjs7Dxw4cMiQIb6+vpcuXcKTsaSkROqoLCMjI8nTJPcl9b59+5RRrwiyBONBQ9esrMGDVlZWUu0TExOFQ3ZQ0FE+kqfsu+++y8nJwf37/h/sKid9PKMS3Lt3D898OC0zf/78pqYmolXIZMuWLRUVFUSr0An8/f2JliCTjo4OOp1OtAoF6HeCVSEkJKSxsVGJjNhVTm1r7bi6ujY0NLx69UpdDlWHw+HY2dnp8vAFNze3iooKolUQT1tbm6WlJdEqZDJo0CDJFxe6TL8TrArNzc1yH+hLIrfKqXMVsri4uNTUVDU6VJFDhw7FxMQQrQKLTz/9VNa983vFtWvXxBbg0TWsrKza2tq0XGhJScnkyZNHjx49ZsyYvXv3KpSXEMHap7W1Vbmuj9wqp87I6Orq+tlnn6nRoYqEhYXpck8EAGBtba1TvWyiyMvLmzlzJtEqsAgICCgoKNByoQiCHD9+vLy8vLi4OCkpqbq6Gn9eQgRrn4KCAlkPRrGRW+XUvHKth4eHeh2qgjYXa1Cajz766OnTp0SrIJjGxka5I8OIxdfXNzc3V8uFTpw4ER3B9+DBAxMTE4XewBIiWPsUFBQEBAQokVFulYNrehNMSEjIqVOniFZBJGVlZbq/9DSFQjE0NOzq6tJyucXFxba2tvPnz//tt99EF6qRC1GCtQmPx+vq6lJiyA6eKgcjI8HY29u/fPkS0foEat3h999/X7p0KdEq5LNkyZIzZ85ouVAajVZfX5+VlbVkyRJFZwcTIlibZGdn4xkxLgmeKgcjI/EsXLjwxYsXRKsgDCcnJ6Xn7WqTiRMnouO6CSna398/Oztb0VxECdYOHR0dyk1SwFPlSO9zbwUC0WWYTOaXX35pa2vb3Nw8efLk/fv3v/ObqekOmlqBBgKBqAiNRps7dy6fz+/t7V29ejUMi9oE9hkhEAhEHPicEQKBQMT5P9v4mp+q5jgPAAAAAElFTkSuQmCC\"></div>"
+      ],
+      "text/plain": [
+       "    1          -1 + 2 x               2\n",
+       "--------- - -------------- + -------------------\n",
+       "3 (1 + x)               2                     2\n",
+       "            6 (1 - x + x )          (-1 + 2 x)\n",
+       "                             3 (1 + -----------)\n",
+       "                                         3"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {
+      "text/html": [],
+      "text/plain": []
+     },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "D[Integrate[1/(x^3 + 1), x], x]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Wolfram Language 13.1",
+   "language": "Wolfram Language",
+   "name": "wolframlanguage13.1"
+  },
+  "language_info": {
+   "codemirror_mode": "mathematica",
+   "file_extension": ".wolfram",
+   "mimetype": "application/vnd.wolfram.m",
+   "name": "Wolfram Language",
+   "pygments_lexer": "mathematica",
+   "version": "12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/notebooks/mirror/ipynb_to_Rmd/wolfram.Rmd
+++ b/tests/notebooks/mirror/ipynb_to_Rmd/wolfram.Rmd
@@ -1,0 +1,28 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Wolfram Language 13.1
+    language: Wolfram Language
+    name: wolframlanguage13.1
+---
+
+**Note:** The `language_info` `file_extension` in this notebook should be `.m`, but it was deliberately changed to `.wolfram` to avoid conflicts with Matlab which is using the same extension.
+
+
+We start with...
+
+```{wolfram language}
+Print["Hello, World!"];
+```
+
+Then we draw the first example plot from the [ListPlot](https://reference.wolfram.com/language/ref/ListPlot.html) reference:
+
+```{wolfram language}
+ListPlot[Prime[Range[25]]]
+```
+
+We also test the math outputs as in the [Simplify](https://reference.wolfram.com/language/ref/Simplify.html) example:
+
+```{wolfram language}
+D[Integrate[1/(x^3 + 1), x], x]
+```

--- a/tests/notebooks/mirror/ipynb_to_hydrogen/wolfram.wolfram
+++ b/tests/notebooks/mirror/ipynb_to_hydrogen/wolfram.wolfram
@@ -1,0 +1,28 @@
+(* --- *)
+(* jupyter: *)
+(*   kernelspec: *)
+(*     display_name: Wolfram Language 13.1 *)
+(*     language: Wolfram Language *)
+(*     name: wolframlanguage13.1 *)
+(* --- *)
+
+(* %% [markdown] *)
+(* **Note:** The `language_info` `file_extension` in this notebook should be `.m`, but it was deliberately changed to `.wolfram` to avoid conflicts with Matlab which is using the same extension. *)
+
+(* %% [markdown] *)
+(* We start with... *)
+
+(* %% *)
+Print["Hello, World!"];
+
+(* %% [markdown] *)
+(* Then we draw the first example plot from the [ListPlot](https://reference.wolfram.com/language/ref/ListPlot.html) reference: *)
+
+(* %% *)
+ListPlot[Prime[Range[25]]]
+
+(* %% [markdown] *)
+(* We also test the math outputs as in the [Simplify](https://reference.wolfram.com/language/ref/Simplify.html) example: *)
+
+(* %% *)
+D[Integrate[1/(x^3 + 1), x], x]

--- a/tests/notebooks/mirror/ipynb_to_md/wolfram.md
+++ b/tests/notebooks/mirror/ipynb_to_md/wolfram.md
@@ -1,0 +1,28 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Wolfram Language 13.1
+    language: Wolfram Language
+    name: wolframlanguage13.1
+---
+
+**Note:** The `language_info` `file_extension` in this notebook should be `.m`, but it was deliberately changed to `.wolfram` to avoid conflicts with Matlab which is using the same extension.
+
+
+We start with...
+
+```wolfram language
+Print["Hello, World!"];
+```
+
+Then we draw the first example plot from the [ListPlot](https://reference.wolfram.com/language/ref/ListPlot.html) reference:
+
+```wolfram language
+ListPlot[Prime[Range[25]]]
+```
+
+We also test the math outputs as in the [Simplify](https://reference.wolfram.com/language/ref/Simplify.html) example:
+
+```wolfram language
+D[Integrate[1/(x^3 + 1), x], x]
+```

--- a/tests/notebooks/mirror/ipynb_to_myst/wolfram.md
+++ b/tests/notebooks/mirror/ipynb_to_myst/wolfram.md
@@ -1,0 +1,28 @@
+---
+kernelspec:
+  display_name: Wolfram Language 13.1
+  language: Wolfram Language
+  name: wolframlanguage13.1
+---
+
+**Note:** The `language_info` `file_extension` in this notebook should be `.m`, but it was deliberately changed to `.wolfram` to avoid conflicts with Matlab which is using the same extension.
+
++++
+
+We start with...
+
+```{code-cell} mathematica
+Print["Hello, World!"];
+```
+
+Then we draw the first example plot from the [ListPlot](https://reference.wolfram.com/language/ref/ListPlot.html) reference:
+
+```{code-cell} mathematica
+ListPlot[Prime[Range[25]]]
+```
+
+We also test the math outputs as in the [Simplify](https://reference.wolfram.com/language/ref/Simplify.html) example:
+
+```{code-cell} mathematica
+D[Integrate[1/(x^3 + 1), x], x]
+```

--- a/tests/notebooks/mirror/ipynb_to_percent/wolfram.wolfram
+++ b/tests/notebooks/mirror/ipynb_to_percent/wolfram.wolfram
@@ -1,0 +1,28 @@
+(* --- *)
+(* jupyter: *)
+(*   kernelspec: *)
+(*     display_name: Wolfram Language 13.1 *)
+(*     language: Wolfram Language *)
+(*     name: wolframlanguage13.1 *)
+(* --- *)
+
+(* %% [markdown] *)
+(* **Note:** The `language_info` `file_extension` in this notebook should be `.m`, but it was deliberately changed to `.wolfram` to avoid conflicts with Matlab which is using the same extension. *)
+
+(* %% [markdown] *)
+(* We start with... *)
+
+(* %% *)
+Print["Hello, World!"];
+
+(* %% [markdown] *)
+(* Then we draw the first example plot from the [ListPlot](https://reference.wolfram.com/language/ref/ListPlot.html) reference: *)
+
+(* %% *)
+ListPlot[Prime[Range[25]]]
+
+(* %% [markdown] *)
+(* We also test the math outputs as in the [Simplify](https://reference.wolfram.com/language/ref/Simplify.html) example: *)
+
+(* %% *)
+D[Integrate[1/(x^3 + 1), x], x]

--- a/tests/notebooks/mirror/ipynb_to_script/wolfram.wolfram
+++ b/tests/notebooks/mirror/ipynb_to_script/wolfram.wolfram
@@ -1,0 +1,21 @@
+(* --- *)
+(* jupyter: *)
+(*   kernelspec: *)
+(*     display_name: Wolfram Language 13.1 *)
+(*     language: Wolfram Language *)
+(*     name: wolframlanguage13.1 *)
+(* --- *)
+
+(* **Note:** The `language_info` `file_extension` in this notebook should be `.m`, but it was deliberately changed to `.wolfram` to avoid conflicts with Matlab which is using the same extension. *)
+
+(* We start with... *)
+
+Print["Hello, World!"];
+
+(* Then we draw the first example plot from the [ListPlot](https://reference.wolfram.com/language/ref/ListPlot.html) reference: *)
+
+ListPlot[Prime[Range[25]]]
+
+(* We also test the math outputs as in the [Simplify](https://reference.wolfram.com/language/ref/Simplify.html) example: *)
+
+D[Integrate[1/(x^3 + 1), x], x]


### PR DESCRIPTION
This adds support for Wolfram Language notebooks. For background, see:
  https://github.com/WolframResearch/WolframLanguageForJupyter

Unfortunately, the way the Wolfram Language Jupyter kernel was designed poses a couple of issues with jupytext which I had to work around in this commit:

 - The language_info name is "Wolfram Language", which has unusual capitalization and whitespace. jupytext is mostly fine with this, except for Rmd where I had to hack around it in the parser.

 - The file extension is .m which clashes with Matlab. The current code structure seems to assume that an extension always maps to a single language. I worked around it by inventing a new extension (.wolfram), which is clearly not great but works fine for most use cases.