### PR TITLE
Check `ContentsManager` base class using `inspect`

### DIFF
--- a/.github/workflows/step_tests-conda.yml
+++ b/.github/workflows/step_tests-conda.yml
@@ -51,15 +51,21 @@ jobs:
       - name: Install a Jupyter Kernel
         run: python -m ipykernel install --name jupytext-ci --user
 
+      - name: Test with pytest
+        run: pytest -n logical --cov --cov-report=xml
+
       - name: Test lab extension
         run: |
+          # Uninstall jupyter-fs as it overrides the original browser-test.js to
+          # check its own functionality (https://github.com/jpmorganchase/jupyter-fs/blob/main/jupyterfs/browser-test.js)
+          # So uninstall jupyter-fs before running browser check
+          #
+          pip uninstall jupyter-fs -y
+
           # Check extension
           jupyter labextension list
           jupyter labextension list 2>&1 | grep -ie "jupyterlab-jupytext.*OK"
           python -m jupyterlab.browser_check
-
-      - name: Test with pytest
-        run: pytest -n logical --cov --cov-report=xml
 
       - name: Upload coverage
         uses: codecov/codecov-action@v3

--- a/.github/workflows/step_tests-pip.yml
+++ b/.github/workflows/step_tests-pip.yml
@@ -80,16 +80,22 @@ jobs:
           # install it
           sudo apt install ./*.deb
 
+      - name: Test with pytest
+        continue-on-error: ${{ matrix.experimental }}
+        run: pytest -n logical --cov --cov-report=xml
+
       - name: Test lab extension
         run: |
+          # Uninstall jupyter-fs as it overrides the original browser-test.js to
+          # check its own functionality (https://github.com/jpmorganchase/jupyter-fs/blob/main/jupyterfs/browser-test.js)
+          # So uninstall jupyter-fs before running browser check
+          #
+          pip uninstall jupyter-fs -y
+
           # Check extension
           jupyter labextension list
           jupyter labextension list 2>&1 | grep -ie "jupyterlab-jupytext.*OK"
           python -m jupyterlab.browser_check
-
-      - name: Test with pytest
-        continue-on-error: ${{ matrix.experimental }}
-        run: pytest -n logical --cov --cov-report=xml
 
       - name: Upload coverage
         uses: codecov/codecov-action@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Jupytext ChangeLog
 
 **Fixed**
 - We have fixed a typo when `build_jupytext_contents_manager_class` can't be imported ([#1162](https://github.com/mwouts/jupytext/issues/1162))
+- We use `inspect` to determine whether the current contents manager derives from `AsyncContentsManager` (which is not
+supported by Jupytext at the moment). This fixes a compatibility issue with `jupyter-fs==1.0.0` ([#1239](https://github.com/mwouts/jupytext/issues/1239)). Thanks to [Mahendra Paipuri](https://github.com/mahendrapaipuri) for this PR!
 
 **Added**
 - Added support for Lua notebooks ([#1252](https://github.com/mwouts/jupytext/pull/1252)) - thanks to [erentar](https://github.com/erentar) for this contribution

--- a/docs/install.md
+++ b/docs/install.md
@@ -32,6 +32,17 @@ If you don't have the notebook icon on text documents after a fresh restart of y
 jupyter serverextension enable jupytext
 ```
 
+When [`jupyter-fs>=1.0.0`](https://github.com/jpmorganchase/jupyter-fs) is being used along with `jupytext`, use `SyncMetaManager` as the contents manager for `jupyter-fs` as `jupytext` do not support async contents manager which is used in default `MetaManager` of `jupyter-fs`. The `jupyter-fs` config must be as follows:
+
+```json
+{
+  "ServerApp": {
+    "contents_manager_class": "jupyterfs.metamanager.SyncMetaManager",
+  }
+}
+```
+so that `jupytext` will create its own contents manager derived from `SyncMetaManager`.
+
 ## Jupytext commands in JupyterLab
 
 Jupytext comes with a frontend extension for JupyterLab which provides pairing commands (accessible with View / Activate Command Palette, or Ctrl+Shift+C):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ test-external = [
   "pre-commit",
   # Interaction with other contents managers
   # Starting with jupyter-fs==1.0.0, there is SyncMetaManager available
+  # Bump to 1.0.1 once it is released which has some important bugfixes
   "jupyter-fs==1.0.0"
 ]
 # Coverage requirements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,9 +75,7 @@ test-external = [
   "gitpython",
   "pre-commit",
   # Interaction with other contents managers
-  # Starting with jupyter-fs==1.0.0, there is SyncMetaManager available
-  # Bump to 1.0.1 once it is released which has some important bugfixes
-  "jupyter-fs==1.0.0"
+  "jupyter-fs>=1.0"
 ]
 # Coverage requirements
 test-cov = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,8 +75,8 @@ test-external = [
   "gitpython",
   "pre-commit",
   # Interaction with other contents managers
-  # jupyter-fs==0.4.0 is async, which is not supported by Jupytext ATM
-  "jupyter-fs<0.4.0"
+  # Starting with jupyter-fs==1.0.0, there is SyncMetaManager available
+  "jupyter-fs==1.0.0"
 ]
 # Coverage requirements
 test-cov = [

--- a/tests/external/jupyter_fs/test_jupyter_fs.py
+++ b/tests/external/jupyter_fs/test_jupyter_fs.py
@@ -9,11 +9,11 @@ from jupytext.compare import compare_cells, notebook_model
 
 def fs_meta_manager(tmpdir):
     try:
-        from jupyterfs.metamanager import MetaManager
+        from jupyterfs.metamanager import SyncMetaManager
     except ImportError:
         pytest.skip("jupyterfs is not available")
 
-    cm_class = jupytext.build_jupytext_contents_manager_class(MetaManager)
+    cm_class = jupytext.build_jupytext_contents_manager_class(SyncMetaManager)
     logger = logging.getLogger("jupyter-fs")
     cm = cm_class(parent=None, log=logger)
     cm.initResource(


### PR DESCRIPTION
Closes #1239 

@mwouts What do you think of this change? I have bumped `jupytext` version in tests to use new [`SyncMetaManager`](https://github.com/jpmorganchase/jupyter-fs/blob/4dc6f12486771bfb5b0b1f4bd54367db9a1eb848/jupyterfs/metamanager.py#L169)