### PR TITLE
Use a "-" as a delimeter for filenames of temporary files

### DIFF
--- a/src/jupytext/cli.py
+++ b/src/jupytext/cli.py
@@ -1189,7 +1189,7 @@ def pipe_notebook(
     command = shlex.split(command)
     if "{}" in command:
         if prefix is not None:
-            prefix = prefix + (" " if " " in prefix else "_")
+            prefix = prefix + (" " if " " in prefix else "-")
         tmp_file_args = dict(
             mode="w+",
             encoding="utf8",

--- a/src/jupytext/cli.py
+++ b/src/jupytext/cli.py
@@ -1189,7 +1189,7 @@ def pipe_notebook(
     command = shlex.split(command)
     if "{}" in command:
         if prefix is not None:
-            prefix = prefix + (" " if " " in prefix else "-")
+            prefix = prefix + "-"
         tmp_file_args = dict(
             mode="w+",
             encoding="utf8",


### PR DESCRIPTION
Based on the issue #1289 I propose a solution using the "-" (minus) instead of "_" (underscore) for the delimiter of original filename and filename of temporary file.

I suggest to take "-" since the "safe" characters to use in filename for all platforms are `[0-9a-zA-Z-._]` while the "_" already interferes with poor chosen python temp filename naming sequence characters. I would also do not take "." since it is already used for the file extension on the right and is more error prone if the file has no extension prefix.

This let us basically only with the "-" as a valid character.

Thanks!    