### PR TITLE
Use jupyter-fs<0.4.0 in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,8 @@ test = [
     "jupyterlab",
     "notebook",
     "nbconvert",
-    "jupyter-fs",
+    # jupyter-fs==0.4.0 is async, which is not supported by Jupytext ATM
+    "jupyter-fs<0.4.0",
     "ipykernel",
     "pre-commit",
 ]


### PR DESCRIPTION
We will from now on test Jupytext agains jupyter-fs<0.4.0, because the more recent versions provide an async contents manager, which is not supported by Jupytext at the moment.

Cf. #1150 