### PR TITLE
fix: current version not compatible with JupyterLab v4+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["jupyter_packaging~=0.7.9", "jupyterlab>=3.0.0,==3.*", "setuptools>=40.8.0", "wheel"]
+requires = ["jupyter_packaging~=0.7.9", "jupyterlab>=3.0.0 <4.0.0,==3.*", "setuptools>=40.8.0", "wheel"]
 build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 filterwarnings = [


### PR DESCRIPTION
I simply made a requirements list change that added ` <4.0.0` to the `pyproject.toml` for `jupyterlab`.

Per this, in-progress, issue: [TypeError... not a function with JupyterLab 4](https://github.com/mwouts/jupytext/issues/1054#issue-1645593510)