### PR TITLE
Version 1.15.2

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -152,7 +152,6 @@ jobs:
         if: ${{ matrix.os != 'windows-latest' }}
 
   build:
-    needs: test-pip
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
@@ -175,3 +174,8 @@ jobs:
           # Install
           python -m pip install dist/*.tar.gz
           echo "Install went OK"
+      - name: Archive build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: dist

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,13 @@
 Jupytext ChangeLog
 ==================
 
+1.15.2 (2023-09-16)
+-------------------
+
+**Added**
+- The Jupyter Lab extension is now compatible with the [JupyterLab RISE](https://github.com/jupyterlab-contrib/rise) extension. Many thanks to [Frédéric Collonval](https://github.com/fcollonval) for his PR ([#1126](https://github.com/mwouts/jupytext/pull/1126))!
+
+
 1.15.1 (2023-08-26)
 -------------------
 

--- a/jupytext/version.py
+++ b/jupytext/version.py
@@ -1,3 +1,3 @@
 """Jupytext's version number"""
 
-__version__ = "1.15.1"
+__version__ = "1.15.2"


### PR DESCRIPTION
Plus, a workaround for #1127, we publish the build artifacts