### PR TITLE
 fix: #1281 pre-commit fails with log.showsignature=True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Jupytext ChangeLog
 **Fixed**
 - The `rst2md` tests have been fixed by requiring `sphinx<8` ([#1266](https://github.com/mwouts/jupytext/issues/1266))
 - Some dependencies of the JupyterLab extensions were updated ([#1272](https://github.com/mwouts/jupytext/issues/1272), [#1273](https://github.com/mwouts/jupytext/issues/1273), [#1280](https://github.com/mwouts/jupytext/issues/1280), [#1285](https://github.com/mwouts/jupytext/issues/1285), [#1290](https://github.com/mwouts/jupytext/issues/1290))
+- The pre-commit hook is now compatible with log.showsignature=True (#1281). Thanks to [Justin Lecher](https://github.com/jlec) for this fix.
 
 **Added**
 - Jupytext is now tested with Python 3.13 ([#1242](https://github.com/mwouts/jupytext/issues/1242)). Thanks to [Jerry James](https://github.com/jamesjer) for the suggested fixes!

--- a/src/jupytext/cli.py
+++ b/src/jupytext/cli.py
@@ -1057,7 +1057,9 @@ def git_timestamp(path):
 
     # Return the commit timestamp
     try:
-        git_ts_str = system("git", "log", "-1", "--pretty=%ct", path).strip()
+        git_ts_str = system(
+            "git", "log", "-1", "--pretty=%ct", "--no-show-signature", path
+        ).strip()
     except SystemExit as err:
         if err.code == 128:
             # git not initialized


### PR DESCRIPTION
This PR contains @jlec's fix from #1283 (I have reverted the formatting change and rebase on latest `main`)