### PR TITLE
a helper tool for initializing defaultViewers in labconfig/

### DIFF
--- a/demo/get_started.md
+++ b/demo/get_started.md
@@ -23,6 +23,7 @@ a bit of what happens under the hood.
 installation instructions and activate the JupyterLab plugin. If you're on
 Binder, it should already work.**
 
+
 ## Enabling Jupytext in a new notebook
 
 This notebook is brand new - it hasn't had any special extra metadata added
@@ -35,7 +36,7 @@ we can use the JupyterLab **command palette** to do so.
 * Then type **`Jupytext`**. You should see a number of commands come up. Each
   one tells Jupytext to save the notebook in a different
   file format automatically.
-* Select **Pair notebook with Markdown**
+* Select **Pair notebook with MyST Markdown**
 
 That's it! If you have Jupytext installed, it will now save your notebook in
 markdown format automatically when you save this `.ipynb` file
@@ -43,6 +44,7 @@ markdown format automatically when you save this `.ipynb` file
 
 After you've done this, save the notebook. You should now see a new file called
 **`get_started.md`** in the same directory as this notebook.
+
 
 ## How does Jupytext know to do this?
 
@@ -76,6 +78,6 @@ plt.scatter(*np.random.randn(2, 100), c=np.random.randn(100), s=np.random.rand(1
 
 # Experiment with the demo notebook!
 
-In the "demo" folder for `jupytext` there is a notebook called **`World population.ipynb`**.
+In the *`demo/`* folder for `jupytext` there is a notebook called **`World population.ipynb`**.
 By default, saving the demo notebook will also create *many* possible Jupytext
 outputs so you can see what each looks like and which you prefer.

--- a/docs/install.md
+++ b/docs/install.md
@@ -54,6 +54,11 @@ jupyter labextension install jupyterlab-jupytext@1.1.1  # for JupyterLab 1.x
 
 ## Jupytext menu in Jupyter Notebook
 
+*Note*: as of this writing (version 1.15.1) this section **applies only to
+notebook classic**, i.e. Jupyter Notebook 6.x and below. See [PR
+#1095](https://github.com/mwouts/jupytext/issues/1095) where we discuss how to
+add a Jupytext menu to Jupyter Lab and Notebook 7.x.
+
 Jupytext includes an extensions for Jupyter Notebook that adds a Jupytext section in the File menu.
 
 ![](images/jupytext_menu.png)

--- a/docs/text-notebooks.md
+++ b/docs/text-notebooks.md
@@ -1,26 +1,124 @@
 # Text notebooks
 
-Jupytext can save Jupytext Notebooks as text files, with e.g. a `.py` or `.md` extension.
-These text files only contain the inputs of your notebooks, as well as [selected metadata](advanced-options.md#metadata-filtering).
+Jupytext can save Jupyter Notebooks as text files, with e.g. a `.py` or `.md`
+extension. These text files only contain the inputs of your notebooks, as well
+as [selected metadata](advanced-options.md#metadata-filtering).
 
-Text notebooks are well suited for version control. They are standard text files and you can easily edit
-or refactor them in the editor of your choice.
+Text notebooks are well suited for version control. They are standard text files
+and you can easily edit or refactor them in the editor of your choice.
 
-The outputs of the notebook are not stored on disk, unless you decide to [pair](paired-notebooks.md) your text notebook to a regular `.ipynb` file.
-
-Once you have [installed](install.md) Jupytext, `.py` and `.md` files get a notebook icon in Jupyter. And you can really open and run these files as notebooks.
+The outputs of the notebook are not stored on disk, unless you decide to
+[pair](paired-notebooks.md) your text notebook to a regular `.ipynb` file.
 
 ## How to open a text notebook in Jupyter Lab
 
+Once you have [installed](install.md) Jupytext, `.py` and `.md` files get a
+notebook icon in Jupyter. And you can really open and run these files as
+notebooks.
+
 ### With a right click
 
-Right click on the text notebook, then select _open with Notebook_:
+Right click on the text notebook, then select _Open With_ → _Notebook_:
 
 ![](images/jupyterlab_right_click.png)
 
-### With a single click
+Notes:
 
-It is possible to open text notebooks in Jupyter Lab as notebooks with a single click. To do so, go to _Settings_, _Advanced Settings Editor_, and in the JSON view for the `Document Manager` copy-paste the following settings (or the subset that matches your use case):
+* you can achieve the same result if you use _Open With_ → _Jupytext Notebook_
+* to open links to `.md` files in notebooks with the Notebook editor, you will
+  need `jupyterlab>=3.6.0`.
+
+### With a double click
+
+Right clicking and the _Open With_ submenu allows you to choose among several
+ways to open a file (several **viewers**, in Jupyter Lab jargon); and when you
+double click instead, you open the file using **its default viewer**.
+
+The default viewer for text notebooks is by default configured to be the
+**Editor** (which means: text editor); if you'd prefer to have the text files
+open as a notebook instead, you have the option to **redefine the default
+viewer**, which is something defined for each document type.
+
+Since version 1.15.1, `jupytext` comes with a helper command that allows you to
+do this from the command line; and essentially you would just need to run
+
+```bash
+jupytext-config set-default-viewer
+```
+
+See also [the last section below](#more-on-default-viewers) for alternative
+means to change and inspect the default viewers configuration
+
+## How to open a text notebook in Jupyter notebook (nb7)
+
+As of July 2023, Jupyter Notebook now comes as version 7.x - and is known in short as nb7
+
+nb7 being built on top of Jupyter Lab, the principles described above apply as
+well in this context; which means that
+
+* you can always right-click a file and select *Open With* → *Notebook*;
+* and if you have properly defined the default viewers as described above, you
+  can also double-click a file to open it as a notebook.
+
+
+## How to open a text notebook in Jupyter Notebook (classic)
+
+Previous releases of Jupyter Notebook, i.e. up to version 6, were known as notebook classic
+
+By default, notebook classic opens scripts and Markdown documents as notebooks.
+If you want to open them with the text editor, select the document and click on
+_edit_:
+
+![](https://github.com/mwouts/jupytext-screenshots/raw/master/JupytextDocumentation/OpenAsText.png)
+
+
+## How to decide which extensions are notebooks
+
+By default, Jupytext will classify documents with a `.py`, `.R`, `.jl`, `.md`,
+`.Rmd`, `.qmd` extension (and more!) as notebooks. If you prefer to limit the
+notebook type to certain extensions, you can add a `notebook_extensions` option
+to your [Jupytext config file (`jupytext.toml`)](config.md) configuration file
+with, for instance, the following value:
+```
+notebook_extensions = "ipynb,md,qmd,Rmd"
+```
+
+
+## More on default viewers
+
+### `jupytext-config`
+
+This command has more options than the one shown above; in particular:
+
+* you can use `jupytext-config` to set only some of the default viewers; for
+  example, if you want to have your `.py` and `.md` files open as a notebook
+  when you double-click them e.g.
+  `jupytext-config set-default-viewer python markdown`
+* you can use `jupytext-config` to inspect the current configuration, e.g.
+  `jupytext-config list-default-viewer`
+* you can use `jupytext-config unset-default-viewer python` to remove some of the settings
+
+Here's an example of a session, starting from the default config of Jupyter Lab
+```bash
+# starting from the default config of Jupyter Lab
+$ jupytext-config list-default-viewer
+# we add the default viewer for 2 doctypes
+$ jupytext-config set-default-viewer python markdown
+# we check what was done
+$ jupytext-config list-default-viewer
+python: Jupytext Notebook
+markdown: Jupytext Notebook
+# we can now remove the default viewer for markdown
+$ jupytext-config unset-default-viewer markdown
+# and check again
+$ jupytext-config list-default-viewer
+python: Jupytext Notebook
+$
+```
+
+### From Jupyter Lab settings dialog
+
+Alternatively to using `jupytext-config`, you can also find the configuration of the default viewers from Jupyter Lab interactively; to do so, go to _Settings_, _Advanced Settings Editor_, and in the JSON view for the `Document Manager` copy-paste the following settings (or the subset that matches your use case):
 
 ```json
 {
@@ -39,25 +137,3 @@ It is possible to open text notebooks in Jupyter Lab as notebooks with a single 
 Here is a screencast of the steps to follow:
 
 ![](images/jupyterlab_default_viewer.gif)
-
-Another possibility is to activate this with a [default_setting_overrides.json](../binder/labconfig/default_setting_overrides.json) file in the `.jupyter/labconfig` folder with e.g.
-```
-wget https://raw.githubusercontent.com/mwouts/jupytext/main/binder/labconfig/default_setting_overrides.json -P  ~/.jupyter/labconfig/
-```
-
-Note: to open links to `.md` files in notebooks with the Notebook editor, you will need `jupyterlab>=3.6.0`.
-
-
-## How to open a text notebook in Jupyter Notebook
-
-By default, Jupyter Notebook open scripts and Markdown documents as notebooks. If you want to open them with the text editor, select the document and click on _edit_:
-
-![](https://github.com/mwouts/jupytext-screenshots/raw/master/JupytextDocumentation/OpenAsText.png)
-
-
-## How to decide which extensions are notebooks
-
-By default, Jupytext will classify documents with a `.py`, `.R`, `.jl`, `.md`, `.Rmd`, `.qmd` extension (and more!) as notebooks. If you prefer to limit the notebook type to certain extensions, you can add a `notebook_extensions` option to your [`jupytext.toml`](config.md) configuration file with, for instance, the following value:
-```
-notebook_extensions = "ipynb,md,qmd,Rmd"
-```

--- a/jupytext/jupytext_config.py
+++ b/jupytext/jupytext_config.py
@@ -28,12 +28,14 @@ class SubCommand:
         return 1
 
 
-class List(SubCommand):
+class ListDefaultViewer(SubCommand):
     def __init__(self):
-        super().__init__("list", "Display current settings in labconfig/")
+        super().__init__(
+            "list-default-viewer", "Display current settings in labconfig/"
+        )
 
     def main(self, args):
-        LabConfig().read().list()
+        LabConfig().read().list_default_viewer()
         return 0
 
     def fill_parser(self, subparser):
@@ -56,7 +58,7 @@ class SetDefaultViewer(SubCommand):
 
 # create the subcommands
 SUBCOMMANDS = [
-    List(),
+    ListDefaultViewer(),
     SetDefaultViewer(),
 ]
 

--- a/jupytext/jupytext_config.py
+++ b/jupytext/jupytext_config.py
@@ -1,0 +1,61 @@
+from argparse import ArgumentParser
+
+from .labconfig import LabConfig
+
+# list of subcommands - filled by SubCommand.__init__
+SUBCOMMANDS = []
+
+
+class SubCommand:
+    def __init__(self, name, help):
+        self.name = name
+        self.help = help
+        SUBCOMMANDS.append(self)
+    def main(self, args):
+        """
+        return 0 if all goes well
+        """
+        print(f"redefine to implement this subcommand")
+    def __call__(self, args):
+        return self.main(args)
+
+
+class List(SubCommand):
+    def __init__(self):
+        super().__init__("list",
+                         "Display current settings in labconfig/")
+    def main(self, args):
+        LabConfig().read().list()
+        return 0
+    def fill_parser(self, subparser):
+        pass
+
+
+class SetDefaultViewer(SubCommand):
+    def __init__(self):
+        super().__init__("set-default-viewer",
+                         "Set default viewers for JupyterLab")
+    def main(self, args):
+        LabConfig().read().set_default_viewers(args.language).write()
+        return 0
+    def fill_parser(self, subparser):
+        subparser.add_argument(
+            "language", nargs='*',
+            help="the language(s) that the viewer applies to")
+
+
+# create the subcommands
+List()
+SetDefaultViewer()
+
+
+def main():
+    parser = ArgumentParser()
+    subparsers = parser.add_subparsers(required=True)
+    for subcommand in SUBCOMMANDS:
+        subparser = subparsers.add_parser(subcommand.name, help=subcommand.help)
+        subparser.set_defaults(func=subcommand)
+        subcommand.fill_parser(subparser)
+    args = parser.parse_args()
+    # calling the subcommand object since it's a callable
+    return args.func(args)

--- a/jupytext/jupytext_config.py
+++ b/jupytext/jupytext_config.py
@@ -1,16 +1,22 @@
+"""
+the code for
+jupytext-config set-default-viewer
+and related subcommands
+"""
+
 from argparse import ArgumentParser
 
 from .labconfig import LabConfig
 
-# list of subcommands - filled by SubCommand.__init__
-SUBCOMMANDS = []
-
 
 class SubCommand:
+    """
+    a subcommand for jupytext-config
+    """
+
     def __init__(self, name, help):
         self.name = name
         self.help = help
-        SUBCOMMANDS.append(self)
 
     def main(self, args):
         """
@@ -49,8 +55,10 @@ class SetDefaultViewer(SubCommand):
 
 
 # create the subcommands
-List()
-SetDefaultViewer()
+SUBCOMMANDS = [
+    List(),
+    SetDefaultViewer(),
+]
 
 
 def main():

--- a/jupytext/jupytext_config.py
+++ b/jupytext/jupytext_config.py
@@ -47,12 +47,15 @@ class SetDefaultViewer(SubCommand):
         super().__init__("set-default-viewer", "Set default viewers for JupyterLab")
 
     def main(self, args):
-        LabConfig().read().set_default_viewers(args.language).write()
+        LabConfig().read().set_default_viewers(args.doctype).write()
         return 0
 
     def fill_parser(self, subparser):
         subparser.add_argument(
-            "language", nargs="*", help="the language(s) that the viewer applies to"
+            "doctype",
+            nargs="*",
+            help=f"the document types to be associated with the notebook editor. "
+            f"Defaults to {' '.join(LabConfig.DOCTYPES)}",
         )
 
 

--- a/jupytext/jupytext_config.py
+++ b/jupytext/jupytext_config.py
@@ -55,8 +55,25 @@ class SetDefaultViewer(SubCommand):
         subparser.add_argument(
             "doctype",
             nargs="*",
-            help=f"the document types to be associated with the notebook editor. "
-            f"Defaults to {' '.join(LabConfig.DOCTYPES)}",
+            help=f"the document types to be associated with the notebook editor; "
+            f"defaults to {' '.join(LabConfig.DOCTYPES)}",
+        )
+
+
+class UnsetDefaultViewer(SubCommand):
+    def __init__(self):
+        super().__init__("unset-default-viewer", "Unset default viewers for JupyterLab")
+
+    def main(self, args):
+        LabConfig().read().unset_default_viewers(args.doctype).write()
+        return 0
+
+    def fill_parser(self, subparser):
+        subparser.add_argument(
+            "doctype",
+            nargs="*",
+            help=f"the document types for which the default viewer will be unset; "
+            f"defaults to {' '.join(LabConfig.DOCTYPES)}",
         )
 
 
@@ -64,6 +81,7 @@ class SetDefaultViewer(SubCommand):
 SUBCOMMANDS = [
     ListDefaultViewer(),
     SetDefaultViewer(),
+    UnsetDefaultViewer(),
 ]
 
 

--- a/jupytext/jupytext_config.py
+++ b/jupytext/jupytext_config.py
@@ -11,37 +11,41 @@ class SubCommand:
         self.name = name
         self.help = help
         SUBCOMMANDS.append(self)
+
     def main(self, args):
         """
         return 0 if all goes well
         """
-        print(f"redefine to implement this subcommand")
-    def __call__(self, args):
-        return self.main(args)
+        print(
+            f"{self.__class__.__name__}: redefine main() to implement this subcommand"
+        )
+        return 1
 
 
 class List(SubCommand):
     def __init__(self):
-        super().__init__("list",
-                         "Display current settings in labconfig/")
+        super().__init__("list", "Display current settings in labconfig/")
+
     def main(self, args):
         LabConfig().read().list()
         return 0
+
     def fill_parser(self, subparser):
         pass
 
 
 class SetDefaultViewer(SubCommand):
     def __init__(self):
-        super().__init__("set-default-viewer",
-                         "Set default viewers for JupyterLab")
+        super().__init__("set-default-viewer", "Set default viewers for JupyterLab")
+
     def main(self, args):
         LabConfig().read().set_default_viewers(args.language).write()
         return 0
+
     def fill_parser(self, subparser):
         subparser.add_argument(
-            "language", nargs='*',
-            help="the language(s) that the viewer applies to")
+            "language", nargs="*", help="the language(s) that the viewer applies to"
+        )
 
 
 # create the subcommands
@@ -54,8 +58,7 @@ def main():
     subparsers = parser.add_subparsers(required=True)
     for subcommand in SUBCOMMANDS:
         subparser = subparsers.add_parser(subcommand.name, help=subcommand.help)
-        subparser.set_defaults(func=subcommand)
+        subparser.set_defaults(subcommand=subcommand)
         subcommand.fill_parser(subparser)
     args = parser.parse_args()
-    # calling the subcommand object since it's a callable
-    return args.func(args)
+    return args.subcommand.main(args)

--- a/jupytext/jupytext_config.py
+++ b/jupytext/jupytext_config.py
@@ -4,6 +4,7 @@ jupytext-config set-default-viewer
 and related subcommands
 """
 
+import sys
 from argparse import ArgumentParser
 
 from .labconfig import LabConfig
@@ -73,5 +74,5 @@ def main():
         subparser = subparsers.add_parser(subcommand.name, help=subcommand.help)
         subparser.set_defaults(subcommand=subcommand)
         subcommand.fill_parser(subparser)
-    args = parser.parse_args()
+    args = parser.parse_args(sys.argv[1:] or ["--help"])
     return args.subcommand.main(args)

--- a/jupytext/labconfig.py
+++ b/jupytext/labconfig.py
@@ -82,6 +82,21 @@ class LabConfig:
         if doctype not in viewers:
             viewers[doctype] = "Jupytext Notebook"
 
+    def unset_default_viewers(self, doctypes=None):
+        if not doctypes:
+            doctypes = self.DOCTYPES
+        for doctype in doctypes:
+            self.unset_default_viewer(doctype)
+        return self
+
+    def unset_default_viewer(self, doctype):
+        viewers = self.config.get("@jupyterlab/docmanager-extension:plugin", {}).get(
+            "defaultViewers", {}
+        )
+        if doctype not in viewers:
+            return
+        del viewers[doctype]
+
     def write(self) -> bool:
         """
         write the labconfig settings file

--- a/jupytext/labconfig.py
+++ b/jupytext/labconfig.py
@@ -1,0 +1,103 @@
+"""
+helper to inspect / initialize jupyterlab labconfig settings
+that are required to open jupytext notebooks in jupyterlab by default
+when these settings are not present, a double click on a jupytext
+notebook will cause jupyterlab to open it in an editor, i.e. as a text file
+"""
+
+import copy
+import json
+import logging
+import pprint
+from pathlib import Path
+
+
+class LabConfig:
+    SETTINGS = Path.home() / ".jupyter" / "labconfig" / "default_setting_overrides.json"
+
+    LANGUAGES = [
+        "python",
+        "markdown",
+        "myst",
+        "r-markdown",
+        "quarto",
+        "julia",
+        "r",
+    ]
+
+    def __init__(self, logger=None):
+        self.logger = logger or logging.getLogger(__name__)
+        self.config = {}
+        # the state before any changes
+        self._prior_config = {}
+
+    def read(self):
+        """
+        read the labconfig settings file
+        """
+        try:
+            if self.SETTINGS.exists():
+                with self.SETTINGS.open() as fid:
+                    self.config = json.load(fid)
+        except OSError as exc:
+            self.logger.error(f"Could not read {self.SETTINGS}", exc)
+            return False
+        # store for further comparison
+        self._prior_config = copy.deepcopy(self.config)
+        return self
+
+    def list(self):
+        """
+        list the current labconfig settings
+        """
+        self.logger.debug(
+            f"Current @jupyterlab/docmanager-extension:plugin in {self.SETTINGS}"
+        )
+        docmanager = self.config.get("@jupyterlab/docmanager-extension:plugin", {})
+        for key, value in docmanager.items():
+            print(f"{key}:")
+            pprint.pprint(value)
+
+    def set_default_viewers(self, languages=None):
+        if not languages:
+            languages = self.LANGUAGES
+        for language in languages:
+            self.set_default_viewer(language)
+        return self
+
+    def set_default_viewer(self, language):
+        if "@jupyterlab/docmanager-extension:plugin" not in self.config:
+            self.config["@jupyterlab/docmanager-extension:plugin"] = {}
+        if (
+            "defaultViewers"
+            not in self.config["@jupyterlab/docmanager-extension:plugin"]
+        ):
+            self.config["@jupyterlab/docmanager-extension:plugin"][
+                "defaultViewers"
+            ] = {}
+        viewers = self.config["@jupyterlab/docmanager-extension:plugin"][
+            "defaultViewers"
+        ]
+        if language not in viewers:
+            viewers[language] = "Jupytext Notebook"
+
+    def write(self) -> bool:
+        """
+        write the labconfig settings file
+        """
+        # compare - avoid changing the file if nothing changed
+        if self.config == self._prior_config:
+            self.logger.info(f"Nothing to do for {self.SETTINGS}")
+            return True
+
+        # save
+        try:
+            self.SETTINGS.parent.mkdir(parents=True, exist_ok=True)
+            with self.SETTINGS.open("w") as fid:
+                json.dump(self.config, fid, indent=2)
+            # useful in case of successive write's
+            self._prior_config = copy.deepcopy(self.config)
+            return True
+        except OSError as exc:
+            self.logger.error(f"Could not write {self.SETTINGS}", exc)
+            return False

--- a/jupytext/labconfig.py
+++ b/jupytext/labconfig.py
@@ -16,7 +16,7 @@ from pathlib import Path
 class LabConfig:
     SETTINGS = Path.home() / ".jupyter" / "labconfig" / "default_setting_overrides.json"
 
-    LANGUAGES = [
+    DOCTYPES = [
         "python",
         "markdown",
         "myst",
@@ -59,14 +59,14 @@ class LabConfig:
         for key, value in viewers.items():
             print(f"{key}: {value}")
 
-    def set_default_viewers(self, languages=None):
-        if not languages:
-            languages = self.LANGUAGES
-        for language in languages:
-            self.set_default_viewer(language)
+    def set_default_viewers(self, doctypes=None):
+        if not doctypes:
+            doctypes = self.DOCTYPES
+        for doctype in doctypes:
+            self.set_default_viewer(doctype)
         return self
 
-    def set_default_viewer(self, language):
+    def set_default_viewer(self, doctype):
         if "@jupyterlab/docmanager-extension:plugin" not in self.config:
             self.config["@jupyterlab/docmanager-extension:plugin"] = {}
         if (
@@ -79,8 +79,8 @@ class LabConfig:
         viewers = self.config["@jupyterlab/docmanager-extension:plugin"][
             "defaultViewers"
         ]
-        if language not in viewers:
-            viewers[language] = "Jupytext Notebook"
+        if doctype not in viewers:
+            viewers[doctype] = "Jupytext Notebook"
 
     def write(self) -> bool:
         """

--- a/jupytext/labconfig.py
+++ b/jupytext/labconfig.py
@@ -8,7 +8,8 @@ notebook will cause jupyterlab to open it in an editor, i.e. as a text file
 import copy
 import json
 import logging
-import pprint
+
+# import pprint
 from pathlib import Path
 
 
@@ -46,7 +47,7 @@ class LabConfig:
         self._prior_config = copy.deepcopy(self.config)
         return self
 
-    def list(self):
+    def list_default_viewer(self):
         """
         list the current labconfig settings
         """
@@ -54,9 +55,9 @@ class LabConfig:
             f"Current @jupyterlab/docmanager-extension:plugin in {self.SETTINGS}"
         )
         docmanager = self.config.get("@jupyterlab/docmanager-extension:plugin", {})
-        for key, value in docmanager.items():
-            print(f"{key}:")
-            pprint.pprint(value)
+        viewers = docmanager.get("defaultViewers", {})
+        for key, value in viewers.items():
+            print(f"{key}: {value}")
 
     def set_default_viewers(self, languages=None):
         if not languages:

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,12 @@ setup_args = dict(
     long_description_content_type="text/markdown",
     url="https://github.com/mwouts/jupytext",
     packages=find_packages(exclude=["tests"]),
-    entry_points={"console_scripts": ["jupytext = jupytext.cli:jupytext"]},
+    entry_points={
+        "console_scripts": [
+            "jupytext = jupytext.cli:jupytext",
+            "jupytext-config = jupytext.jupytext_config:main",
+        ]
+    },
     tests_require=["pytest"],
     install_requires=[
         "nbformat",


### PR DESCRIPTION
with nb7 about to be released, the default versions of jupyterlab(4)/notebook(7) will both require to configure `defaultViewers` if one wants, for example, to easily open text notebooks from the web app, or to be able to open notebooks through a URL (these settings were not required with nbclassic)

here's a typical setup (this one is right for my use case, but more languages could be added of course)

```
cat ~/.jupyter/labconfig/default_setting_overrides.json
{
    "@jupyterlab/docmanager-extension:plugin": {
        "defaultViewers": {
            "python": "Jupytext Notebook",
            "markdown": "Jupytext Notebook"
        }
    }
}
```

So I've been thinking that providing a simple way to safely implement these settings would be helpful, especially for large classes of beginner students

Here's a POC for that

Of course it would need to be integrated more nicely, and could be exposed as either

* `jupytext init`
* `jupytext --init`

or any variant, to be discussed... 

the first form would resonate with `conda init bash` but it might have ambiguous meaning (and/or be harder to implement)
what if a file is named `init` ? 
on the other hand, there's a precedent with
`jupyter notebook mynotebook` and `jupyter notebook list` that behave differently - so in this instance too, what if your notebook is called `list` ?

anyways, just throwing the idea in the air, I just feel like having this could save a lot of frustration
