### PR TITLE
Release jupyterlab-jupytext==1.3.9

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,14 @@
 Jupytext ChangeLog
 ==================
 
+1.14.6 (2023-06-04)
+-------------------
+
+**Changed**
+- This version comes with a build requirement `jupyterlab>=3,<4`, as the Jupyterlab
+extension for Jupytext is not compatible with JupyterLab 4 yet (#1054)
+- The JupyterLab extension was released to `npm` in version 1.3.9.
+
 1.14.5 (2023-02-25)
 -------------------
 

--- a/jupytext/version.py
+++ b/jupytext/version.py
@@ -1,3 +1,3 @@
 """Jupytext's version number"""
 
-__version__ = "1.14.5"
+__version__ = "1.14.6"

--- a/packages/labextension/CHANGELOG.md
+++ b/packages/labextension/CHANGELOG.md
@@ -1,6 +1,7 @@
-# 1.3.8+dev
+# 1.3.9 (2022-06-02)
 
 - We updated the `yarn.lock` file for the jupyter lab extension to address security vulnerabilities ([#904](https://github.com/mwouts/jupytext/issues/904), [#925](https://github.com/mwouts/jupytext/issues/925), [#935](https://github.com/mwouts/jupytext/issues/935), [#939](https://github.com/mwouts/jupytext/issues/939), [#984](https://github.com/mwouts/jupytext/issues/984), [#1005](https://github.com/mwouts/jupytext/issues/1005), [#1011](https://github.com/mwouts/jupytext/issues/1011), [#1030](https://github.com/mwouts/jupytext/issues/1030), [#1036](https://github.com/mwouts/jupytext/issues/1036))
+- This version is the last version that is compatible with `jupyterlab==3.x`.
 
 # 1.3.8 (2021-12-03)
 

--- a/packages/labextension/CHANGELOG.md
+++ b/packages/labextension/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1.3.9 (2022-06-02)
 
-- We updated the `yarn.lock` file for the jupyter lab extension to address security vulnerabilities ([#904](https://github.com/mwouts/jupytext/issues/904), [#925](https://github.com/mwouts/jupytext/issues/925), [#935](https://github.com/mwouts/jupytext/issues/935), [#939](https://github.com/mwouts/jupytext/issues/939), [#984](https://github.com/mwouts/jupytext/issues/984), [#1005](https://github.com/mwouts/jupytext/issues/1005), [#1011](https://github.com/mwouts/jupytext/issues/1011), [#1030](https://github.com/mwouts/jupytext/issues/1030), [#1036](https://github.com/mwouts/jupytext/issues/1036))
+- We updated the `yarn.lock` file for the jupyter lab extension to address security vulnerabilities ([#904](https://github.com/mwouts/jupytext/issues/904), [#925](https://github.com/mwouts/jupytext/issues/925), [#935](https://github.com/mwouts/jupytext/issues/935), [#939](https://github.com/mwouts/jupytext/issues/939), [#984](https://github.com/mwouts/jupytext/issues/984), [#1005](https://github.com/mwouts/jupytext/issues/1005), [#1011](https://github.com/mwouts/jupytext/issues/1011), [#1030](https://github.com/mwouts/jupytext/issues/1030), [#1036](https://github.com/mwouts/jupytext/issues/1036), [#1052](https://github.com/mwouts/jupytext/pull/1052))
 - This version is the last version that is compatible with `jupyterlab==3.x`.
 
 # 1.3.8 (2021-12-03)

--- a/packages/labextension/package.json
+++ b/packages/labextension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab-jupytext",
-  "version": "1.3.8+dev",
+  "version": "1.3.9",
   "description": "Save Jupyter Notebooks as Scripts or Markdown files that work well with version control & external text editors",
   "keywords": [
     "jupyter",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["jupyter_packaging~=0.7.9", "jupyterlab>=3.0.0,==3.*", "setuptools>=40.8.0", "wheel"]
+requires = ["jupyter_packaging~=0.7.9", "jupyterlab>=3,<=4", "setuptools>=40.8.0", "wheel"]
 build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 filterwarnings = [


### PR DESCRIPTION
This is the last version of the extension compatible with `jupyterlab==3.x`.