### PR TITLE
feat: add option to ignore some paths

### DIFF
--- a/src/jupytext/config.py
+++ b/src/jupytext/config.py
@@ -173,6 +173,12 @@ class JupytextConfiguration(Configurable):
         config=True,
     )
 
+    ignored_paths = Union(
+        [List(Unicode()), Unicode()],
+        help="A list of paths that should be ignored when saving notebooks",
+        config=True,
+    )
+
     def set_default_format_options(self, format_options, read=False):
         """Set default format option"""
         if self.default_notebook_metadata_filter:
@@ -402,6 +408,8 @@ def load_jupytext_configuration_file(config_file, stream=None):
     config.formats = short_form_multiple_formats(config.formats)
     if isinstance(config.notebook_extensions, str):
         config.notebook_extensions = config.notebook_extensions.split(",")
+    if isinstance(config.ignored_paths, str):
+        config.ignored_paths = config.ignored_paths.split(",")
     return config
 
 

--- a/src/jupytext/contentsmanager.py
+++ b/src/jupytext/contentsmanager.py
@@ -119,6 +119,16 @@ def build_jupytext_contents_manager_class(base_contents_manager_class):
             nbk = model["content"]
             try:
                 config = self.get_config(path)
+
+                if any(path.startswith(ignored_path) for ignored_path in config.ignored_paths):
+                    # Remove Jupytext metadata (if any)
+                    try:
+                        del model["content"]["metadata"]["jupytext"]
+                    except KeyError:
+                        pass
+
+                    return self.super.save(model, path)
+
                 jupytext_formats = notebook_formats(nbk, config, path)
                 self.update_paired_notebooks(path, jupytext_formats)
 


### PR DESCRIPTION
_Disclaimer: As I am pretty unfamiliar with the Jupytext codebase, this proposal may come across as poorly implemented. Before spending time devising a better implementation and adding tests, I'd like to explore whether the documented intent even makes sense... or not!_

Assuming the following `jupytext.toml` configuration:

```toml
formats = "notebooks///ipynb,source///py:percent"
```

The scenario I've been attempting to tackle is the following.

I have a Jupyter Notebook (`.ipynb`) stored under `notebooks/hello.ipynb`, which thanks to Jupytext gets automatically synced with its Python counterpart at `source/hello.py`.

Now, copying `notebooks/hello.ipynb` over to `export/hello.ipynb` (via the GUI) will fail with the following error:


```
Paste Error

Unexpected error while saving file: export/hello.ipynb Path 'export/hello.ipynb' matches none of the export formats. Please make sure that jupytext.formats covers the current file (e.g. add 'ipynb' to the export formats)
```

which makes sense, since `export/` isn't part of the directory tree "covered" by Jupytext.

In my opinion, an expected behavior in this case could have been to allow the copy resulting in an unpaired notebook.

So the proposed approach here is to introduce an `ignored_paths` option, allowing to define folders that aren't subject to Jupytext's notebook pairing.

Thoughts?