### PR TITLE
Version 1.16.0rc0

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,9 +1,9 @@
 codecov:
   notify:
-    after_n_builds: 15
+    after_n_builds: 16
 
 comment:
-  after_n_builds: 15
+  after_n_builds: 16
 
 coverage:
   status:

--- a/.github/workflows/step_tests-pip.yml
+++ b/.github/workflows/step_tests-pip.yml
@@ -42,6 +42,12 @@ jobs:
         if: ${{ !matrix.no_kernel }}
         run: python -m ipykernel install --name python_kernel --user
 
+      - name: Uninstall markdown-it-py
+        # Markdown-it-py is a dependency of Jupytext,
+        # but Jupytext should still work if it is not installed
+        if: ${{ matrix.markdown-it-py-version == '' }}
+        run: python -m pip uninstall markdown-it-py --yes
+
       - name: Install Quarto
         if: ${{ matrix.quarto }}
         env:

--- a/.github/workflows/step_tests-pip.yml
+++ b/.github/workflows/step_tests-pip.yml
@@ -14,9 +14,12 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12"]
         markdown-it-py-version: ["~=3.0"]
+        pip-flags: [""]
         include:
+          - python-version: "3.x"
+            pip-flags: "--pre --upgrade --upgrade-strategy eager"
           - python-version: "3.x"
             markdown-it-py-version: "~=2.0"
           - python-version: "3.x"
@@ -36,7 +39,7 @@ jobs:
           python_version: ${{ matrix.python-version }}
 
       - name: Install from source
-        run: python -m pip install -e '.[test-cov,test-external]' ${{ matrix.markdown-it-py-version && format('markdown-it-py{0}', matrix.markdown-it-py-version) }}
+        run: python -m pip install -e '.[test-cov,test-external]' jupyterlab ${{ matrix.markdown-it-py-version && format('markdown-it-py{0}', matrix.markdown-it-py-version) }} ${{ matrix.pip-flags }}
 
       - name: Install a Jupyter Kernel
         if: ${{ !matrix.no_kernel }}
@@ -61,7 +64,6 @@ jobs:
       - name: Test lab extension
         run: |
           # Check extension
-          pip install jupyterlab
           jupyter labextension list
           jupyter labextension list 2>&1 | grep -ie "jupyterlab-jupytext.*OK"
           python -m jupyterlab.browser_check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
 Jupytext ChangeLog
 ==================
 
-1.16.0-dev (2023-10-??)
+1.16.0-dev (2023-11-??)
 -------------------
 
+**Added**
+- The Jupytext Menu is back! And text notebooks can be created directly from the launcher. This is an outstanding contribution by [Mahendra Paipuri](https://github.com/mahendrapaipuri) ([#1154](https://github.com/mwouts/jupytext/issues/1154), [#1163](https://github.com/mwouts/jupytext/issues/1163)). This requires JupyterLab 4.x or Jupyter Notebook 7.x.
+
 **Changed**
-- Jupytext is now configured with `pyproject.toml` and built with `hatch`. The layout has been reorganised to follow `src-layout` ([#1140](https://github.com/mwouts/jupytext/issues/1140)). This outstanding update was contributed by [Mahendra Paipuri](https://github.com/mahendrapaipuri).
+- Jupytext is now configured with `pyproject.toml` and built with `hatch`. The layout has been reorganised to follow `src-layout` ([#1140](https://github.com/mwouts/jupytext/issues/1140)). This is another outstanding contribution by [Mahendra Paipuri](https://github.com/mahendrapaipuri).
+- The tests are now part of the `sdist`. They have been reorganized into unit/functional/integration/external ([#1167](https://github.com/mwouts/jupytext/issues/1167), [#1173](https://github.com/mwouts/jupytext/issues/1173)).
 - The legacy extension for Jupyter Notebook <=6 (the Jupytext Menu) has been removed.
+
+**Fixed**
+- The bibliography section in Rmd files does not become a code cell anymore ([#1161](https://github.com/mwouts/jupytext/issues/1161))
+- Commented code in `active-py` cells is not uncommented anymore ([#1131](https://github.com/mwouts/jupytext/issues/1131))
 
 
 1.15.2 (2023-09-16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Jupytext ChangeLog
 **Fixed**
 - The bibliography section in Rmd files does not become a code cell anymore ([#1161](https://github.com/mwouts/jupytext/issues/1161))
 - Commented code in `active-py` cells is not uncommented anymore ([#1131](https://github.com/mwouts/jupytext/issues/1131))
+- The test coverage has been restored ([#1167](https://github.com/mwouts/jupytext/issues/1167), [#1173](https://github.com/mwouts/jupytext/issues/1173))
+- We test Jupytext against the pre-release version of JupyterLab, and other dependencies ([#1168](https://github.com/mwouts/jupytext/issues/1168))
 
 
 1.15.2 (2023-09-16)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <!-- INDEX-START -->
 
-![CI](https://github.com/mwouts/jupytext/actions/workflows/ci.yml/badge.svg?branch=main)
+[![CI](https://github.com/mwouts/jupytext/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/mwouts/jupytext/actions)
 [![Documentation Status](https://readthedocs.org/projects/jupytext/badge/?version=latest)](https://jupytext.readthedocs.io/en/latest/?badge=latest)
 [![codecov.io](https://codecov.io/github/mwouts/jupytext/coverage.svg?branch=main)](https://codecov.io/gh/mwouts/jupytext/branch/main)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)

--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jupyterlab-jupytext-extensions",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "private": true,
     "files": [],
     "workspaces": [

--- a/jupyterlab/packages/jupyterlab-jupytext-extension/CHANGELOG.md
+++ b/jupyterlab/packages/jupyterlab-jupytext-extension/CHANGELOG.md
@@ -1,6 +1,10 @@
+# 1.4.1 (2023-11-27)
+
+- The Jupytext Menu is back! And text notebooks can be created directly from the launcher. This is an outstanding contribution by [Mahendra Paipuri](https://github.com/mahendrapaipuri) ([#1154](https://github.com/mwouts/jupytext/issues/1154), [#1163](https://github.com/mwouts/jupytext/issues/1163)). This requires JupyterLab 4.x or Jupyter Notebook 7.x.
+
 # 1.4.0 (2023-10-22)
 
-- This version of the JupyterLab extension requires JupyterLab 4.x.
+- This version of the JupyterLab extension is fully compatible with (and requires) JupyterLab 4.x.
 
 # 1.3.11 (2023-10-22)
 

--- a/jupyterlab/packages/jupyterlab-jupytext-extension/package.json
+++ b/jupyterlab/packages/jupyterlab-jupytext-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab-jupytext",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Save Jupyter Notebooks as Scripts or Markdown files that work well with version control & external text editors",
   "keywords": [
     "jupyter",

--- a/jupyterlab/packages/jupyterlab-jupytext-extension/ui-tests/package.json
+++ b/jupyterlab/packages/jupyterlab-jupytext-extension/ui-tests/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jupyterlab-jupytext-ui-tests",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "description": "Basic Integration Tests",
     "private": true,
     "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ Documentation = "https://jupytext.readthedocs.io"
 # Test related dependencies
 test = [
   "pytest",
+  "pytest-xdist",
   "pytest-randomly"
 ]
 test-functional = [
@@ -83,8 +84,7 @@ test-cov = [
     "pytest-cov>=2.6.1",
 ]
 dev = [
-    "jupytext[test]",
-    "pre-commit"
+    "jupytext[test-cov,test-external]",
 ]
 # Documentation dependencies
 docs = [

--- a/src/jupytext/version.py
+++ b/src/jupytext/version.py
@@ -1,3 +1,3 @@
 """Jupytext's version number"""
 
-__version__ = "1.16.0-dev"
+__version__ = "1.16.0rc0"

--- a/tests/integration/contents_manager/test_contentsmanager.py
+++ b/tests/integration/contents_manager/test_contentsmanager.py
@@ -1741,6 +1741,7 @@ def test_filter_jupytext_version_information_416(python_notebook, tmpdir, cwd_tm
     assert "jupytext_version:" not in text
 
 
+@pytest.mark.requires_myst
 def test_new_untitled(tmpdir):
     cm = jupytext.TextFileContentsManager()
     cm.root_dir = str(tmpdir)


### PR DESCRIPTION
In this PR we 
- bump the version number for the jupyterlab-jupytext extension to 1.4.1
- update the CHANGELOG.md
- and setup a new CI build that will test Jupytext and its extension against the pre-release versions of Python dependencies