### PR TITLE
fix: Get CI running again

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,11 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.9
+      - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
-      - uses: pre-commit/action@v2.0.0
+          python-version: "3.x"
+      - uses: pre-commit/action@v3.0.0
 
   analyse:
     name: Analyse

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -101,13 +101,13 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r requirements-dev.txt
+          python -m pip install -r requirements.txt
+          python -m pip install -r requirements-dev.txt
           # install sphinx_gallery and matplotlib if available (may not work on pypy)
-          pip install sphinx_gallery~=0.7.0 || true
-          pip install jupyter-fs || true
+          python -m pip install sphinx_gallery~=0.7.0 || true
+          python -m pip install jupyter-fs || true
       - name: Install from source (required for the pre-commit tests)
-        run: pip install .
+        run: python -m pip install .
       - name: Install a Jupyter Kernel
         run: python -m ipykernel install --name python_kernel --user
       - name: Install Quarto
@@ -152,7 +152,7 @@ jobs:
       - name: Install from source
         # This is required for the pre-commit tests
         shell: pwsh
-        run: pip install .
+        run: python -m pip install .
       - name: Create kernel
         shell: pwsh
         run: |
@@ -190,8 +190,8 @@ jobs:
           run: |
             python -m pip install --upgrade pip
             # All dependencies but markdown-it-py
-            pip install nbformat pyyaml toml
-            pip install -r requirements-dev.txt
+            python -m pip install nbformat pyyaml toml
+            python -m pip install -r requirements-dev.txt
         - name: Install a Jupyter Kernel
           run: python -m ipykernel install --name python_kernel --user
         - name: Test with pytest
@@ -216,8 +216,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r requirements-dev.txt
+          python -m pip install -r requirements.txt
+          python -m pip install -r requirements-dev.txt
       - name: Test with pytest
         run: pytest --cov=./ --cov-report=xml
       - name: Upload coverage
@@ -241,10 +241,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           # All dependencies but markdown-it-py
-          pip install -r requirements.txt
-          pip install -r requirements-dev.txt
+          python -m pip install -r requirements.txt
+          python -m pip install -r requirements-dev.txt
           # Notebook pre-release version #933
-          pip install --pre -U notebook
+          python -m pip install --pre -U notebook
       - name: Install a Jupyter Kernel
         run: python -m ipykernel install --name python_kernel --user
       - name: Test with pytest
@@ -264,7 +264,7 @@ jobs:
           python-version: 3.9
       - name: Build package
         run: |
-          pip install wheel jupyter-packaging jupyterlab>=3
+          python -m pip install wheel jupyter-packaging jupyterlab>=3
           BUILD_JUPYTERLAB_EXTENSION=1 python setup.py sdist bdist_wheel
           # Don't publish a tar.gz file over 1MB  (Issue #730)
           if (($(wc -c < dist/*.tar.gz) > 1000000)); then exit 1; fi
@@ -274,7 +274,7 @@ jobs:
           if (($(tar -tf dist/*.tar.gz | grep packages/labextension/package.json$ | wc -l)==0)); then echo "Missing lab extension" && exit 1; fi
           if (($(tar -tf dist/*.tar.gz | grep jupytext/nbextension/index.js$ | wc -l)==0)); then echo "Missing notebook extension" && exit 1; fi
           # Install
-          pip install dist/*.tar.gz
+          python -m pip install dist/*.tar.gz
           echo "Install went OK"
   publish:
     name: Publish to PyPi
@@ -290,7 +290,7 @@ jobs:
           python-version: 3.9
       - name: Build package
         run: |
-          pip install wheel jupyter-packaging jupyterlab>=3
+          python -m pip install wheel jupyter-packaging jupyterlab>=3
           BUILD_JUPYTERLAB_EXTENSION=1 python setup.py sdist bdist_wheel
       - name: Publish
         uses: pypa/gh-action-pypi-publish@v1.1.0

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -30,6 +30,31 @@ jobs:
           python-version: "3.x"
       - uses: pre-commit/action@v3.0.0
 
+  lint:
+    name: Lint
+    needs: skip_duplicate
+    if: ${{ needs.skip_duplicate.outputs.should_skip == 'false' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install flake8
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # all Python files should follow PEP8 (except some notebooks, see setup.cfg)
+          flake8 jupytext tests
+          # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --statistics
+
   analyse:
     name: Analyse
     needs: skip_duplicate
@@ -60,7 +85,7 @@ jobs:
         uses: github/codeql-action/analyze@v1
 
   test-pip:
-    needs: skip_duplicate
+    needs: lint
     if: ${{ needs.skip_duplicate.outputs.should_skip == 'false' }}
     strategy:
       matrix:
@@ -78,21 +103,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
-          # install black, isort, and autopep8 for testing the pipe mode
-          pip install black
-          pip install isort>=5.3.0
-          pip install autopep8
           # install sphinx_gallery and matplotlib if available (may not work on pypy)
           pip install sphinx_gallery~=0.7.0 || true
           pip install jupyter-fs || true
-      - name: Lint with flake8
-        run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # all Python files should follow PEP8 (except some notebooks, see setup.cfg)
-          flake8 jupytext tests
-          # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --statistics
       - name: Install from source (required for the pre-commit tests)
         run: pip install .
       - name: Install a Jupyter Kernel
@@ -111,7 +124,7 @@ jobs:
         uses: codecov/codecov-action@v1
 
   test-conda:
-    needs: skip_duplicate
+    needs: lint
     if: ${{ needs.skip_duplicate.outputs.should_skip == 'false' }}
     strategy:
       matrix:
@@ -136,15 +149,6 @@ jobs:
           channels: defaults,conda-forge
           environment-file: environment-ci.yml
           use-only-tar-bz2: true
-      - name: Lint with flake8
-        shell: pwsh
-        run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # all Python files should follow PEP8 (except some notebooks, see setup.cfg)
-          flake8 jupytext tests
-          # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --statistics
       - name: Install from source
         # This is required for the pre-commit tests
         shell: pwsh

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,9 +23,9 @@ jobs:
     if: ${{ needs.skip_duplicate.outputs.should_skip == 'false' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.9
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - uses: pre-commit/action@v2.0.0
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # We must fetch at least the immediate parents so that if this is
           # a pull request then we can check out the head.
@@ -68,9 +68,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -120,9 +120,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Cache conda
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/conda_pkgs_dir
           key: conda-${{ matrix.os }}-python-${{ matrix.python-version }}-${{ hashFiles('environment-ci.yml') }}
@@ -177,9 +177,9 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Checkout
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
         - name: Set up Python ${{ matrix.python-version }}
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v4
           with:
             python-version: ${{ matrix.python-version }}
         - name: Install dependencies, except markdown-it-py
@@ -204,9 +204,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -228,9 +228,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -253,9 +253,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python 3.9
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - name: Build package
@@ -279,9 +279,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python 3.9
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - name: Build package

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ exclude: >
 repos:
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
     - id: check-json
     - id: check-yaml
@@ -26,24 +26,24 @@ repos:
     - id: trailing-whitespace
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.1
+    rev: v3.3.1
     hooks:
     - id: pyupgrade
       args: ["--py36-plus"]
 
   - repo: https://github.com/myint/autoflake
-    rev: v1.4
+    rev: v2.0.1
     hooks:
     - id: autoflake
       args: ['--in-place', '--remove-all-unused-imports', '--remove-unused-variable']
 
   - repo: https://github.com/pycqa/flake8
-    rev: 3.9.2
+    rev: 6.0.0
     hooks:
     - id: flake8
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       # isort needs the 'black' profile when used in combination with black
       # See https://github.com/PyCQA/isort/issues/1518
@@ -51,6 +51,6 @@ repos:
       args: ["--profile", "black"]
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.1.0
     hooks:
     - id: black

--- a/jupytext/cell_reader.py
+++ b/jupytext/cell_reader.py
@@ -770,7 +770,6 @@ class LightScriptCellReader(ScriptCellReader):
                     self.cell_marker_start or i == 0 or _BLANK_LINE.match(lines[i - 1])
                 )
             ):
-
                 if self.explicit_end_marker_required:
                     # Metadata here was conditioned on finding an explicit end marker
                     # before the next start marker. So we dismiss it.

--- a/jupytext/compare.py
+++ b/jupytext/compare.py
@@ -246,7 +246,6 @@ def compare_cells(
         if (ref_cell.cell_type == "code" and not allow_missing_code_cell_metadata) or (
             ref_cell.cell_type != "code" and not allow_missing_markdown_cell_metadata
         ):
-
             ref_metadata = ref_cell.metadata
             test_metadata = test_cell.metadata
             if allow_filtered_cell_metadata:

--- a/jupytext/myst.py
+++ b/jupytext/myst.py
@@ -311,7 +311,6 @@ def myst_to_notebook(
     md_metadata = {}
 
     for token in tokens:
-
         nesting_level += token.nesting
 
         if nesting_level != 0:
@@ -381,7 +380,6 @@ def notebook_to_myst(
 
     last_cell_md = False
     for i, cell in enumerate(nb.cells):
-
         if cell.cell_type == "markdown":
             metadata = from_nbnode(cell.metadata)
             if metadata or last_cell_md:

--- a/tests/test_combine.py
+++ b/tests/test_combine.py
@@ -46,7 +46,7 @@ def test_read_text_and_combine_with_outputs(tmpdir):
     tmp_ipynb = "notebook.ipynb"
     tmp_script = "notebook.py"
 
-    with (open(str(tmpdir.join(tmp_script)), "w")) as fp:
+    with open(str(tmpdir.join(tmp_script)), "w") as fp:
         fp.write(
             """# ---
 # jupyter:
@@ -61,7 +61,7 @@ def test_read_text_and_combine_with_outputs(tmpdir):
 """
         )
 
-    with (open(str(tmpdir.join(tmp_ipynb)), "w")) as fp:
+    with open(str(tmpdir.join(tmp_ipynb)), "w") as fp:
         fp.write(
             """{
  "cells": [

--- a/tests/test_hide_remove_input_outputs_rmarkdown.py
+++ b/tests/test_hide_remove_input_outputs_rmarkdown.py
@@ -56,7 +56,8 @@ def test_jupyter_book_options_to_rmarkdown(md, rmd):
 )
 def test_runtools_options_to_rmarkdown(md, rmd):
     """Options set by the runtools extension are mapped to the corresponding R Markdown options
-    https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/nbextensions/runtools/readme.html"""
+    https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/nbextensions/runtools/readme.html
+    """
     md = (
         "```python "
         + md

--- a/tests/test_read_simple_python.py
+++ b/tests/test_read_simple_python.py
@@ -1209,7 +1209,6 @@ if True:
     ],
 )
 def test_indented_magic_commands(script, cell):
-
     nb = jupytext.reads(script, "py")
     assert len(nb.cells) == 1
     assert nb.cells[0].cell_type == "code"


### PR DESCRIPTION
I saw that `jupytext`'s CI was broken so thought I'd try to help fix it. There's lots of cleaning that could be done on the CI, but this just gets it running again.

This updates all the GitHub Actions to their latest releases and updates and applies the pre-commit hooks so those pass as well. It additionally fixes the dependency conflicts happening by trying to install the linting dependencies for older Pythons by just having the lint job be separate as it only needs to run once, not for every Python being tested.

I also threw in the use of `python -m pip` pattern over just `pip` even though it isn't needed to try to spread this best practice to others who might be looking at jupytext's CI. Feel free to ask for that to be removed if you aren't a fan.