### PR TITLE
a couple obvious tweaks

### DIFF
--- a/jupyterlab/packages/jupyterlab-jupytext-extension/schema/plugin.json
+++ b/jupyterlab/packages/jupyterlab-jupytext-extension/schema/plugin.json
@@ -82,7 +82,7 @@
           {
             "type": "submenu",
             "submenu": {
-              "id": "jp-mainmenu-jupytext-new",
+              "id": "jp-mainmenu-jupytext-pair",
               "label": "Pair Notebook",
               "items": [
                 {

--- a/jupyterlab/packages/jupyterlab-jupytext-extension/schema/plugin.json
+++ b/jupyterlab/packages/jupyterlab-jupytext-extension/schema/plugin.json
@@ -32,7 +32,7 @@
               "label": "New Text Notebook",
               "items": [
                 {
-                  "command": "jupytext:create-new-text-noteboook-auto:percent",
+                  "command": "jupytext:create-new-text-notebook-auto:percent",
                   "rank": 1
                 },
                 {
@@ -40,15 +40,15 @@
                   "rank": 2
                 },
                 {
-                  "command": "jupytext:create-new-text-noteboook-auto:light",
+                  "command": "jupytext:create-new-text-notebook-auto:light",
                   "rank": 5
                 },
                 {
-                  "command": "jupytext:create-new-text-noteboook-auto:hydrogen",
+                  "command": "jupytext:create-new-text-notebook-auto:hydrogen",
                   "rank": 10
                 },
                 {
-                  "command": "jupytext:create-new-text-noteboook-auto:nomarker",
+                  "command": "jupytext:create-new-text-notebook-auto:nomarker",
                   "rank": 15
                 },
                 {
@@ -56,11 +56,11 @@
                   "rank": 16
                 },
                 {
-                  "command": "jupytext:create-new-text-noteboook-md",
+                  "command": "jupytext:create-new-text-notebook-md",
                   "rank": 20
                 },
                 {
-                  "command": "jupytext:create-new-text-noteboook-md:myst",
+                  "command": "jupytext:create-new-text-notebook-md:myst",
                   "rank": 25
                 },
                 {
@@ -68,11 +68,11 @@
                   "rank": 26
                 },
                 {
-                  "command": "jupytext:create-new-text-noteboook-Rmd",
+                  "command": "jupytext:create-new-text-notebook-Rmd",
                   "rank": 30
                 },
                 {
-                  "command": "jupytext:create-new-text-noteboook-qmd",
+                  "command": "jupytext:create-new-text-notebook-qmd",
                   "rank": 35
                 }
               ]

--- a/jupyterlab/packages/jupyterlab-jupytext-extension/src/index.ts
+++ b/jupyterlab/packages/jupyterlab-jupytext-extension/src/index.ts
@@ -328,7 +328,7 @@ const extension: JupyterFrontEndPlugin<void> = {
     // https://github.com/jupyterlab/jupyterlab/blob/c106f0a19110efad7c5e1b136144985819e21100/packages/notebook-extension/src/index.ts#L1902-L1965
     jupytextTextNotebookFormats.forEach(
       (jupytextFormat: IJupytextFormat, rank: number) => {
-        const command = `jupytext:create-new-text-noteboook-${jupytextFormat.format}`;
+        const command = `jupytext:create-new-text-notebook-${jupytextFormat.format}`;
         const label = trans.__(jupytextFormat.label.split('with')[1].trim());
         console.log('Registering text notebook command=', command);
         commands.addCommand(command, {


### PR DESCRIPTION
in `main` we have
- `notebook` sometimes written `noteboook` with 3 o's
- mainmenu has 2 entries with the same id `jp-mainmenu-jupytext-new`

at first I tried to file this PR against @mahendrapaipuri's current branch `lang_specific_text_nb` but could not find their fork so, here it goes..