### PR TITLE
Implement `require_hash` in the `get` method of Jupytext's content manager

### DIFF
--- a/.github/workflows/step_tests-pip.yml
+++ b/.github/workflows/step_tests-pip.yml
@@ -21,6 +21,7 @@ jobs:
       ${{ matrix.no_kernel && '(No kernel)' }}
       ${{ matrix.markdown-it-py && format('(markdown-it-py {0})', matrix.markdown-it-py) }}
       ${{ matrix.no_markdown-it-py && '(No markdown-it-py)'}}
+      ${{ matrix.jupyter_server && '(Jupyer-server {0})'}}
     runs-on: ubuntu-latest
 
     strategy:
@@ -29,6 +30,9 @@ jobs:
         python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         experimental: [false]
         include:
+          # Test with jupyter-server=2.10 that does not have the 'require_hash' argument
+          - python-version: "3.x"
+            jupyter_server: "2.10.0"
           # Test minimum markdown-it-py supported (otherwise the most recent version is used)
           - python-version: "3.x"
             markdown-it-py: "~=2.0"
@@ -57,6 +61,10 @@ jobs:
           -e '.[test-cov,test-external]'
           jupyterlab
           ${{ format('markdown-it-py{0}', matrix.markdown-it-py) }}
+
+      - name: Install Jupyter Server
+        if: ${{ matrix.jupyter_server }}
+        run: python -m pip install 'jupyter_server~=${{ matrix.jupyter_server }}'
 
       - name: List the versions of the Jupyter components
         run: jupyter --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 Jupytext ChangeLog
 ==================
 
-1.16.5-dev
-----------
+1.16.5 (2024-12-15)
+-------------------
 
 **Fixed**
-- We have fixed a notebook corruption issue when using Jupytext with Jupyter-Collaboration ([#1124](https://github.com/mwouts/jupytext/issues/1124), [jupyter-collaboration #214](https://github.com/jupyterlab/jupyter-collaboration/issues/214)).
+- We have fixed a notebook corruption issue when using Jupytext with Jupyter-Collaboration ([#1124](https://github.com/mwouts/jupytext/issues/1124), [jupyter-collaboration 214](https://github.com/mwouts/jupytext/issues/214)).
+- We have added the `require_hash` argument on the Jupytext contents manager. The hash of a paired file is the concatenation of the hash of the text file and the hash for the `.ipynb` file ([#1165](https://github.com/mwouts/jupytext/issues/1165))
 - The `rst2md` tests have been fixed by requiring `sphinx<8` ([#1266](https://github.com/mwouts/jupytext/issues/1266))
 - Some dependencies of the JupyterLab extensions were updated ([#1272](https://github.com/mwouts/jupytext/issues/1272), [#1273](https://github.com/mwouts/jupytext/issues/1273), [#1280](https://github.com/mwouts/jupytext/issues/1280), [#1285](https://github.com/mwouts/jupytext/issues/1285), [#1290](https://github.com/mwouts/jupytext/issues/1290))
 - The pre-commit hook is now compatible with log.showsignature=True ([#1281](https://github.com/mwouts/jupytext/issues/1281)). Thanks to [Justin Lecher](https://github.com/jlec) for this fix.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![CI](https://github.com/mwouts/jupytext/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/mwouts/jupytext/actions)
 [![Documentation Status](https://readthedocs.org/projects/jupytext/badge/?version=latest)](https://jupytext.readthedocs.io/en/latest/?badge=latest)
 [![codecov.io](https://codecov.io/github/mwouts/jupytext/coverage.svg?branch=main)](https://codecov.io/gh/mwouts/jupytext/branch/main)
+[![MIT License](https://img.shields.io/github/license/mwouts/jupytext)](LICENSE)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![GitHub language count](https://img.shields.io/github/languages/count/mwouts/jupytext)](docs/languages.md)
 [![Conda Version](https://img.shields.io/conda/vn/conda-forge/jupytext.svg)](https://anaconda.org/conda-forge/jupytext)

--- a/src/jupytext/version.py
+++ b/src/jupytext/version.py
@@ -1,3 +1,3 @@
 """Jupytext's version number"""
 
-__version__ = "1.16.5-dev"
+__version__ = "1.16.5"


### PR DESCRIPTION
Will close #1165 

TODO:
- [x] Find out how to properly combine two hashes
- [x] Don't add a `require_hash` argument if the original contents manager does not have one
- [x] Add a test against `jupyter_server==2.10.x`