### PR TITLE
Temporary workaround for #1051 on Binder

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -21,3 +21,7 @@ jupyter trust demo/World\ population.ipynb
 
 # Install the bash kernel
 python -m bash_kernel.install
+
+# This is a **TEMPORARY** workaround for https://github.com/mwouts/jupytext/issues/1051
+# Please make sure to remove this when a fix is provided in nbclassic
+pip install git+https://github.com/mwouts/nbclassic.git@do_not_redirect_notebook_to_files


### PR DESCRIPTION
With this PR we install a dev version of `nbclassic` that does not redirect text notebooks to `files/` (causing text notebooks to be downloaded rather than opened)