### PR TITLE
Update the pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     - id: trailing-whitespace
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
+    rev: v3.16.0
     hooks:
     - id: pyupgrade
       args: ["--py38-plus"]


### PR DESCRIPTION
Hopefully this will fix the error seen on the CI at https://github.com/mwouts/jupytext/actions/runs/9614533554/job/26519542096?pr=1245

```
pyupgrade................................................................Failed
- hook id: pyupgrade
- exit code: 1
- files were modified by this hook

Rewriting tests/external/simple_external_notebooks/test_read_simple_pandoc.py

isort....................................................................Passed
black....................................................................Failed
- hook id: black
- files were modified by this hook

reformatted tests/external/simple_external_notebooks/test_read_simple_pandoc.py
```