### PR TITLE
Register arbritrary kernel languages with docRegistry

### DIFF
--- a/jupyterlab/packages/jupyterlab-jupytext-extension/src/index.ts
+++ b/jupyterlab/packages/jupyterlab-jupytext-extension/src/index.ts
@@ -363,15 +363,14 @@ const extension: JupyterFrontEndPlugin<void> = {
       );
 
     // Register Jupytext text notebooks file types
-    registerFileTypes(docRegistry, trans);
+    registerFileTypes(availableKernelLanguages, docRegistry, trans);
 
     // Get all kernel file types to add to Jupytext factory
     const kernelLanguageNames = [];
-    for (const kernelLanguages of availableKernelLanguages.values()) {
-      for (const kernelLanguage of kernelLanguages) {
-        kernelLanguageNames.push(kernelLanguage.kernelName);
-      }
+    for (const kernelLanguage of availableKernelLanguages.keys()) {
+      kernelLanguageNames.push(kernelLanguage);
     }
+
     // Create a factory for Jupytext
     createFactory(
       kernelLanguageNames,

--- a/jupyterlab/packages/jupyterlab-jupytext-extension/src/registry.ts
+++ b/jupyterlab/packages/jupyterlab-jupytext-extension/src/registry.ts
@@ -2,12 +2,35 @@ import { DocumentRegistry } from '@jupyterlab/docregistry';
 
 import { TranslationBundle } from '@jupyterlab/translation';
 
-import { markdownIcon } from '@jupyterlab/ui-components';
+import { markdownIcon, kernelIcon } from '@jupyterlab/ui-components';
+
+import { IFileTypeData } from './tokens';
 
 export function registerFileTypes(
+  availableKernelLanguages: Map<string, IFileTypeData[]>,
   docRegistry: DocumentRegistry,
   trans: TranslationBundle
 ) {
+  // Add kernel file types to registry
+  availableKernelLanguages.forEach(
+    (kernelFileTypes: IFileTypeData[], kernelLanguage: string) => {
+      // Do not add python as it will be already there by default
+      if (kernelLanguage !== 'python') {
+        kernelFileTypes.map((kernelFileType) => {
+          docRegistry.addFileType({
+            name: kernelLanguage,
+            contentType: 'file',
+            displayName: trans.__(
+              kernelFileType.paletteLabel.split('New')[1].trim()
+            ),
+            extensions: [`.${kernelFileType.fileExt}`],
+            icon: kernelFileType.kernelIcon || kernelIcon,
+          });
+        });
+      }
+    }
+  );
+
   // Add markdown file types to registry
   docRegistry.addFileType(
     {


### PR DESCRIPTION
Fixes #1164 

Now users can configure default Viewers for docManager to open them as Notebooks. By default text notebooks will always open as file with editor factory.

@parmentelat @mwouts Could you please test the patch and see if it is the desired behaviour? Current implementation will open markdown, myst, Rmd and qmd formats as notebooks by default. Is it intended? I m asking because this was the behaviour in `1.15.x` and I have not changed it. I guess you would like the markdown variants open as text files by default and able to change them as notebooks by overriding default viewers. If so, let me know, I will make necessary changes.

@mwouts What is the reason of choosing format as `md:myst` for MyST? I have noticed that creating a MyST text notebook  creates the file with `.md` extension. Is it not supposed to be created with `.myst` extension? If so, we need to change the format to `myst`.

Cheers!!