### PR TITLE
restore notebook toolbar under jlab4 - fix for issue #1107

### DIFF
--- a/jupytext/version.py
+++ b/jupytext/version.py
@@ -1,3 +1,3 @@
 """Jupytext's version number"""
 
-__version__ = "1.15.0.dev1"
+__version__ = "1.15.0.dev2"

--- a/packages/labextension/src/index.ts
+++ b/packages/labextension/src/index.ts
@@ -509,7 +509,7 @@ const extension: JupyterFrontEndPlugin<void> = {
     if (! JLAB4) {
       toolbarFactory = notebookFactory.toolbarFactory
     } else {
-      const FACTORY = 'Jupytext Notebook';
+      const FACTORY = 'Notebook';
       const PANEL_SETTINGS = '@jupyterlab/notebook-extension:panel';
 
       toolbarFactory = createToolbarFactory(

--- a/packages/labextension/src/index.ts
+++ b/packages/labextension/src/index.ts
@@ -503,12 +503,15 @@ const extension: JupyterFrontEndPlugin<void> = {
       icon: markdownIcon
     });
 
-    // Duplicate notebook factory to apply it on Jupytext notebooks
-    //   Mirror: https://github.com/jupyterlab/jupyterlab/blob/8a8c3752564f37493d4eb6b4c59008027fa83880/packages/notebook-extension/src/index.ts#L860
+    // the way to create the toolbar factory is different in JupyterLab 3 and 4
     let toolbarFactory
     if (! JLAB4) {
       toolbarFactory = notebookFactory.toolbarFactory
     } else {
+      // primarily this block is copied/pasted from jlab4 code and specifically
+      // jupyterlab/packages/notebook-extension/src/index.ts
+      // inside the function `activateWidgetFactory` at line 1150 as of this writing
+      //
       const FACTORY = 'Notebook';
       const PANEL_SETTINGS = '@jupyterlab/notebook-extension:panel';
 
@@ -520,10 +523,8 @@ const extension: JupyterFrontEndPlugin<void> = {
         translator
       )
     }
-    console.log("jupytext extension - using toolbarFactory", toolbarFactory)
-    // using this breaks it all
-    // const deferred_notebook_factory = (widget: any) => notebookFactory.toolbarFactory(widget)
-    // console.log(deferred_notebook_factory)
+    // Duplicate notebook factory to apply it on Jupytext notebooks
+    //   Mirror: https://github.com/jupyterlab/jupyterlab/blob/8a8c3752564f37493d4eb6b4c59008027fa83880/packages/notebook-extension/src/index.ts#L860
     const factory = new NotebookWidgetFactory({
       name: "Jupytext Notebook",
       label: trans.__("Jupytext Notebook"), // mandatory in jlab4 (not in jlab3)


### PR DESCRIPTION
a fix for solving issue #1107 

here's what both widgets (Notebook and Jupytext Notebook) look like

![image](https://github.com/mwouts/jupytext/assets/4519227/89daa163-56ba-47eb-b780-69589c0e48bc)

---
as can be seen on the screenshot there remains issues related to extensions
here I have installed `jupyterlab-courselevels` that adds some buttons in the toolbar; and what happens is that these buttons show up in the pure Notebook (ipynb) widget but not in the Jupytext Notebook widget

IMO this PR is still very welcome because
* the situation is far better than it was before this work
* I suspect that getting this to work perfectly is something very tricky
* especially considering that we build in a jlab3 environment, where some of the symbols that are, I think, needed to solve this properly, are not defined to typescript

So @mwouts I would be grateful if you could publish this under pypi - it is already versioned as 1.15.0.dev2

