### PR TITLE
Use pull_request_target event rather than pull_request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,10 @@ on:
     paths-ignore:
       - "CHANGELOG.md"
     branches: [main]
-  pull_request:
+  # We use pull_request_target rather than pull_request
+  # because the latter does not let us comment on PR
+  # coming from a fork.
+  pull_request_target:
     branches: [main]
   schedule:
     - cron: "0 11 * * 4"


### PR DESCRIPTION
This is required to make the comments work on PRs coming from a fork

Cf. https://github.com/marketplace/actions/comment-pull-request:

> Note that, if the PR comes from a fork, it will have only read permission despite the permissions given in the action for the pull_request event. In this case, you may use the pull_request_target event. With this event, permissions can be given without issue (the difference is that it will execute the action from the target branch and not from the origin PR).
