### PR TITLE
Don't build the extension in pre-commit environments

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,31 @@
+import logging
+import os
+import sys
+
+from hatch_jupyter_builder.plugin import JupyterBuildHook
+
+LOGGER = logging.getLogger(__name__)
+
+
+class CustomBuildHook(JupyterBuildHook):
+    """
+    We use a custom build hook to detect pre-commit environments. In those
+    environments there is no need to build the extension (and, in addition
+    the build will fail if npm is not available, which is often the case
+    of pre-commit environments).
+    """
+
+    def initialize(self, version, _):
+        if "/.cache/pre-commit/".replace("/", os.path.sep) in sys.executable:
+            LOGGER.info(
+                "This environment looks like a pre-commit environment. "
+                "We will skip the build of the Jupytext extension for JupyterLab."
+            )
+            self._skipped = True
+            return
+
+        return super().initialize(version=version, _=_)
+
+
+# hatch wants a single hook
+del JupyterBuildHook

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,14 +130,14 @@ packages = ["src/jupytext", "src/jupytext_config", "jupyterlab/jupyterlab_jupyte
 "jupyterlab/jupyter-config" = "etc/jupyter"
 "jupyterlab/jupyterlab_jupytext/labextension" = "share/jupyter/labextensions/jupyterlab-jupytext"
 
-[tool.hatch.build.hooks.jupyter-builder]
+[tool.hatch.build.hooks.custom]
 # Enable running hook by default.
 # We disable this hook only by setting env var HATCH_BUILD_HOOKS_ENABLE=false
 # So `HATCH_BUILD_HOOKS_ENABLE=false pip install .` will **not** build JupyterLab related
 # extension. A simple `pip install .` will **always** build extension
 enable-by-default = true
 # Runtime dependency for this build hook
-# We need jupyterlab as build time depdendency to get jlpm (wrapper around yarn)
+# We need jupyterlab as build time dependency to get jlpm (wrapper around yarn)
 dependencies = [
     "hatch-jupyter-builder>=0.5", "jupyterlab>=4"
 ]
@@ -154,7 +154,7 @@ ensured-targets = [
 # the extension, build will be triggered even if the build assets exist
 skip-if-exists = ["jupyterlab/jupyterlab_jupytext/labextension/static/style.js"]
 
-[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
+[tool.hatch.build.hooks.custom.build-kwargs]
 # Root directory where build should be done
 path = "jupyterlab"
 # Build command that is defined in package.json
@@ -162,7 +162,7 @@ build_cmd = "build:prod"
 # We use jlpm, which is wrapper around yarn to build transpiled assets
 npm = ["jlpm"]
 
-[tool.hatch.build.hooks.jupyter-builder.editable-build-kwargs]
+[tool.hatch.build.hooks.custom.editable-build-kwargs]
 path = "jupyterlab"
 build_cmd = "build"
 npm = ["jlpm"]


### PR DESCRIPTION
With this PR, the extension is not build when the Python executable looks like a pre-commit environment.

Closes #1210

After this PR, the test `tests/external/pre_commit/test_pre_commit_1_sync_with_no_config.py` runs in 25 seconds (was 54 seconds previously).

At least this should fix the issue that Jupytext can't be installed in a pre-commit hook env when npm is not present.

If I new how to do that, I would prefer to not even take a dependency on `hatch-jupyter-builder` and `jupyterlab` (I think that's where most of the 25 seconds come from).

I see that it is possible to have [dynamical](https://hatch.pypa.io/1.9/config/metadata/#dynamic) values in the `project` table (e.g. `version`, or even [`dependencies`](https://github.com/repo-helper/hatch-requirements-txt), so I have been thinking of writing a hook that would identify pre-commit environments and set e.g. a `build_for_pre_commit_env` variable, but then 
@mahendrapaipuri do you think I could use that variable to skip the extension build?