### PR TITLE
Deactivate pyupgrade in the pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,12 +25,6 @@ repos:
     - id: end-of-file-fixer
     - id: trailing-whitespace
 
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
-    hooks:
-    - id: pyupgrade
-      args: ["--py38-plus"]
-
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0
     hooks:

--- a/tests/functional/round_trip/test_myst_header.py
+++ b/tests/functional/round_trip/test_myst_header.py
@@ -1,8 +1,11 @@
+import pytest
+
 from jupytext import reads, writes
 from jupytext.compare import compare
 from jupytext.config import load_jupytext_configuration_file
 
 
+@pytest.mark.requires_myst
 def test_myst_header_is_stable_1247_using_inline_filter(
     md="""---
 jupytext:
@@ -29,6 +32,7 @@ settings:
     compare(md2, md)
 
 
+@pytest.mark.requires_myst
 def test_myst_header_is_stable_1247_using_config(
     jupytext_toml_content="""notebook_metadata_filter = "-jupytext.text_representation.jupytext_version,settings,mystnb"
 """,


### PR DESCRIPTION
Until we figure out what is the problem with `tests/external/simple_external_notebooks/test_read_simple_pandoc.py`