### PR TITLE
Fix re.split DeprecationWarning

### DIFF
--- a/src/jupytext/cell_metadata.py
+++ b/src/jupytext/cell_metadata.py
@@ -257,7 +257,7 @@ def parse_rmd_options(line):
 
 def rmd_options_to_metadata(options, use_runtools=False):
     """Parse rmd options and return a metadata dictionary"""
-    options = re.split(r"\s|,", options, 1)
+    options = re.split(r"\s|,", options, maxsplit=1)
     # Special case Wolfram Language, which sadly has a space in the language
     # name.
     if options[0:2] == ["wolfram", "language"]:


### PR DESCRIPTION
Silences this DeprecationWarning with python 3.13.0b2:
```
  /builddir/build/BUILD/python-jupytext-1.16.2-build/BUILDROOT/usr/lib/python3.13/site-packages/jupytext/cell_metadata.py:260: DeprecationWarning: 'maxsplit' is passed as positional argument
    options = re.split(r"\s|,", options, 1)
```
