### PR TITLE
Ignore invalid pyproject.toml files in Jupytext's content manager

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ Jupytext ChangeLog
 - This version comes with a version of the JupyterLab extension that is compatible with JupyterLab 4.x. Many thanks to [Thierry Parmentelat](https://github.com/parmentelat) for his PRs! ([#1092](https://github.com/mwouts/jupytext/pull/1092), [#1109](https://github.com/mwouts/jupytext/pull/1109))
 - Pandoc 3.0 is now supported, thanks to [Raniere Silva](https://github.com/rgaiacs) for his PR ([#1099](https://github.com/mwouts/jupytext/pull/1099))
 - We have reorganized the documentation and the README.md ([#1031](https://github.com/mwouts/jupytext/issues/1031), [#1073](https://github.com/mwouts/jupytext/issues/1073))
+- Invalid `pyproject.toml` files will be ignored by Jupytext in Jupyter ([#1103](https://github.com/mwouts/jupytext/issues/1103))
 - We have updated the pre-commit tools
 
 

--- a/jupytext/contentsmanager.py
+++ b/jupytext/contentsmanager.py
@@ -515,9 +515,13 @@ to your jupytext.toml file
                 import toml
 
                 model = self.get(pyproject_path, type="file")
-                doc = toml.loads(model["content"])
-                if doc.get("tool", {}).get("jupytext") is not None:
-                    return pyproject_path
+                try:
+                    doc = toml.loads(model["content"])
+                except toml.decoder.TomlDecodeError as e:
+                    self.log.warning(f"Cannot load {pyproject_path}: {e}")
+                else:
+                    if doc.get("tool", {}).get("jupytext") is not None:
+                        return pyproject_path
 
             if not directory:
                 return None

--- a/tests/test_contentsmanager.py
+++ b/tests/test_contentsmanager.py
@@ -1704,6 +1704,25 @@ def test_notebook_extensions_in_config(tmpdir, cwd_tmpdir):
     assert model["type"] == "file"
 
 
+def test_invalid_config_in_cm(tmpdir, cwd_tmpdir):
+    nb = new_notebook()
+    write(nb, "notebook.ipynb")
+    tmpdir.join("pyproject.toml").write(
+        """[tool.jupysql.SqlMagic]
+autopandas = False
+displaylimit = 1"""
+    )
+
+    cm = jupytext.TextFileContentsManager()
+    cm.root_dir = str(tmpdir)
+
+    # list directory
+    cm.get("")
+
+    model = cm.get("notebook.ipynb")
+    assert model["type"] == "notebook"
+
+
 def test_download_file_318(tmpdir):
     tmp_ipynb = str(tmpdir.join("notebook.ipynb"))
     tmp_py = str(tmpdir.join("notebook.py"))


### PR DESCRIPTION
Closes #1103