### PR TITLE
Support newer versions of sphinx gallery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ test-external = [
   "flake8",
   # Sphinx gallery
   "sphinx<8", # Issue 1266
-  "sphinx-gallery<0.8",
+  "sphinx-gallery>=0.8",
   # Pre-commit tests
   "gitpython",
   "pre-commit",

--- a/tests/data/notebooks/outputs/sphinx-rst2md_to_ipynb/plot_notebook.ipynb
+++ b/tests/data/notebooks/outputs/sphinx-rst2md_to_ipynb/plot_notebook.ipynb
@@ -211,9 +211,6 @@
    "main_language": "python",
    "notebook_metadata_filter": "-all",
    "rst2md": false
-  },
-  "language_info": {
-   "name": "python"
   }
  },
  "nbformat": 4,

--- a/tests/data/notebooks/outputs/sphinx-rst2md_to_ipynb/plot_notebook.ipynb
+++ b/tests/data/notebooks/outputs/sphinx-rst2md_to_ipynb/plot_notebook.ipynb
@@ -15,8 +15,7 @@
     "cell_marker": "\"\"\""
    },
    "source": [
-    "Notebook styled examples\n",
-    "========================\n",
+    "# Notebook styled examples\n",
     "\n",
     "The gallery is capable of transforming Python files into reStructuredText files\n",
     "with a notebook structure. For this to be used you need to respect some syntax\n",
@@ -201,7 +200,7 @@
     "\n",
     "You can also insert images:\n",
     "\n",
-    "![Sphinx header](http://www.sphinx-doc.org/en/stable/_static/sphinxheader.png)"
+    "<img src=\"http://www.sphinx-doc.org/en/stable/_static/sphinxheader.png\" alt=\"Sphinx header\">"
    ]
   }
  ],
@@ -212,6 +211,9 @@
    "main_language": "python",
    "notebook_metadata_filter": "-all",
    "rst2md": false
+  },
+  "language_info": {
+   "name": "python"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
With this PR, the newer versions of sphinx gallery can be used with `jupytext`.

Sphinx-gallery has kept the rst2cmd function signature since 0.8.0:

- `0.8.0`: https://github.com/sphinx-gallery/sphinx-gallery/blob/05cc570f62dbe4b71ddc57832ba119fc5457ea0d/sphinx_gallery/notebook.py#L72
- `master`: https://github.com/sphinx-gallery/sphinx-gallery/blob/f84a7af3459c053124c34c4c53037228689d3656/sphinx_gallery/notebook.py#L96

As for the changes, the API for headers is tested by sphinx gallery:

https://github.com/sphinx-gallery/sphinx-gallery/blob/05cc570f62dbe4b71ddc57832ba119fc5457ea0d/sphinx_gallery/tests/test_notebook.py#L146-L148

And setting `gallery_conf = {"notebook_images": False}` skips any image embedding:

https://github.com/sphinx-gallery/sphinx-gallery/blob/f84a7af3459c053124c34c4c53037228689d3656/sphinx_gallery/notebook.py#L192-L193