### PR TITLE
Use either `pkg_resources` or `packaging` to parse version numbers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ Jupytext ChangeLog
 - Double quote strings in R Markdown options can contain single quotes ([#1079](https://github.com/mwouts/jupytext/issues/1079))
 - The necessary directories are created when paired notebooks are moved to a sub-folder ([#1059](https://github.com/mwouts/jupytext/issues/1059))
 - Commented quotes are recognized as such ([#1060](https://github.com/mwouts/jupytext/issues/1060))
+- Jupytext can use either `pkg_resources` or `packaging` to parse version numbers ([#1085](https://github.com/mwouts/jupytext/issues/1085))
 
 
 1.14.6 (2023-06-04)

--- a/jupytext/cell_reader.py
+++ b/jupytext/cell_reader.py
@@ -8,10 +8,10 @@ from nbformat.v4.nbbase import new_code_cell, new_markdown_cell, new_raw_cell
 
 from .doxygen import doxygen_to_markdown
 from .languages import _SCRIPT_EXTENSIONS
+from .parse_version import parse_version
 
 # Sphinx Gallery is an optional dependency. And we intercept the SyntaxError for #301
 try:
-    from pkg_resources import parse_version
     from sphinx_gallery import __version__ as sg_version
 
     if parse_version(sg_version) <= parse_version("0.7.0"):

--- a/jupytext/pandoc.py
+++ b/jupytext/pandoc.py
@@ -3,10 +3,13 @@
 import os
 import subprocess
 import tempfile
+from functools import partial
 
 # Copy nbformat reads and writes to avoid them being patched in the contents manager!!
 from nbformat import reads as ipynb_reads
 from nbformat import writes as ipynb_writes
+
+from .parse_version import parse_version as parse
 
 
 class PandocError(OSError):
@@ -48,11 +51,6 @@ def is_pandoc_available(min_version="2.7.2", max_version=None):
 
 def raise_if_pandoc_is_not_available(min_version="2.7.2", max_version=None):
     """Raise with an informative error message if pandoc is not available"""
-    try:
-        from pkg_resources import parse_version
-    except ImportError:
-        raise PandocError("Please install pkg_resources")
-
     version = pandoc_version()
     if version == "N/A":
         raise PandocError(
@@ -60,6 +58,7 @@ def raise_if_pandoc_is_not_available(min_version="2.7.2", max_version=None):
             "but pandoc was not found"
         )
 
+    parse_version = partial(parse, custom_error=PandocError)
     if parse_version(version) < parse_version(min_version):
         raise PandocError(
             f"The Pandoc Markdown format requires 'pandoc>={min_version}', "

--- a/jupytext/parse_version.py
+++ b/jupytext/parse_version.py
@@ -1,0 +1,11 @@
+def parse_version(version, custom_error=ImportError):
+    try:
+        from pkg_resources import parse_version as parse
+    except ImportError:
+        try:
+            from packaging.version import parse
+        except ImportError:
+            raise custom_error("Please install either pkg_resources or packaging")
+
+    print(version)
+    return parse(version)

--- a/jupytext/quarto.py
+++ b/jupytext/quarto.py
@@ -3,10 +3,13 @@
 import os
 import subprocess
 import tempfile
+from functools import partial
 
 # Copy nbformat reads and writes to avoid them being patched in the contents manager!!
 from nbformat import reads as ipynb_reads
 from nbformat import writes as ipynb_writes
+
+from .parse_version import parse_version as parse
 
 QUARTO_MIN_VERSION = "0.2.134"
 
@@ -43,11 +46,6 @@ def is_quarto_available(min_version=QUARTO_MIN_VERSION):
 
 def raise_if_quarto_is_not_available(min_version=QUARTO_MIN_VERSION):
     """Raise with an informative error message if quarto is not available"""
-    try:
-        from pkg_resources import parse_version
-    except ImportError:
-        raise QuartoError("Please install pkg_resources")
-
     version = quarto_version()
     if version == "N/A":
         raise QuartoError(
@@ -55,6 +53,7 @@ def raise_if_quarto_is_not_available(min_version=QUARTO_MIN_VERSION):
             "but quarto was not found"
         )
 
+    parse_version = partial(parse, custom_error=QuartoError)
     if parse_version(version) < parse_version(min_version):
         raise QuartoError(
             f"The Quarto Markdown format requires 'quarto>={min_version}', "


### PR DESCRIPTION
Fixes #1085 