### PR TITLE
Add Xonsh support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 Jupytext ChangeLog
 ==================
 
-1.16.2-dev (2024-03-??)
+1.16.2-dev (2024-05-??)
 -------------------
+
+**Added**
+- Added support for Xonsh notebooks ([#1213](https://github.com/mwouts/jupytext/pull/1213)) - thanks to [Jeffrey Odongo](https://github.com/jsquaredosquared) for this contribution
 
 **Changed**
 - Temporary text notebooks for the `--pipe` or `--check` commands are now created in the notebook directory ([#1206](https://github.com/mwouts/jupytext/issues/1206))

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -34,5 +34,6 @@ Jupytext works with notebooks in any of the following languages:
 - TypeScript
 - Wolfram Language
   - Note that Jupytext uses the non-standard `.wolfram` file extension for Wolfram Language files to avoid conflicts with Matlab.
+- Xonsh
 
 Extending Jupytext to more languages should be easy, see the sections on [contributing to](contributing.md) and [developing](developing.md) Jupytext.

--- a/jupyterlab/yarn.lock
+++ b/jupyterlab/yarn.lock
@@ -10812,21 +10812,21 @@ __metadata:
 
 "typescript@patch:typescript@^3 || ^4#~builtin<compat/typescript>":
   version: 4.9.5
-  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=289587"
+  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=23ec76"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 1f8f3b6aaea19f0f67cba79057674ba580438a7db55057eb89cc06950483c5d632115c14077f6663ea76fd09fce3c190e6414bb98582ec80aa5a4eaf345d5b68
+  checksum: ab417a2f398380c90a6cf5a5f74badd17866adf57f1165617d6a551f059c3ba0a3e4da0d147b3ac5681db9ac76a303c5876394b13b3de75fdd5b1eaa06181c9d
   languageName: node
   linkType: hard
 
 "typescript@patch:typescript@~5.0.2#~builtin<compat/typescript>":
   version: 5.0.4
-  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=b5f058"
+  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=85af82"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: d26b6ba97b6d163c55dbdffd9bbb4c211667ebebc743accfeb2c8c0154aace7afd097b51165a72a5bad2cf65a4612259344ff60f8e642362aa1695c760d303ac
+  checksum: bb309d320c59a26565fb3793dba550576ab861018ff3fd1b7fccabbe46ae4a35546bc45f342c0a0b6f265c801ccdf64ffd68f548f117ceb7f0eac4b805cd52a9
   languageName: node
   linkType: hard
 

--- a/jupyterlab/yarn.lock
+++ b/jupyterlab/yarn.lock
@@ -10812,21 +10812,21 @@ __metadata:
 
 "typescript@patch:typescript@^3 || ^4#~builtin<compat/typescript>":
   version: 4.9.5
-  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=23ec76"
+  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=289587"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: ab417a2f398380c90a6cf5a5f74badd17866adf57f1165617d6a551f059c3ba0a3e4da0d147b3ac5681db9ac76a303c5876394b13b3de75fdd5b1eaa06181c9d
+  checksum: 1f8f3b6aaea19f0f67cba79057674ba580438a7db55057eb89cc06950483c5d632115c14077f6663ea76fd09fce3c190e6414bb98582ec80aa5a4eaf345d5b68
   languageName: node
   linkType: hard
 
 "typescript@patch:typescript@~5.0.2#~builtin<compat/typescript>":
   version: 5.0.4
-  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=85af82"
+  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=b5f058"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: bb309d320c59a26565fb3793dba550576ab861018ff3fd1b7fccabbe46ae4a35546bc45f342c0a0b6f265c801ccdf64ffd68f548f117ceb7f0eac4b805cd52a9
+  checksum: d26b6ba97b6d163c55dbdffd9bbb4c211667ebebc743accfeb2c8c0154aace7afd097b51165a72a5bad2cf65a4612259344ff60f8e642362aa1695c760d303ac
   languageName: node
   linkType: hard
 

--- a/src/jupytext/languages.py
+++ b/src/jupytext/languages.py
@@ -90,6 +90,7 @@ _SCRIPT_EXTENSIONS = {
         "comment": "/*",
         "comment_suffix": "*/",
     },
+    ".xsh": {"language": "xonsh", "comment": "#"},
 }
 
 _COMMENT_CHARS = [

--- a/tests/data/notebooks/inputs/ipynb_xonsh/xonsh_example.ipynb
+++ b/tests/data/notebooks/inputs/ipynb_xonsh/xonsh_example.ipynb
@@ -1,0 +1,58 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "35196\n"
+     ]
+    }
+   ],
+   "source": [
+    "len($(curl -L https://xon.sh))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "xonsh_example.ipynb\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "for filename in `.*`:\n",
+    "    print(filename)\n",
+    "    du -sh @(filename)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Xonsh",
+   "language": "xonsh",
+   "name": "xonsh"
+  },
+  "language_info": {
+   "codemirror_mode": "shell",
+   "file_extension": ".xsh",
+   "mimetype": "text/x-sh",
+   "name": "xonsh",
+   "pygments_lexer": "xonsh",
+   "version": "0.14.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/data/notebooks/outputs/ipynb_to_Rmd/xonsh_example.Rmd
+++ b/tests/data/notebooks/outputs/ipynb_to_Rmd/xonsh_example.Rmd
@@ -1,0 +1,17 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Xonsh
+    language: xonsh
+    name: xonsh
+---
+
+```{xonsh}
+len($(curl -L https://xon.sh))
+```
+
+```{xonsh}
+for filename in `.*`:
+    print(filename)
+    du -sh @(filename)
+```

--- a/tests/data/notebooks/outputs/ipynb_to_hydrogen/xonsh_example.xsh
+++ b/tests/data/notebooks/outputs/ipynb_to_hydrogen/xonsh_example.xsh
@@ -1,0 +1,15 @@
+# ---
+# jupyter:
+#   kernelspec:
+#     display_name: Xonsh
+#     language: xonsh
+#     name: xonsh
+# ---
+
+# %%
+len($(curl -L https://xon.sh))
+
+# %%
+for filename in `.*`:
+    print(filename)
+    du -sh @(filename)

--- a/tests/data/notebooks/outputs/ipynb_to_md/xonsh_example.md
+++ b/tests/data/notebooks/outputs/ipynb_to_md/xonsh_example.md
@@ -1,0 +1,17 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Xonsh
+    language: xonsh
+    name: xonsh
+---
+
+```xonsh
+len($(curl -L https://xon.sh))
+```
+
+```xonsh
+for filename in `.*`:
+    print(filename)
+    du -sh @(filename)
+```

--- a/tests/data/notebooks/outputs/ipynb_to_myst/xonsh_example.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/xonsh_example.md
@@ -1,0 +1,16 @@
+---
+kernelspec:
+  display_name: Xonsh
+  language: xonsh
+  name: xonsh
+---
+
+```{code-cell} xonsh
+len($(curl -L https://xon.sh))
+```
+
+```{code-cell} xonsh
+for filename in `.*`:
+    print(filename)
+    du -sh @(filename)
+```

--- a/tests/data/notebooks/outputs/ipynb_to_percent/xonsh_example.xsh
+++ b/tests/data/notebooks/outputs/ipynb_to_percent/xonsh_example.xsh
@@ -1,0 +1,15 @@
+# ---
+# jupyter:
+#   kernelspec:
+#     display_name: Xonsh
+#     language: xonsh
+#     name: xonsh
+# ---
+
+# %%
+len($(curl -L https://xon.sh))
+
+# %%
+for filename in `.*`:
+    print(filename)
+    du -sh @(filename)

--- a/tests/data/notebooks/outputs/ipynb_to_script/xonsh_example.xsh
+++ b/tests/data/notebooks/outputs/ipynb_to_script/xonsh_example.xsh
@@ -1,0 +1,13 @@
+# ---
+# jupyter:
+#   kernelspec:
+#     display_name: Xonsh
+#     language: xonsh
+#     name: xonsh
+# ---
+
+len($(curl -L https://xon.sh))
+
+for filename in `.*`:
+    print(filename)
+    du -sh @(filename)


### PR DESCRIPTION
### Summary

Hi @mwouts, I have tried following the instructions in the documentation to add support for [Xonsh](https://github.com/xonsh/xonsh).

File extension: `.xsh`
Comment: `"#"`
Kernel: [xonsh-jupyter](https://github.com/xonsh/xontrib-jupyter)

However, on my machine, 2 tests are still failing (even though I did not touch the code):
```python
================================================================================= short test summary info ==================================================================================
FAILED tests/integration/cli/test_execute.py::test_execute_r - AttributeError: outputs
FAILED tests/functional/others/test_pytest.py::test_run_pytest_ok - SystemExit: 4
============================================================ 2 failed, 3123 passed, 88 skipped, 6 warnings in 563.72s (0:09:23) ============================================================
```
**Can you provide any guidance on this?**

Thanks,
Jeff

---
<details>
<summary><b>Full test failures:</b></summary>

```python
______________________________________________________________________________________ test_execute_r ______________________________________________________________________________________
[gw1] linux -- Python 3.11.7 /home/jeffr/miniconda3/envs/jupytext-dev/bin/python

tmpdir = local('/tmp/pytest-of-jeffr/pytest-9/popen-gw1/test_execute_r0'), caplog = <_pytest.logging.LogCaptureFixture object at 0x7f7c2e31ef10>
capsys = <_pytest.capture.CaptureFixture object at 0x7f7c2e31c3d0>

    @pytest.mark.requires_nbconvert
    @pytest.mark.requires_ir_kernel
    @pytest.mark.skip_on_windows
    def test_execute_r(tmpdir, caplog, capsys):  # pragma: no cover
        tmp_ipynb = str(tmpdir.join("notebook.ipynb"))
        tmp_md = str(tmpdir.join("notebook.md"))

        with open(tmp_md, "w") as fp:
            fp.write(
                """```r
    1 + 2 + 3
    ```
    """
            )

        jupytext(args=[tmp_md, "--to", "ipynb", "--execute"])

        nb = read(tmp_ipynb)
        assert len(nb.cells) == 1
>       assert nb.cells[0].outputs[0]["data"]["text/markdown"] == "6"

tests/integration/cli/test_execute.py:176:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = {'cell_type': 'markdown', 'id': 'cell-1208', 'metadata': {}, 'source': '```r\n1 + 2 + 3\n```'}, key = 'outputs'

    def __getattr__(self, key):
        """Get an attr by calling :meth:`dict.__getitem__`.

        Like :meth:`__setattr__`, this method converts :exc:`KeyError` to
        :exc:`AttributeError`.

        Examples
        --------
        >>> s = Struct(a=10)
        >>> s.a
        10
        >>> type(s.get)
        <... 'builtin_function_or_method'>
        >>> try:
        ...     s.b
        ... except AttributeError:
        ...     print("I don't have that key")
        ...
        I don't have that key
        """
        try:
            result = self[key]
        except KeyError:
>           raise AttributeError(key) from None
E           AttributeError: outputs

../miniconda3/envs/jupytext-dev/lib/python3.11/site-packages/nbformat/_struct.py:125: AttributeError
----------------------------------------------------------------------------------- Captured stdout call -----------------------------------------------------------------------------------
[jupytext] Reading /tmp/pytest-of-jeffr/pytest-9/popen-gw1/test_execute_r0/notebook.md in format md
[jupytext] Setting kernel python3
[jupytext] Updating notebook metadata with '{"kernelspec": {"name": "python3", "language": "python", "display_name": "Python 3 (ipykernel)"}}'
[jupytext] Executing notebook with kernel python3
[jupytext] Writing /tmp/pytest-of-jeffr/pytest-9/popen-gw1/test_execute_r0/notebook.ipynb
----------------------------------------------------------------------------------- Captured stderr call -----------------------------------------------------------------------------------
0.00s - Debugger warning: It seems that frozen modules are being used, which may
0.00s - make the debugger miss breakpoints. Please pass -Xfrozen_modules=off
0.00s - to python to disable frozen modules.
0.00s - Note: Debugging will proceed. Set PYDEVD_DISABLE_FILE_VALIDATION=1 to disable this validation.
____________________________________________________________________________________ test_run_pytest_ok ____________________________________________________________________________________
[gw2] linux -- Python 3.11.7 /home/jeffr/miniconda3/envs/jupytext-dev/bin/python

tmpdir = local('/tmp/pytest-of-jeffr/pytest-9/popen-gw2/test_run_pytest_ok0')
text = 'This is a notebook with a test that is supposed to pass\n```python\ndef test_ok():\n    assert True\n```\n'

    def test_run_pytest_ok(
        tmpdir,
        text="""This is a notebook with a test that is supposed to pass
    ```python
    def test_ok():
        assert True
    ```
    """,
    ):
        tmp_md = str(tmpdir.join("notebook.md"))
        with open(tmp_md, "w") as fp:
            fp.write(text)
>       jupytext([tmp_md, "--check", "pytest"])

tests/functional/others/test_pytest.py:18:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
src/jupytext/cli.py:497: in jupytext
    exit_code += jupytext_single_file(nb_file, args, log)
src/jupytext/cli.py:670: in jupytext_single_file
    pipe_notebook(
src/jupytext/cli.py:1182: in pipe_notebook
    exec_command(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

command = ['pytest', '/tmp/notebook_oo_56at8.py'], input = None, capture = False, warn_only = False

    def exec_command(command, input=None, capture=False, warn_only=False):
        """Execute the desired command, and pipe the given input into it"""
        assert isinstance(command, list)
        sys.stdout.write("[jupytext] Executing {}\n".format(" ".join(command)))
        process = subprocess.Popen(
            command,
            **(
                dict(stdout=subprocess.PIPE, stdin=subprocess.PIPE)
                if input is not None
                else {}
            ),
        )
        out, err = process.communicate(input=input)
        if out and not capture:
            sys.stdout.write(out.decode("utf-8"))
        if err:
            sys.stderr.write(err.decode("utf-8"))

        if process.returncode:
            msg = f"The command '{' '.join(command)}' exited with code {process.returncode}"
            hint = (
                "" if warn_only else " (use --warn-only to turn this error into a warning)"
            )
            sys.stderr.write(
                f"[jupytext] {'Warning' if warn_only else 'Error'}: {msg}{hint}\n"
            )
            if not warn_only:
>               raise SystemExit(process.returncode)
E               SystemExit: 4

src/jupytext/cli.py:1140: SystemExit
----------------------------------------------------------------------------------- Captured stdout call -----------------------------------------------------------------------------------
[jupytext] Reading /tmp/pytest-of-jeffr/pytest-9/popen-gw2/test_run_pytest_ok0/notebook.md in format md
[jupytext] Executing pytest /tmp/notebook_oo_56at8.py
============================= test session starts ==============================
platform linux -- Python 3.11.7, pytest-8.0.0, pluggy-1.4.0
Using --randomly-seed=419236798
rootdir: /tmp
plugins: xdist-3.5.0, cov-4.1.0, anyio-4.2.0, randomly-3.15.0, xonsh-0.14.4
collected 0 items / 1 error

==================================== ERRORS ====================================
______________________________ ERROR collecting . ______________________________
../miniconda3/envs/jupytext-dev/lib/python3.11/site-packages/pluggy/_hooks.py:501: in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
../miniconda3/envs/jupytext-dev/lib/python3.11/site-packages/pluggy/_manager.py:119: in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
../miniconda3/envs/jupytext-dev/lib/python3.11/site-packages/_pytest/python.py:210: in pytest_collect_directory
    if pkginit.is_file():
../miniconda3/envs/jupytext-dev/lib/python3.11/pathlib.py:1267: in is_file
    return S_ISREG(self.stat().st_mode)
../miniconda3/envs/jupytext-dev/lib/python3.11/pathlib.py:1013: in stat
    return os.stat(self, follow_symlinks=follow_symlinks)
E   PermissionError: [Errno 13] Permission denied: '/tmp/systemd-private-0c4b06cedf23405bad0e7365a61e84d6-systemd-logind.service-bDyMgv/__init__.py'
=========================== short test summary info ============================
ERROR ../../../tmp - PermissionError: [Errno 13] Permission denied: '/tmp/sys...
=============================== 1 error in 0.74s ===============================
----------------------------------------------------------------------------------- Captured stderr call -----------------------------------------------------------------------------------
ERROR: found no collectors for /tmp/notebook_oo_56at8.py

[jupytext] Error: The command 'pytest /tmp/notebook_oo_56at8.py' exited with code 4 (use --warn-only to turn this error into a warning)
===================================================================================== warnings summary =====================================================================================
../miniconda3/envs/jupytext-dev/lib/python3.11/site-packages/sphinx_gallery/sphinx_compatibility.py:71
../miniconda3/envs/jupytext-dev/lib/python3.11/site-packages/sphinx_gallery/sphinx_compatibility.py:71
../miniconda3/envs/jupytext-dev/lib/python3.11/site-packages/sphinx_gallery/sphinx_compatibility.py:71
../miniconda3/envs/jupytext-dev/lib/python3.11/site-packages/sphinx_gallery/sphinx_compatibility.py:71
../miniconda3/envs/jupytext-dev/lib/python3.11/site-packages/sphinx_gallery/sphinx_compatibility.py:71
../miniconda3/envs/jupytext-dev/lib/python3.11/site-packages/sphinx_gallery/sphinx_compatibility.py:71
  /home/jeffr/miniconda3/envs/jupytext-dev/lib/python3.11/site-packages/sphinx_gallery/sphinx_compatibility.py:71: RemovedInSphinx80Warning: The alias 'sphinx.util.status_iterator' is deprecated, use 'sphinx.util.display.status_iterator' instead. Check CHANGES for Sphinx API modifications.
    status_iterator = sphinx.util.status_iterator

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================= short test summary info ==================================================================================
FAILED tests/integration/cli/test_execute.py::test_execute_r - AttributeError: outputs
FAILED tests/functional/others/test_pytest.py::test_run_pytest_ok - SystemExit: 4
============================================================ 2 failed, 3123 passed, 88 skipped, 6 warnings in 563.72s (0:09:23) ============================================================
```
</details>