### PR TITLE
Rename publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Publish
 on:
   push:
     tags:


### PR DESCRIPTION
The name is currently `CI` which is incorrect