### PR TITLE
Add support to Pandoc >= 2.11.2

### DIFF
--- a/jupytext/pandoc.py
+++ b/jupytext/pandoc.py
@@ -89,8 +89,13 @@ def md_to_notebook(text):
     tmp_file.write(text.encode("utf-8"))
     tmp_file.close()
 
+    parse_version = partial(parse, custom_error=PandocError)
+    if parse_version(pandoc_version()) < parse_version('2.11.2'):
+        pandoc_args = "--from markdown --to ipynb -s --atx-headers --wrap=preserve --preserve-tabs"
+    else:
+        pandoc_args = "--from markdown --to ipynb -s --markdown-headings=atx --wrap=preserve --preserve-tabs"
     pandoc(
-        "--from markdown --to ipynb -s --atx-headers --wrap=preserve --preserve-tabs",
+        pandoc_args,
         tmp_file.name,
         tmp_file.name,
     )
@@ -109,8 +114,13 @@ def notebook_to_md(notebook):
     tmp_file.write(ipynb_writes(notebook).encode("utf-8"))
     tmp_file.close()
 
+    parse_version = partial(parse, custom_error=PandocError)
+    if parse_version(pandoc_version()) < parse_version('2.11.2'):
+        pandoc_args = "--from ipynb --to markdown -s --atx-headers --wrap=preserve --preserve-tabs"
+    else:
+        pandoc_args = "--from ipynb --to markdown -s --markdown-headings=atx --wrap=preserve --preserve-tabs"
     pandoc(
-        "--from ipynb --to markdown -s --atx-headers --wrap=preserve --preserve-tabs",
+        pandoc_args,
         tmp_file.name,
         tmp_file.name,
     )


### PR DESCRIPTION
Pandoc replaced `--atx-headers` with `--markdown-headings=atx` in [2.11.2 (2020-11-19)](https://pandoc.org/releases.html#pandoc-2.11.2-2020-11-19). Latest release of Pandoc is [3.1.5 (2023-07-07)](https://github.com/jgm/pandoc/releases/tag/3.1.5) and `--atx-headers` is not supported any more!

```
pandoc --from markdown --to html --atx-headers <<EOF
# Foo
EOF
```

returns

```
Unknown option --atx-headers.
Try pandoc --help for more information.
```

This pull request updates https://github.com/mwouts/jupytext/pull/982 to support `--atx-headers` **and** `--markdown-headings=atx`.

Note: [Quarto](https://quarto.org/) is using bundling Pandoc 3.1.2.