### PR TITLE
Ensure that we get the text as text (not json)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Jupytext ChangeLog
 ----------
 
 **Fixed**
+- We have fixed a notebook corruption issue when using Jupytext with Jupyter-Collaboration ([#1124](https://github.com/mwouts/jupytext/issues/1124), [jupyter-collaboration #214](https://github.com/jupyterlab/jupyter-collaboration/issues/214)).
 - The `rst2md` tests have been fixed by requiring `sphinx<8` ([#1266](https://github.com/mwouts/jupytext/issues/1266))
 - Some dependencies of the JupyterLab extensions were updated ([#1272](https://github.com/mwouts/jupytext/issues/1272), [#1273](https://github.com/mwouts/jupytext/issues/1273), [#1280](https://github.com/mwouts/jupytext/issues/1280), [#1285](https://github.com/mwouts/jupytext/issues/1285), [#1290](https://github.com/mwouts/jupytext/issues/1290))
 - The pre-commit hook is now compatible with log.showsignature=True ([#1281](https://github.com/mwouts/jupytext/issues/1281)). Thanks to [Justin Lecher](https://github.com/jlec) for this fix.

--- a/src/jupytext/contentsmanager.py
+++ b/src/jupytext/contentsmanager.py
@@ -299,7 +299,11 @@ def build_jupytext_contents_manager_class(base_contents_manager_class):
 
                 self.log.info(f"Reading SOURCE from {alt_path}")
                 text = self.super.get(
-                    alt_path, content=True, type="file", format=format
+                    alt_path,
+                    content=True,
+                    type="file",
+                    # Don't use the parent format, see https://github.com/mwouts/jupytext/issues/1124
+                    format=None,
                 )["content"]
                 return reads(text, fmt=alt_fmt, config=config)
 

--- a/src/jupytext/version.py
+++ b/src/jupytext/version.py
@@ -1,3 +1,3 @@
 """Jupytext's version number"""
 
-__version__ = "1.16.4"
+__version__ = "1.16.5-dev"


### PR DESCRIPTION
When `jupyter-collaboration` is installed, the `format` argument in

                text = self.super.get(
                    alt_path, content=True, type="file", format=format
                )["content"]

equals `json`, and because of that we get a `base64` encoding of the notebook inputs instead of the notebook inputs themselves.

That is a very serious issue, as the notebook appears with a single cell that is unreadable. If the user saves or autosaves the notebook then the notebook will be corrupted on disk. In that case, the inputs can be recovered (but not the outputs) with:
```
text = """IyAtLS0K...""" # copy the corrupted cell
print(base64.b64decode("".join(text.splitlines())).decode('utf8'))  # this will recover the .py file
```

This PR addresses this problem by setting `format="text"`, instead of inherited it from the parent call.

Fixes https://github.com/mwouts/jupytext/issues/1124
Fixes https://github.com/jupyterlab/jupyter-collaboration/issues/214