### PR TITLE
Perserve the lexer when converting from `md:myst` to notebook

### DIFF
--- a/src/jupytext/myst.py
+++ b/src/jupytext/myst.py
@@ -320,6 +320,9 @@ def myst_to_notebook(
         if token.type == "fence" and token.info.startswith(code_directive):
             _flush_markdown(md_start_line, token, md_metadata)
             options, body_lines = read_fenced_cell(token, len(notebook.cells), "Code")
+            lexer = token.info.removeprefix(code_directive).strip()
+            if lexer:
+                options["language"] = lexer
             meta = nbf.from_dict(options)
             source_map.append(token.map[0] + 1)
             notebook.cells.append(


### PR DESCRIPTION
@chrisjsewell @choldgraf I am looking for a way to preserve the cell lexer when converting the notebook from MyST Markdown to a Jupyter notebook. The reasons for that are the following:
1. I would like to preserve the lexer on round trips and solve #789 
2. I would like to distinguish between cells in the kernel language (that can be converted to code cells) and those in other languages (which might need a language magic), see e.g. #1317

Do you have recommendations on how to best do this? Thanks