### PR TITLE
Require sphinx<8 in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Jupytext ChangeLog
 ==================
 
+1.16.5-dev
+----------
+
+**Fixed**
+- The `rst2md` tests have been fixed by requiring `sphinx<8` ([#1266](https://github.com/mwouts/jupytext/issues/1266))
+
+
 1.16.4 (2024-07-12)
 -------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ test-external = [
   "isort",
   "flake8",
   # Sphinx gallery
+  "sphinx<8", # Issue 1266
   "sphinx-gallery<0.8",
   # Pre-commit tests
   "gitpython",


### PR DESCRIPTION
Fixes: the `rst2md` tests fail in the CI #1266