### PR TITLE
Update links to pre-commit examples

### DIFF
--- a/docs/using-pre-commit.md
+++ b/docs/using-pre-commit.md
@@ -62,5 +62,5 @@ repos:
       language_version: python3
 ```
 
-Tested examples of how to use the pre-commit hook are available in our [tests](https://github.com/mwouts/jupytext/tree/main/tests/functional/pre-commit) -
-see for instance [test_pre_commit_1_sync_with_config.py](https://github.com/mwouts/jupytext/blob/main/tests/functional/pre-commit/test_pre_commit_1_sync_with_config.py).
+Tested examples of how to use the pre-commit hook are available in our [tests](https://github.com/mwouts/jupytext/tree/main/tests/external/pre_commit) -
+see for instance [test_pre_commit_1_sync_with_config.py](https://github.com/mwouts/jupytext/blob/main/tests/external/pre_commit/test_pre_commit_1_sync_with_config.py).


### PR DESCRIPTION
I noticed the links to the pre-commit examples were outdated.