### PR TITLE
Set the language lexer on MyST code cells from the language info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Jupytext ChangeLog
 
 **Changed**
 - We have updated the JupyterLab extension dependencies ([#1300](https://github.com/mwouts/jupytext/pull/1300)). Thanks to [Mahendra Paipuri](https://github.com/mahendrapaipuri) for this PR!
+- The language lexer (e.g. `ipython3`) for `md:myst` files is now only included when `language_info` is added to `notebook_metadata_filter`.
 
 
 1.16.7 (2025-02-09)

--- a/src/jupytext/jupytext.py
+++ b/src/jupytext/jupytext.py
@@ -232,12 +232,8 @@ class TextNotebookConverter(NotebookReader, NotebookWriter):
         if self.fmt.get(
             "format_name"
         ) == MYST_FORMAT_NAME or self.ext in myst_extensions(no_md=True):
-            pygments_lexer = metadata.get("language_info", {}).get(
-                "pygments_lexer", None
-            )
             return notebook_to_myst(
                 self.filter_notebook(nb, metadata),
-                default_lexer=pygments_lexer,
             )
 
         # Copy the notebook, in order to be sure we do not modify the original notebook

--- a/tests/data/notebooks/outputs/ipynb_to_myst/Line_breaks_in_LateX_305.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/Line_breaks_in_LateX_305.md
@@ -3,6 +3,16 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.7.4
 ---
 
 This cell uses no particular cell marker

--- a/tests/data/notebooks/outputs/ipynb_to_myst/Notebook with function and cell metadata 164.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/Notebook with function and cell metadata 164.md
@@ -3,6 +3,16 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.6.6
 ---
 
 ```{code-cell} ipython3

--- a/tests/data/notebooks/outputs/ipynb_to_myst/Notebook with html and latex cells.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/Notebook with html and latex cells.md
@@ -3,6 +3,16 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.6.6
 ---
 
 ```{code-cell} ipython3

--- a/tests/data/notebooks/outputs/ipynb_to_myst/Notebook with many hash signs.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/Notebook with many hash signs.md
@@ -3,6 +3,16 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.6.6
 ---
 
 ##################################################################

--- a/tests/data/notebooks/outputs/ipynb_to_myst/Notebook with metadata and long cells.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/Notebook with metadata and long cells.md
@@ -3,6 +3,16 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.6.6
 ---
 
 # Part one - various cells

--- a/tests/data/notebooks/outputs/ipynb_to_myst/Notebook_with_R_magic.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/Notebook_with_R_magic.md
@@ -3,6 +3,16 @@ kernelspec:
   display_name: Python 2
   language: python
   name: python2
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 2
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython2
+  version: 2.7.11
 ---
 
 # A notebook with R cells

--- a/tests/data/notebooks/outputs/ipynb_to_myst/Notebook_with_more_R_magic_111.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/Notebook_with_more_R_magic_111.md
@@ -3,6 +3,16 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.6.6
 ---
 
 ```{code-cell} ipython3

--- a/tests/data/notebooks/outputs/ipynb_to_myst/R notebook with invalid cell keys.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/R notebook with invalid cell keys.md
@@ -3,6 +3,13 @@ kernelspec:
   display_name: R
   language: R
   name: ir
+language_info:
+  codemirror_mode: r
+  file_extension: .r
+  mimetype: text/x-r-source
+  name: R
+  pygments_lexer: r
+  version: 3.5.1
 ---
 
 This notebook was created with IRKernel 0.8.12, and is not completely valid, as the code cell below contains an unexpected 'source' entry. This did cause https://github.com/mwouts/jupytext/issues/234. Note that the problem is solved when one upgrades to IRKernel 1.0.0.

--- a/tests/data/notebooks/outputs/ipynb_to_myst/Reference Guide for Calysto Scheme.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/Reference Guide for Calysto Scheme.md
@@ -3,6 +3,12 @@ kernelspec:
   display_name: Calysto Scheme (Python)
   language: scheme
   name: calysto_scheme
+language_info:
+  codemirror_mode:
+    name: scheme
+  mimetype: text/x-scheme
+  name: scheme
+  pygments_lexer: scheme
 ---
 
 <img src="images/logo-64x64.png"/>

--- a/tests/data/notebooks/outputs/ipynb_to_myst/The flavors of raw cells.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/The flavors of raw cells.md
@@ -3,6 +3,16 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.7.3
 ---
 
 ```{raw-cell}

--- a/tests/data/notebooks/outputs/ipynb_to_myst/cat_variable.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/cat_variable.md
@@ -3,6 +3,16 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.6.4
 ---
 
 ```{code-cell} ipython3

--- a/tests/data/notebooks/outputs/ipynb_to_myst/coconut_homepage_demo.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/coconut_homepage_demo.md
@@ -3,6 +3,15 @@ kernelspec:
   display_name: Coconut
   language: coconut
   name: coconut
+language_info:
+  codemirror_mode:
+    name: python
+    version: 3
+  file_extension: .coco
+  mimetype: text/x-python3
+  name: coconut
+  pygments_lexer: coconut
+  version: 1.4.3-post_dev25
 ---
 
 Taken from [coconut-lang.org](coconut-lang.org)

--- a/tests/data/notebooks/outputs/ipynb_to_myst/convert_to_py_then_test_with_update83.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/convert_to_py_then_test_with_update83.md
@@ -3,6 +3,16 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.5.3
 ---
 
 ```{code-cell} ipython3

--- a/tests/data/notebooks/outputs/ipynb_to_myst/csharp.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/csharp.md
@@ -3,6 +3,12 @@ kernelspec:
   display_name: .NET (C#)
   language: C#
   name: .net-csharp
+language_info:
+  file_extension: .cs
+  mimetype: text/x-csharp
+  name: C#
+  pygments_lexer: csharp
+  version: '8.0'
 ---
 
 We start with...

--- a/tests/data/notebooks/outputs/ipynb_to_myst/demo_gdl_fbp.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/demo_gdl_fbp.md
@@ -3,6 +3,11 @@ kernelspec:
   display_name: IDL [conda env:gdl] *
   language: IDL
   name: conda-env-gdl-idl
+language_info:
+  codemirror_mode: idl
+  file_extension: .pro
+  mimetype: text/x-idl
+  name: idl
 ---
 
 ## GDL demo notebook

--- a/tests/data/notebooks/outputs/ipynb_to_myst/evcxr_jupyter_tour.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/evcxr_jupyter_tour.md
@@ -3,6 +3,13 @@ kernelspec:
   display_name: Rust
   language: rust
   name: rust
+language_info:
+  codemirror_mode: rust
+  file_extension: .rs
+  mimetype: text/rust
+  name: Rust
+  pygment_lexer: rust
+  version: ''
 ---
 
 # Tour of the EvCxR Jupyter Kernel

--- a/tests/data/notebooks/outputs/ipynb_to_myst/frozen_cell.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/frozen_cell.md
@@ -3,6 +3,16 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.7.0
 ---
 
 ```{code-cell} ipython3

--- a/tests/data/notebooks/outputs/ipynb_to_myst/fsharp.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/fsharp.md
@@ -3,6 +3,12 @@ kernelspec:
   display_name: .NET (F#)
   language: F#
   name: .net-fsharp
+language_info:
+  file_extension: .fs
+  mimetype: text/x-fsharp
+  name: C#
+  pygments_lexer: fsharp
+  version: '4.5'
 ---
 
 This notebook was inspired by [Plottting with XPlot](https://github.com/dotnet/interactive/blob/master/NotebookExamples/fsharp/Docs/Plotting%20with%20Xplot.ipynb).

--- a/tests/data/notebooks/outputs/ipynb_to_myst/gnuplot_notebook.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/gnuplot_notebook.md
@@ -3,6 +3,14 @@ kernelspec:
   display_name: gnuplot
   language: gnuplot
   name: gnuplot
+language_info:
+  codemirror_mode: Octave
+  file_extension: .gp
+  help_links:
+  - text: MetaKernel Magics
+    url: https://metakernel.readthedocs.io/en/latest/source/README.html
+  mimetype: text/x-gnuplot
+  name: gnuplot
 ---
 
 # Sample gnuplot notebook

--- a/tests/data/notebooks/outputs/ipynb_to_myst/haskell_notebook.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/haskell_notebook.md
@@ -3,6 +3,13 @@ kernelspec:
   display_name: Haskell
   language: haskell
   name: haskell
+language_info:
+  codemirror_mode: ihaskell
+  file_extension: .hs
+  mimetype: text/x-haskell
+  name: haskell
+  pygments_lexer: Haskell
+  version: 8.10.7
 ---
 
 # Example Haskell Notebook

--- a/tests/data/notebooks/outputs/ipynb_to_myst/hello_world_gonb.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/hello_world_gonb.md
@@ -3,6 +3,14 @@ kernelspec:
   display_name: Go (gonb)
   language: go
   name: gonb
+language_info:
+  codemirror_mode: ''
+  file_extension: .go
+  mimetype: ''
+  name: go
+  nbconvert_exporter: ''
+  pygments_lexer: ''
+  version: go1.21.6
 ---
 
 A notebook that use [GoNB](https://github.com/janpfeifer/gonb)

--- a/tests/data/notebooks/outputs/ipynb_to_myst/ijavascript.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/ijavascript.md
@@ -3,6 +3,11 @@ kernelspec:
   display_name: Javascript (Node.js)
   language: javascript
   name: javascript
+language_info:
+  file_extension: .js
+  mimetype: application/javascript
+  name: javascript
+  version: 11.14.0
 ---
 
 ## A notebook that uses IJavascript kernel

--- a/tests/data/notebooks/outputs/ipynb_to_myst/ir_notebook.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/ir_notebook.md
@@ -3,6 +3,13 @@ kernelspec:
   display_name: R
   language: R
   name: ir
+language_info:
+  codemirror_mode: r
+  file_extension: .r
+  mimetype: text/x-r-source
+  name: R
+  pygments_lexer: r
+  version: 3.5.0
 ---
 
 This is a jupyter notebook that uses the IR kernel.

--- a/tests/data/notebooks/outputs/ipynb_to_myst/itypescript.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/itypescript.md
@@ -3,6 +3,11 @@ kernelspec:
   display_name: Typescript 3.5
   language: typescript
   name: typescript
+language_info:
+  file_extension: .ts
+  mimetype: application/x-typescript
+  name: typescript
+  version: 3.5.1
 ---
 
 ```{code-cell}

--- a/tests/data/notebooks/outputs/ipynb_to_myst/julia_benchmark_plotly_barchart.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/julia_benchmark_plotly_barchart.md
@@ -3,6 +3,11 @@ kernelspec:
   display_name: Julia 1.1.1
   language: julia
   name: julia-1.1
+language_info:
+  file_extension: .jl
+  mimetype: application/julia
+  name: julia
+  version: 1.1.1
 ---
 
 ```{code-cell}

--- a/tests/data/notebooks/outputs/ipynb_to_myst/jupyter.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/jupyter.md
@@ -3,6 +3,16 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.6.4
 ---
 
 # Jupyter notebook

--- a/tests/data/notebooks/outputs/ipynb_to_myst/jupyter_again.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/jupyter_again.md
@@ -3,6 +3,16 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.6.5
 ---
 
 ```{code-cell} ipython3

--- a/tests/data/notebooks/outputs/ipynb_to_myst/jupyter_with_raw_cell_in_body.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/jupyter_with_raw_cell_in_body.md
@@ -3,6 +3,16 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.6.6
 ---
 
 ```{code-cell} ipython3

--- a/tests/data/notebooks/outputs/ipynb_to_myst/jupyter_with_raw_cell_on_top.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/jupyter_with_raw_cell_on_top.md
@@ -3,6 +3,16 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.6.5
 ---
 
 ```{raw-cell}

--- a/tests/data/notebooks/outputs/ipynb_to_myst/jupytext_replication.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/jupytext_replication.md
@@ -3,6 +3,13 @@ kernelspec:
   display_name: SoS
   language: sos
   name: sos
+language_info:
+  codemirror_mode: sos
+  file_extension: .sos
+  mimetype: text/x-sos
+  name: sos
+  nbconvert_exporter: sos_notebook.converter.SoS_Exporter
+  pygments_lexer: sos
 ---
 
 +++ {"Collapsed": "false", "kernel": "SoS"}

--- a/tests/data/notebooks/outputs/ipynb_to_myst/kalman_filter_and_visualization.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/kalman_filter_and_visualization.md
@@ -3,6 +3,11 @@ kernelspec:
   display_name: Q 3.5
   language: q
   name: qpk
+language_info:
+  file_extension: .q
+  mimetype: text/x-q
+  name: q
+  version: 3.6.0
 ---
 
 ```{code-cell}

--- a/tests/data/notebooks/outputs/ipynb_to_myst/logtalk_notebook.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/logtalk_notebook.md
@@ -3,6 +3,11 @@ kernelspec:
   display_name: Logtalk
   language: logtalk
   name: logtalk_kernel
+language_info:
+  codemirror_mode: logtalk
+  file_extension: .lgt
+  mimetype: text/x-logtalk
+  name: Logtalk
 ---
 
 # An implementation of the Ackermann function

--- a/tests/data/notebooks/outputs/ipynb_to_myst/lua_example.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/lua_example.md
@@ -3,6 +3,11 @@ kernelspec:
   display_name: Lua
   language: lua
   name: lua
+language_info:
+  file_extension: .lua
+  mimetype: text/x-lua
+  name: lua
+  version: '5.4'
 ---
 
 Source: https://www.lua.org/pil/19.3.html

--- a/tests/data/notebooks/outputs/ipynb_to_myst/maxima_example.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/maxima_example.md
@@ -3,6 +3,13 @@ kernelspec:
   display_name: Maxima
   language: maxima
   name: maxima
+language_info:
+  codemirror_mode: maxima
+  file_extension: .mac
+  mimetype: text/x-maxima
+  name: maxima
+  pygments_lexer: maxima
+  version: 5.43.2
 ---
 
 ## maxima misc

--- a/tests/data/notebooks/outputs/ipynb_to_myst/notebook_with_complex_metadata.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/notebook_with_complex_metadata.md
@@ -3,6 +3,16 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.5.1
 ---
 
 ```{code-cell} ipython3

--- a/tests/data/notebooks/outputs/ipynb_to_myst/nteract_with_parameter.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/nteract_with_parameter.md
@@ -5,6 +5,16 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.6.6
 ---
 
 ```{code-cell} ipython3

--- a/tests/data/notebooks/outputs/ipynb_to_myst/ocaml_notebook.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/ocaml_notebook.md
@@ -5,6 +5,14 @@ kernelspec:
   display_name: OCaml default
   language: OCaml
   name: ocaml-jupyter
+language_info:
+  codemirror_mode: text/x-ocaml
+  file_extension: .ml
+  mimetype: text/x-ocaml
+  name: OCaml
+  nbconverter_exporter: null
+  pygments_lexer: OCaml
+  version: 4.12.0
 ---
 
 # Example of an OCaml notebook

--- a/tests/data/notebooks/outputs/ipynb_to_myst/octave_notebook.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/octave_notebook.md
@@ -3,6 +3,18 @@ kernelspec:
   display_name: Octave
   language: octave
   name: octave
+language_info:
+  file_extension: .m
+  help_links:
+  - text: GNU Octave
+    url: https://www.gnu.org/software/octave/support.html
+  - text: Octave Kernel
+    url: https://github.com/Calysto/octave_kernel
+  - text: MetaKernel Magics
+    url: https://github.com/calysto/metakernel/blob/master/metakernel/magics/README.md
+  mimetype: text/x-octave
+  name: octave
+  version: 4.2.2
 ---
 
 A markdown cell

--- a/tests/data/notebooks/outputs/ipynb_to_myst/plotly_graphs.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/plotly_graphs.md
@@ -3,6 +3,16 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.7.4
 ---
 
 This notebook contains complex outputs, including plotly javascript graphs.

--- a/tests/data/notebooks/outputs/ipynb_to_myst/powershell.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/powershell.md
@@ -3,6 +3,14 @@ kernelspec:
   display_name: PowerShell
   language: PowerShell
   name: powershell
+language_info:
+  codemirror_mode: powershell
+  file_extension: .ps1
+  mimetype: text/powershell
+  name: PowerShell
+  nbconvert_exporter: null
+  pygments_lexer: powershell
+  version: '5.0'
 ---
 
 This is an extract from

--- a/tests/data/notebooks/outputs/ipynb_to_myst/sage_print_hello.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/sage_print_hello.md
@@ -3,6 +3,16 @@ kernelspec:
   display_name: SageMath 9.2
   language: sage
   name: sagemath
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.9.1
 ---
 
 ```{code-cell} ipython3

--- a/tests/data/notebooks/outputs/ipynb_to_myst/sample_bash_notebook.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/sample_bash_notebook.md
@@ -3,6 +3,11 @@ kernelspec:
   display_name: Bash
   language: bash
   name: bash
+language_info:
+  codemirror_mode: shell
+  file_extension: .sh
+  mimetype: text/x-sh
+  name: bash
 ---
 
 ```{code-cell}

--- a/tests/data/notebooks/outputs/ipynb_to_myst/sample_rise_notebook_66.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/sample_rise_notebook_66.md
@@ -3,6 +3,16 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.6.6
 ---
 
 +++ {"slideshow": {"slide_type": "slide"}}

--- a/tests/data/notebooks/outputs/ipynb_to_myst/sas.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/sas.md
@@ -3,6 +3,11 @@ kernelspec:
   display_name: SAS
   language: sas
   name: sas
+language_info:
+  codemirror_mode: sas
+  file_extension: .sas
+  mimetype: text/x-sas
+  name: sas
 ---
 
 # SAS Notebooks with jupytext

--- a/tests/data/notebooks/outputs/ipynb_to_myst/simple-helloworld.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/simple-helloworld.md
@@ -6,6 +6,13 @@ kernelspec:
   display_name: Java
   language: java
   name: java
+language_info:
+  codemirror_mode: text/x-java
+  file_extension: .java
+  mimetype: ''
+  name: Java
+  nbconverter_exporter: ''
+  version: 1.8.0_121
 ---
 
 Let's define some class.

--- a/tests/data/notebooks/outputs/ipynb_to_myst/simple_robot_notebook.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/simple_robot_notebook.md
@@ -3,6 +3,12 @@ kernelspec:
   display_name: Robot Framework
   language: robotframework
   name: robotkernel
+language_info:
+  codemirror_mode: robotframework
+  file_extension: .robot
+  mimetype: text/plain
+  name: robotframework
+  pygments_lexer: robotframework
 ---
 
 ```{code-cell} robotframework

--- a/tests/data/notebooks/outputs/ipynb_to_myst/simple_scala_notebook.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/simple_scala_notebook.md
@@ -3,6 +3,13 @@ kernelspec:
   display_name: Apache Toree - Scala
   language: scala
   name: apache_toree_scala
+language_info:
+  codemirror_mode: text/x-scala
+  file_extension: .scala
+  mimetype: text/x-scala
+  name: scala
+  pygments_lexer: scala
+  version: 2.11.12
 ---
 
 ```{code-cell} scala

--- a/tests/data/notebooks/outputs/ipynb_to_myst/stata_notebook.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/stata_notebook.md
@@ -3,6 +3,12 @@ kernelspec:
   display_name: Stata
   language: stata
   name: stata
+language_info:
+  codemirror_mode: stata
+  file_extension: .do
+  mimetype: text/x-stata
+  name: stata
+  version: '15.1'
 ---
 
 ```{code-cell}

--- a/tests/data/notebooks/outputs/ipynb_to_myst/tailrecursive-factorial.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/tailrecursive-factorial.md
@@ -6,6 +6,13 @@ kernelspec:
   display_name: Groovy
   language: groovy
   name: groovy
+language_info:
+  codemirror_mode: groovy
+  file_extension: .groovy
+  mimetype: ''
+  name: Groovy
+  nbconverter_exporter: ''
+  version: 2.5.6
 ---
 
 # TailRecursive annotation

--- a/tests/data/notebooks/outputs/ipynb_to_myst/tcl_test.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/tcl_test.md
@@ -3,6 +3,11 @@ kernelspec:
   display_name: Tcl
   language: tcl
   name: tcljupyter
+language_info:
+  file_extension: .tcl
+  mimetype: txt/x-tcl
+  name: tcl
+  version: 8.6.11
 ---
 
 # Assign Values

--- a/tests/data/notebooks/outputs/ipynb_to_myst/text_outputs_and_images.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/text_outputs_and_images.md
@@ -3,6 +3,16 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.7.4
 ---
 
 This notebook contains outputs of many different types: text, HTML, plots and errors.

--- a/tests/data/notebooks/outputs/ipynb_to_myst/wolfram.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/wolfram.md
@@ -3,6 +3,13 @@ kernelspec:
   display_name: Wolfram Language 13.1
   language: Wolfram Language
   name: wolframlanguage13.1
+language_info:
+  codemirror_mode: mathematica
+  file_extension: .wolfram
+  mimetype: application/vnd.wolfram.m
+  name: Wolfram Language
+  pygments_lexer: mathematica
+  version: '12.0'
 ---
 
 **Note:** The `language_info` `file_extension` in this notebook should be `.m`, but it was deliberately changed to `.wolfram` to avoid conflicts with Matlab which is using the same extension.

--- a/tests/data/notebooks/outputs/ipynb_to_myst/xonsh_example.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/xonsh_example.md
@@ -3,6 +3,13 @@ kernelspec:
   display_name: Xonsh
   language: xonsh
   name: xonsh
+language_info:
+  codemirror_mode: shell
+  file_extension: .xsh
+  mimetype: text/x-sh
+  name: xonsh
+  pygments_lexer: xonsh
+  version: 0.14.4
 ---
 
 ```{code-cell} xonsh

--- a/tests/functional/round_trip/test_mirror.py
+++ b/tests/functional/round_trip/test_mirror.py
@@ -15,6 +15,7 @@ from jupytext.compare import (
     compare_notebooks,
     create_mirror_file_if_missing,
 )
+from jupytext.config import JupytextConfiguration
 from jupytext.formats import auto_ext_from_metadata
 from jupytext.languages import _SCRIPT_EXTENSIONS
 
@@ -59,7 +60,12 @@ def test_ipynb_to_myst(ipynb_file, no_jupytext_version_number):
         r".*(html-demo|julia_functional_geometry|xcpp_by_quantstack).*", ipynb_file
     ):
         pytest.skip()
-    assert_conversion_same_as_mirror(ipynb_file, "md:myst", "ipynb_to_myst")
+    assert_conversion_same_as_mirror(
+        ipynb_file,
+        "md:myst",
+        "ipynb_to_myst",
+        config=JupytextConfiguration(notebook_metadata_filter="language_info"),
+    )
 
 
 """---------------------------------------------------------------------------------

--- a/tests/functional/round_trip/test_myst_md_lexer.py
+++ b/tests/functional/round_trip/test_myst_md_lexer.py
@@ -1,0 +1,19 @@
+from copy import deepcopy
+
+import pytest
+from nbformat.v4 import new_code_cell
+
+from jupytext import writes
+from jupytext.config import JupytextConfiguration
+
+
+@pytest.mark.parametrize("config", [{"notebook_metadata_filter": "language_info"}, {}])
+def test_md_myst_has_no_lexer_unless_language_info_is_set(
+    config, python_notebook, no_jupytext_version_number
+):
+    nb = deepcopy(python_notebook)
+    nb.cells.append(new_code_cell("1+ 1"))
+
+    md = writes(nb, fmt="md:myst", config=JupytextConfiguration(**config))
+    code_lines = [line for line in md.splitlines() if line.startswith("```{code-cell}")]
+    assert code_lines == ["```{code-cell} ipython3"] if config else ["```{code-cell}"]


### PR DESCRIPTION
This is an experimental PR. It set the language lexer on code cells only if the language info is preserved in the filtered metadata.

Might be one way to address #789