### PR TITLE
Add support for the Logtalk language

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -16,6 +16,7 @@ Jupytext works with notebooks in any of the following languages:
 - Java
 - Javascript
 - Julia
+- Logtalk
 - Lua
 - Matlab
 - OCaml

--- a/src/jupytext/languages.py
+++ b/src/jupytext/languages.py
@@ -92,6 +92,8 @@ _SCRIPT_EXTENSIONS = {
         "comment_suffix": "*/",
     },
     ".xsh": {"language": "xonsh", "comment": "#"},
+    ".lgt": {"language": "logtalk", "comment": "%"},
+    ".logtalk": {"language": "logtalk", "comment": "%"},
     ".lua": {"language": "lua", "comment": "--"},
     ".go": {"language": "go", "comment": "//"},
 }

--- a/tests/data/notebooks/inputs/ipynb_logtalk/logtalk_notebook.ipynb
+++ b/tests/data/notebooks/inputs/ipynb_logtalk/logtalk_notebook.ipynb
@@ -1,0 +1,110 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# An implementation of the Ackermann function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "vscode": {
+     "languageId": "logtalk"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[1mtrue"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%load ack.lgt\n",
+    "\n",
+    ":- object(ack).\n",
+    "\n",
+    ":- info([\n",
+    "\tversion is 1:0:0,\n",
+    "\tauthor is 'Paulo Moura',\n",
+    "\tdate is 2008-3-31,\n",
+    "\tcomment is 'Ackermann function (general recursive function).'\n",
+    "]).\n",
+    "\n",
+    ":- public(ack/3).\n",
+    ":- mode(ack(+integer, +integer, -integer), one).\n",
+    ":- info(ack/3, [\n",
+    "\tcomment is 'Ackermann function.',\n",
+    "\targnames is ['M', 'N', 'V']\n",
+    "]).\n",
+    "\n",
+    "ack(0, N, V) :-\n",
+    "\t!,\n",
+    "\tV is N + 1.\n",
+    "ack(M, 0, V) :-\n",
+    "\t!,\n",
+    "\tM2 is M - 1,\n",
+    "\tack(M2, 1, V).\n",
+    "ack(M, N, V) :-\n",
+    "\tM2 is M - 1,\n",
+    "\tN2 is N - 1,\n",
+    "\tack(M, N2, V2),\n",
+    "\tack(M2, V2, V).\n",
+    "\n",
+    ":- end_object."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Sample query"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "vscode": {
+     "languageId": "logtalk"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[1mV = 11"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "ack::ack(2, 4, V)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Logtalk",
+   "language": "logtalk",
+   "name": "logtalk_kernel"
+  },
+  "language_info": {
+   "codemirror_mode": "logtalk",
+   "file_extension": ".lgt",
+   "mimetype": "text/x-logtalk",
+   "name": "Logtalk"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/data/notebooks/outputs/ipynb_to_Rmd/logtalk_notebook.Rmd
+++ b/tests/data/notebooks/outputs/ipynb_to_Rmd/logtalk_notebook.Rmd
@@ -1,0 +1,50 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Logtalk
+    language: logtalk
+    name: logtalk_kernel
+---
+
+# An implementation of the Ackermann function
+
+```{logtalk vscode={'languageId': 'logtalk'}}
+%%load ack.lgt
+
+:- object(ack).
+
+:- info([
+	version is 1:0:0,
+	author is 'Paulo Moura',
+	date is 2008-3-31,
+	comment is 'Ackermann function (general recursive function).'
+]).
+
+:- public(ack/3).
+:- mode(ack(+integer, +integer, -integer), one).
+:- info(ack/3, [
+	comment is 'Ackermann function.',
+	argnames is ['M', 'N', 'V']
+]).
+
+ack(0, N, V) :-
+	!,
+	V is N + 1.
+ack(M, 0, V) :-
+	!,
+	M2 is M - 1,
+	ack(M2, 1, V).
+ack(M, N, V) :-
+	M2 is M - 1,
+	N2 is N - 1,
+	ack(M, N2, V2),
+	ack(M2, V2, V).
+
+:- end_object.
+```
+
+## Sample query
+
+```{logtalk vscode={'languageId': 'logtalk'}}
+ack::ack(2, 4, V).
+```

--- a/tests/data/notebooks/outputs/ipynb_to_hydrogen/logtalk_notebook.lgt
+++ b/tests/data/notebooks/outputs/ipynb_to_hydrogen/logtalk_notebook.lgt
@@ -1,0 +1,50 @@
+% ---
+% jupyter:
+%   kernelspec:
+%     display_name: Logtalk
+%     language: logtalk
+%     name: logtalk_kernel
+% ---
+
+% %% [markdown]
+% # An implementation of the Ackermann function
+
+% %% vscode={"languageId": "logtalk"}
+%%load ack.lgt
+
+:- object(ack).
+
+:- info([
+	version is 1:0:0,
+	author is 'Paulo Moura',
+	date is 2008-3-31,
+	comment is 'Ackermann function (general recursive function).'
+]).
+
+:- public(ack/3).
+:- mode(ack(+integer, +integer, -integer), one).
+:- info(ack/3, [
+	comment is 'Ackermann function.',
+	argnames is ['M', 'N', 'V']
+]).
+
+ack(0, N, V) :-
+	!,
+	V is N + 1.
+ack(M, 0, V) :-
+	!,
+	M2 is M - 1,
+	ack(M2, 1, V).
+ack(M, N, V) :-
+	M2 is M - 1,
+	N2 is N - 1,
+	ack(M, N2, V2),
+	ack(M2, V2, V).
+
+:- end_object.
+
+% %% [markdown]
+% ## Sample query
+
+% %% vscode={"languageId": "logtalk"}
+ack::ack(2, 4, V).

--- a/tests/data/notebooks/outputs/ipynb_to_md/logtalk_notebook.md
+++ b/tests/data/notebooks/outputs/ipynb_to_md/logtalk_notebook.md
@@ -1,0 +1,50 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Logtalk
+    language: logtalk
+    name: logtalk_kernel
+---
+
+# An implementation of the Ackermann function
+
+```logtalk vscode={"languageId": "logtalk"}
+%%load ack.lgt
+
+:- object(ack).
+
+:- info([
+	version is 1:0:0,
+	author is 'Paulo Moura',
+	date is 2008-3-31,
+	comment is 'Ackermann function (general recursive function).'
+]).
+
+:- public(ack/3).
+:- mode(ack(+integer, +integer, -integer), one).
+:- info(ack/3, [
+	comment is 'Ackermann function.',
+	argnames is ['M', 'N', 'V']
+]).
+
+ack(0, N, V) :-
+	!,
+	V is N + 1.
+ack(M, 0, V) :-
+	!,
+	M2 is M - 1,
+	ack(M2, 1, V).
+ack(M, N, V) :-
+	M2 is M - 1,
+	N2 is N - 1,
+	ack(M, N2, V2),
+	ack(M2, V2, V).
+
+:- end_object.
+```
+
+## Sample query
+
+```logtalk vscode={"languageId": "logtalk"}
+ack::ack(2, 4, V).
+```

--- a/tests/data/notebooks/outputs/ipynb_to_myst/logtalk_notebook.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/logtalk_notebook.md
@@ -1,0 +1,57 @@
+---
+kernelspec:
+  display_name: Logtalk
+  language: logtalk
+  name: logtalk_kernel
+---
+
+# An implementation of the Ackermann function
+
+```{code-cell}
+---
+vscode:
+  languageId: logtalk
+---
+%%load ack.lgt
+
+:- object(ack).
+
+:- info([
+	version is 1:0:0,
+	author is 'Paulo Moura',
+	date is 2008-3-31,
+	comment is 'Ackermann function (general recursive function).'
+]).
+
+:- public(ack/3).
+:- mode(ack(+integer, +integer, -integer), one).
+:- info(ack/3, [
+	comment is 'Ackermann function.',
+	argnames is ['M', 'N', 'V']
+]).
+
+ack(0, N, V) :-
+	!,
+	V is N + 1.
+ack(M, 0, V) :-
+	!,
+	M2 is M - 1,
+	ack(M2, 1, V).
+ack(M, N, V) :-
+	M2 is M - 1,
+	N2 is N - 1,
+	ack(M, N2, V2),
+	ack(M2, V2, V).
+
+:- end_object.
+```
+
+## Sample query
+
+```{code-cell}
+---
+vscode:
+  languageId: logtalk
+---
+ack::ack(2, 4, V).
+```

--- a/tests/data/notebooks/outputs/ipynb_to_percent/logtalk_notebook.lgt
+++ b/tests/data/notebooks/outputs/ipynb_to_percent/logtalk_notebook.lgt
@@ -1,0 +1,50 @@
+% ---
+% jupyter:
+%   kernelspec:
+%     display_name: Logtalk
+%     language: logtalk
+%     name: logtalk_kernel
+% ---
+
+% %% [markdown]
+% # An implementation of the Ackermann function
+
+% %% vscode={"languageId": "logtalk"}
+% %%load ack.lgt
+
+:- object(ack).
+
+:- info([
+	version is 1:0:0,
+	author is 'Paulo Moura',
+	date is 2008-3-31,
+	comment is 'Ackermann function (general recursive function).'
+]).
+
+:- public(ack/3).
+:- mode(ack(+integer, +integer, -integer), one).
+:- info(ack/3, [
+	comment is 'Ackermann function.',
+	argnames is ['M', 'N', 'V']
+]).
+
+ack(0, N, V) :-
+	!,
+	V is N + 1.
+ack(M, 0, V) :-
+	!,
+	M2 is M - 1,
+	ack(M2, 1, V).
+ack(M, N, V) :-
+	M2 is M - 1,
+	N2 is N - 1,
+	ack(M, N2, V2),
+	ack(M2, V2, V).
+
+:- end_object.
+
+% %% [markdown]
+% ## Sample query
+
+% %% vscode={"languageId": "logtalk"}
+ack::ack(2, 4, V).

--- a/tests/data/notebooks/outputs/ipynb_to_script/logtalk_notebook.lgt
+++ b/tests/data/notebooks/outputs/ipynb_to_script/logtalk_notebook.lgt
@@ -1,0 +1,49 @@
+% ---
+% jupyter:
+%   kernelspec:
+%     display_name: Logtalk
+%     language: logtalk
+%     name: logtalk_kernel
+% ---
+
+% # An implementation of the Ackermann function
+
+% + vscode={"languageId": "logtalk"}
+% %%load ack.lgt
+
+:- object(ack).
+
+:- info([
+	version is 1:0:0,
+	author is 'Paulo Moura',
+	date is 2008-3-31,
+	comment is 'Ackermann function (general recursive function).'
+]).
+
+:- public(ack/3).
+:- mode(ack(+integer, +integer, -integer), one).
+:- info(ack/3, [
+	comment is 'Ackermann function.',
+	argnames is ['M', 'N', 'V']
+]).
+
+ack(0, N, V) :-
+	!,
+	V is N + 1.
+ack(M, 0, V) :-
+	!,
+	M2 is M - 1,
+	ack(M2, 1, V).
+ack(M, N, V) :-
+	M2 is M - 1,
+	N2 is N - 1,
+	ack(M, N2, V2),
+	ack(M2, V2, V).
+
+:- end_object.
+% -
+
+% ## Sample query
+
+% + vscode={"languageId": "logtalk"}
+ack::ack(2, 4, V).


### PR DESCRIPTION
I noticed a single failed test, apparently due to use of a cell magic in the sample notebook. The cell magic is specific to the Logtalk kernel. Your help is most appreciated on how best to fix this test failure. Thanks.

```text
========================================================================================================= FAILURES =========================================================================================================
_________________________________________________________________________________ test_ipynb_to_Rmd[ipynb_logtalk/logtalk_notebook.ipynb] __________________________________________________________________________________

ipynb_file = '/Users/pmoura/jupytext/tests/data/notebooks/inputs/ipynb_logtalk/logtalk_notebook.ipynb', no_jupytext_version_number = None

    def test_ipynb_to_Rmd(ipynb_file, no_jupytext_version_number):
>       assert_conversion_same_as_mirror(ipynb_file, "Rmd", "ipynb_to_Rmd")

/Users/pmoura/jupytext/tests/functional/round_trip/test_mirror.py:53: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/Users/pmoura/jupytext/src/jupytext/compare.py:441: in assert_conversion_same_as_mirror
    compare(actual, expected)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

actual = "---\njupyter:\n  kernelspec:\n    display_name: Logtalk\n    language: logtalk\n    name: logtalk_kernel\n---\n\n# An...\n\n:- end_object.\n```\n\n## Sample query\n\n```{logtalk vscode={'languageId': 'logtalk'}}\nack::ack(2, 4, V).\n```\n"
expected = "---\njupyter:\n  kernelspec:\n    display_name: Logtalk\n    language: logtalk\n    name: logtalk_kernel\n---\n\n# An...\n\n:- end_object.\n```\n\n## Sample query\n\n```{logtalk vscode={'languageId': 'logtalk'}}\nack::ack(2, 4, V).\n```\n"
actual_name = 'actual', expected_name = 'expected', return_diff = False

    def compare(
        actual, expected, actual_name="actual", expected_name="expected", return_diff=False
    ):
        """Compare two strings, lists or dict-like objects"""
        if actual != expected:
            diff = difflib.unified_diff(
                _multilines(expected),
                _multilines(actual),
                expected_name,
                actual_name,
                lineterm="",
            )
            if expected_name == "" and actual_name == "":
                diff = list(diff)[2:]
            diff = "\n".join(diff)
            if return_diff:
                return diff
>           raise AssertionError("\n" + diff)
E           AssertionError: 
E           --- expected
E           +++ actual
E           @@ -9,7 +9,7 @@
E            # An implementation of the Ackermann function
E            
E            ```{logtalk vscode={'languageId': 'logtalk'}}
E           -%%load ack.lgt
E           +% %%load ack.lgt
E            
E            :- object(ack).

/Users/pmoura/jupytext/src/jupytext/compare.py:50: AssertionError
===================================================================================================== warnings summary =====================================================================================================
../../../usr/local/Caskroom/miniconda/base/envs/jupytext-dev/lib/python3.13/site-packages/sphinx_gallery/sphinx_compatibility.py:71
  /usr/local/Caskroom/miniconda/base/envs/jupytext-dev/lib/python3.13/site-packages/sphinx_gallery/sphinx_compatibility.py:71: RemovedInSphinx80Warning: The alias 'sphinx.util.status_iterator' is deprecated, use 'sphinx.util.display.status_iterator' instead. Check CHANGES for Sphinx API modifications.
    status_iterator = sphinx.util.status_iterator

tests/external/jupyter_fs/test_jupyter_fs.py::test_jupytext_jupyter_fs_metamanager
  /usr/local/Caskroom/miniconda/base/envs/jupytext-dev/lib/python3.13/site-packages/traitlets/traitlets.py:3615: DeprecationWarning: metadata {'per_key_traits': <traitlets.traitlets.Dict object at 0x11e3b60a0>} was set from the constructor. With traitlets 4.1, metadata should be set using the .tag() method, e.g., Int().tag(key1='value1', key2='value2')
    super().__init__(trait=trait, default_value=default_value, **kwargs)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================================= short test summary info ==================================================================================================
FAILED tests/functional/round_trip/test_mirror.py::test_ipynb_to_Rmd[ipynb_logtalk/logtalk_notebook.ipynb] - AssertionError: 
=========================================================================== 1 failed, 3129 passed, 161 skipped, 2 warnings in 187.05s (0:03:07) ============================================================================
```