### PR TITLE
Fix a typo 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Jupytext ChangeLog
 ==================
 
+1.16.3-dev (2024-07-??)
+-------------------
+
+**Fixed**
+- We have fixed a typo when `build_jupytext_contents_manager_class` can't be imported ([#1162](https://github.com/mwouts/jupytext/issues/1162))
+
+
 1.16.2 (2024-05-05)
 -------------------
 

--- a/src/jupytext/__init__.py
+++ b/src/jupytext/__init__.py
@@ -8,7 +8,7 @@ from .version import __version__
 try:
     from .contentsmanager import build_jupytext_contents_manager_class
 except ImportError as err:
-    build_jupytext_contents_manager = reraise(err)
+    build_jupytext_contents_manager_class = reraise(err)
 
 try:
     from .contentsmanager import TextFileContentsManager

--- a/src/jupytext/version.py
+++ b/src/jupytext/version.py
@@ -1,3 +1,3 @@
 """Jupytext's version number"""
 
-__version__ = "1.16.2"
+__version__ = "1.16.3-dev"


### PR DESCRIPTION
when `build_jupytext_contents_manager_class` can't be imported, we
define it as a class that re-raise the exception that was encountered.

Relates to #1162