### PR TITLE
Create directory structure on rename

### DIFF
--- a/jupytext/contentsmanager.py
+++ b/jupytext/contentsmanager.py
@@ -481,6 +481,7 @@ to your jupytext.toml file
             for old_alt_path, alt_fmt in old_alt_paths:
                 new_alt_path = full_path(new_base, alt_fmt)
                 if self.exists(old_alt_path):
+                    os.makedirs(os.path.dirname(new_alt_path), exist_ok=True)
                     self.super.rename_file(old_alt_path, new_alt_path)
 
             self.drop_paired_notebook(old_path)


### PR DESCRIPTION
Using a global configuration like this one:

```toml
formats = "notebooks///ipynb,scripts///py:percent"
```

and moving a notebook stored under `./notebook/my_notebook.ipynb` to a newly created `./notebook/subdir` directory (so that the destination would be `./notebook/subdir/my_notebook.ipynb`) fails when `subdir` is not already present under `./scripts/`.

The proposed change makes the process transparent to the user, by lazily creating the necessary "folder tree" in the mirrored destination.

Issue: https://github.com/mwouts/jupytext/issues/1059