### PR TITLE
Relax jupyter-packaging build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["jupyter_packaging~=0.7.9", "jupyterlab>=3,<=4", "setuptools>=40.8.0", "wheel"]
+requires = ["jupyter_packaging>=0.7.9", "jupyterlab>=3,<=4", "setuptools>=40.8.0", "wheel"]
 build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 filterwarnings = [


### PR DESCRIPTION
`jupyer-packaging` is now on version v0.12.3 and from evidence in https://github.com/mwouts/jupytext/issues/906 and my own experience building this package in [nixpkgs](https://github.com/NixOS/nixpkgs), the latest version seems to work.

Perhaps there is a reason to keep it pinned, but I didn't see discussion about it yet from searching so I thought this PR could also be where this is discussed if there are questions about doing this.