### PR TITLE
Fix the cell toolbar for Jupytext Notebook factory

### DIFF
--- a/jupyterlab/packages/jupyterlab-jupytext-extension/src/factory.ts
+++ b/jupyterlab/packages/jupyterlab-jupytext-extension/src/factory.ts
@@ -68,6 +68,12 @@ export function createFactory(
   });
   docRegistry.addWidgetFactory(factory);
 
+  // Add the widget extensions of the 'Notebook' factory to the 'Jupytext Notebook'
+  // factory.
+  for (const extension of docRegistry.widgetExtensions('Notebook')) {
+    docRegistry.addWidgetExtension(FACTORY, extension);
+  }
+
   // Register widget created with the new factory in the notebook tracker
   // This is required to activate notebook commands (and therefore shortcuts)
   let id = 0; // The ID counter for notebook panels.

--- a/jupyterlab/packages/jupyterlab-jupytext-extension/src/factory.ts
+++ b/jupyterlab/packages/jupyterlab-jupytext-extension/src/factory.ts
@@ -19,10 +19,11 @@ import { IEditorServices } from '@jupyterlab/codeeditor';
 
 import { ITranslator, TranslationBundle } from '@jupyterlab/translation';
 
+import { IDisposable } from '@lumino/disposable';
+
 import { IRisePreviewFactory } from 'jupyterlab-rise';
 
 import { FACTORY, FILE_TYPES } from './tokens';
-import { IDisposable } from '@lumino/disposable';
 
 export function createFactory(
   kernelFileTypeNames: string[],

--- a/jupyterlab/packages/jupyterlab-jupytext-extension/src/index.ts
+++ b/jupyterlab/packages/jupyterlab-jupytext-extension/src/index.ts
@@ -366,26 +366,32 @@ const extension: JupyterFrontEndPlugin<void> = {
     registerFileTypes(availableKernelLanguages, docRegistry, trans);
 
     // Get all kernel file types to add to Jupytext factory
-    const kernelLanguageNames = [];
+    const kernelLanguageNames: string[] = [];
     for (const kernelLanguage of availableKernelLanguages.keys()) {
       kernelLanguageNames.push(kernelLanguage);
     }
 
-    // Create a factory for Jupytext
-    createFactory(
-      kernelLanguageNames,
-      toolbarRegistry,
-      settingRegistry,
-      docRegistry,
-      notebookTracker,
-      notebookFactory,
-      contentFactory,
-      editorServices,
-      rendermime,
-      translator,
-      trans,
-      riseFactory,
-    );
+    // Ensure the cell toolbar extension is activated before creating the factory,
+    // to add this extension to the new factory.
+    await app
+      .activatePlugin('@jupyterlab/cell-toolbar-extension:plugin')
+      .then(() => {
+        // Create a factory for Jupytext
+        createFactory(
+          kernelLanguageNames,
+          toolbarRegistry,
+          settingRegistry,
+          docRegistry,
+          notebookTracker,
+          notebookFactory,
+          contentFactory,
+          editorServices,
+          rendermime,
+          translator,
+          trans,
+          riseFactory,
+        );
+      });
 
     // Register all the commands that create text notebooks with different formats
     // Nicked from notebook-extension package in JupyterLab

--- a/jupyterlab/packages/jupyterlab-jupytext-extension/src/index.ts
+++ b/jupyterlab/packages/jupyterlab-jupytext-extension/src/index.ts
@@ -371,27 +371,21 @@ const extension: JupyterFrontEndPlugin<void> = {
       kernelLanguageNames.push(kernelLanguage);
     }
 
-    // Ensure the cell toolbar extension is activated before creating the factory,
-    // to add this extension to the new factory.
-    await app
-      .activatePlugin('@jupyterlab/cell-toolbar-extension:plugin')
-      .then(() => {
-        // Create a factory for Jupytext
-        createFactory(
-          kernelLanguageNames,
-          toolbarRegistry,
-          settingRegistry,
-          docRegistry,
-          notebookTracker,
-          notebookFactory,
-          contentFactory,
-          editorServices,
-          rendermime,
-          translator,
-          trans,
-          riseFactory,
-        );
-      });
+    // Create a factory for Jupytext
+    createFactory(
+      kernelLanguageNames,
+      toolbarRegistry,
+      settingRegistry,
+      docRegistry,
+      notebookTracker,
+      notebookFactory,
+      contentFactory,
+      editorServices,
+      rendermime,
+      translator,
+      trans,
+      riseFactory,
+    );
 
     // Register all the commands that create text notebooks with different formats
     // Nicked from notebook-extension package in JupyterLab

--- a/jupyterlab/packages/jupyterlab-jupytext-extension/ui-tests/tests/jupytext-notebook.spec.ts
+++ b/jupyterlab/packages/jupyterlab-jupytext-extension/ui-tests/tests/jupytext-notebook.spec.ts
@@ -94,6 +94,11 @@ test.describe('Jupytext Create Text Notebooks from Menu Tests', () => {
       await select!.selectOption(option);
       await page.click('.jp-Dialog .jp-mod-accept');
 
+      const firstCell = await page.notebook.getCellLocator(0);
+      await firstCell?.hover();
+
+      await expect(firstCell!.locator('.jp-cell-toolbar')).toHaveCount(1);
+
       // Populate page
       await populateNotebook(paths.extension, page);
 


### PR DESCRIPTION
This PR fixes #990.

The cell toolbar is an extension added to the *Notebook* factory from the plugin [`'@jupyterlab/cell-toolbar-extension:plugin'`](https://github.com/jupyterlab/jupyterlab/blob/d470c501f50ad7075413cd89967a1a8a332b9a2f/packages/cell-toolbar-extension/src/index.ts#L76).
With this PR, we make sure that the `cell-toolbar-extension` is activated, and add all the extensions of the *Notebook* factory to the *Jupytext Notebook* factory. 