### PR TITLE
updates to the root_level_metadata_filter config handling

### DIFF
--- a/src/jupytext/header.py
+++ b/src/jupytext/header.py
@@ -342,7 +342,6 @@ def metadata_and_cell_to_metadata(nb, fmt, unsupported_keys=None):
     # remaining nb.metadata moved under namespace key for jupyter metadata
     if nb.metadata:
         metadata[_JUPYTER_METADATA_NAMESPACE] = nb.metadata
-    nb.metadata = metadata
     # move first cell frontmatter to the root level of nb.metadata (overwrites)
     if nb.cells and fmt.get("root_level_metadata_as_raw_cell", True):
         cell = nb.cells[0]
@@ -359,7 +358,13 @@ def metadata_and_cell_to_metadata(nb, fmt, unsupported_keys=None):
                     logging.warning("[jupytext] failed to parse YAML in raw cell")
                 else:
                     nb.cells = nb.cells[1:]
-                    nb.metadata = recursive_update(
-                        frontmatter, nb.metadata, overwrite=False
-                    )
+                    if (
+                        "root_level_metadata_filter" not in fmt
+                        and default_root_level_metadata_filter(fmt) == "all"
+                    ):
+                        metadata.setdefault("jupytext", {})[
+                            "root_level_metadata_filter"
+                        ] = "-" + ",-".join(frontmatter)
+                    metadata = recursive_update(frontmatter, metadata, overwrite=False)
+    nb.metadata = metadata
     return nb

--- a/src/jupytext/header.py
+++ b/src/jupytext/header.py
@@ -311,14 +311,15 @@ def default_root_level_metadata_filter(fmt):
 
 def metadata_to_metadata_and_cell(nb, metadata, fmt, unsupported_keys=None):
     # stash notebook metadata, including keys promoted to the root level
-    metadata.update(
+    metadata = recursive_update(
+        metadata,
         filter_metadata(
             nb.metadata,
             fmt.get("root_level_metadata_filter", ""),
             default_root_level_metadata_filter(fmt),
             unsupported_keys=unsupported_keys,
             remove=True,
-        )
+        ),
     )
     # move remaining metadata (i.e. frontmatter) to the first notebook cell
     if nb.metadata and fmt.get("root_level_metadata_as_raw_cell", True):

--- a/src/jupytext/jupytext.py
+++ b/src/jupytext/jupytext.py
@@ -243,13 +243,12 @@ class TextNotebookConverter(NotebookReader, NotebookWriter):
             default_lexer_from_jupytext_metadata = metadata.get("jupytext", {}).pop(
                 "default_lexer", None
             )
+            default_lexer = (
+                default_lexer_from_language_info or default_lexer_from_jupytext_metadata
+            )
             nb = self.filter_notebook(nb, metadata)
             nb = self.merge_frontmatter(nb)
-            return notebook_to_myst(
-                nb,
-                default_lexer=default_lexer_from_language_info
-                or default_lexer_from_jupytext_metadata,
-            )
+            return notebook_to_myst(nb, default_lexer=default_lexer)
 
         # Copy the notebook, in order to be sure we do not modify the original notebook
         nb = NotebookNode(
@@ -363,7 +362,7 @@ class TextNotebookConverter(NotebookReader, NotebookWriter):
         """Use during self.reads to separate notebook metadata from other frontmatter."""
         unsupported_keys = set()
         metadata = nb.metadata.pop(_JUPYTER_METADATA_NAMESPACE, {})
-        metadata.setdefault("jupytext", nb.metadata.get("jupytext", {}))
+        metadata.setdefault("jupytext", {}).update(nb.metadata.get("jupytext", {}))
         self.update_fmt_with_notebook_options(deepcopy(metadata), read=True)
         nb = metadata_to_metadata_and_cell(nb, metadata, self.fmt, unsupported_keys)
         _warn_on_unsupported_keys(unsupported_keys)

--- a/src/jupytext/jupytext.py
+++ b/src/jupytext/jupytext.py
@@ -362,8 +362,15 @@ class TextNotebookConverter(NotebookReader, NotebookWriter):
         """Use during self.reads to separate notebook metadata from other frontmatter."""
         unsupported_keys = set()
         metadata = nb.metadata.pop(_JUPYTER_METADATA_NAMESPACE, {})
-        metadata.setdefault("jupytext", {}).update(nb.metadata.get("jupytext", {}))
-        self.update_fmt_with_notebook_options(deepcopy(metadata), read=True)
+        self.update_fmt_with_notebook_options(
+            {
+                "jupytext": {
+                    **metadata.get("jupytext", {}),
+                    **nb.metadata.get("jupytext", {}),
+                },
+            },
+            read=True,
+        )
         nb = metadata_to_metadata_and_cell(nb, metadata, self.fmt, unsupported_keys)
         _warn_on_unsupported_keys(unsupported_keys)
         return nb

--- a/src/jupytext/metadata_filter.py
+++ b/src/jupytext/metadata_filter.py
@@ -226,11 +226,8 @@ def subset_metadata(
         metadata, unsupported_keys=unsupported_keys
     )
     if keep_only is not None:
-        keys = [key for key in supported_keys if key in keep_only]
-        if remove:
-            filtered_metadata = {key: metadata.pop(key) for key in keys}
-        else:
-            filtered_metadata = {key: metadata[key] for key in keys}
+        include = [key for key in supported_keys if key in keep_only]
+        filtered_metadata = {key: metadata[key] for key in include}
         sub_keep_only = second_level(keep_only)
         keys = [key for key in supported_keys if key in sub_keep_only]
         for key in keys:
@@ -241,10 +238,8 @@ def subset_metadata(
                 remove=remove,
             )
     else:
-        if remove:
-            filtered_metadata = {key: metadata.pop(key) for key in supported_keys}
-        else:
-            filtered_metadata = {key: metadata[key] for key in supported_keys}
+        include = supported_keys
+        filtered_metadata = {key: metadata[key] for key in supported_keys}
 
     if exclude is not None:
         for key in exclude:
@@ -257,7 +252,12 @@ def subset_metadata(
                     filtered_metadata[key],
                     exclude=sub_exclude[key],
                     unsupported_keys=unsupported_keys,
+                    remove=remove,
                 )
+
+    if remove:
+        for key in set(include).difference(exclude or {}):
+            metadata.pop(key, None)
 
     return filtered_metadata
 

--- a/src/jupytext/myst.py
+++ b/src/jupytext/myst.py
@@ -366,7 +366,8 @@ def myst_to_notebook(
 
     if "language_info" not in notebook.metadata and default_lexer:
         has_metadata = bool(notebook.metadata)
-        jupytext_metadata = notebook.metadata.setdefault("jupytext", {})
+        jupyter_metadata = notebook.metadata.setdefault(_JUPYTER_METADATA_NAMESPACE, {})
+        jupytext_metadata = jupyter_metadata.setdefault("jupytext", {})
         jupytext_metadata["default_lexer"] = default_lexer
         if not has_metadata:
             jupytext_metadata["notebook_metadata_filter"] = "-all"

--- a/src/jupytext/myst.py
+++ b/src/jupytext/myst.py
@@ -24,7 +24,7 @@ except ImportError:
 MYST_FORMAT_NAME = "myst"
 CODE_DIRECTIVE = "{code-cell}"
 RAW_DIRECTIVE = "{raw-cell}"
-_DEFAULT_ROOT_LEVEL_METADATA = "kernelspec,jupytext,kernel_info"
+_DEFAULT_ROOT_LEVEL_METADATA = "all"
 
 
 def is_myst_available():

--- a/tests/data/notebooks/outputs/ipynb_to_myst/jupyter_with_raw_cell_on_top.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/jupyter_with_raw_cell_on_top.md
@@ -10,6 +10,8 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+jupytext:
+  root_level_metadata_filter: -title,-output,-editor_options
 ---
 
 ```{code-cell} ipython3

--- a/tests/functional/metadata/test_metadata_filter.py
+++ b/tests/functional/metadata/test_metadata_filter.py
@@ -176,8 +176,6 @@ def test_default_config_has_priority_over_current_metadata(
 @pytest.mark.requires_myst
 def test_metadata_filter_in_notebook_757():
     md = """---
-nbhosting:
-  title: 'Exercice: Taylor'
 jupytext:
   cell_metadata_filter: all,-hidden,-heading_collapsed
   notebook_metadata_filter: all,-language_info,-toc,-jupytext.text_representation.jupytext_version,-jupytext.text_representation.format_version
@@ -188,6 +186,8 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+nbhosting:
+  title: 'Exercice: Taylor'
 ---
 
 ```python

--- a/tests/functional/metadata/test_metadata_filters_from_config.py
+++ b/tests/functional/metadata/test_metadata_filters_from_config.py
@@ -1,8 +1,10 @@
 import nbformat
-from nbformat.v4.nbbase import new_markdown_cell, new_notebook
+import yaml
+from nbformat.v4.nbbase import new_code_cell, new_markdown_cell, new_notebook
 
 from jupytext.cli import jupytext as jupytext_cli
 from jupytext.compare import compare, compare_notebooks
+from jupytext.header import _JUPYTER_METADATA_NAMESPACE
 
 
 def test_metadata_filters_from_config(tmpdir):
@@ -41,6 +43,35 @@ cell_metadata_filter = "-all"
     md = md_file.read()
 
     compare(md, "A markdown cell\n")
+
+    jupytext_cli([str(md_file), "--to", "notebook", "--update"])
+    nb2 = nbformat.read(str(nb_file), as_version=4)
+    compare_notebooks(nb2, nb)
+
+
+def test_root_level_metadata_filters_from_config(tmpdir):
+    cfg_file = tmpdir.join("jupytext.toml")
+    nb_file = tmpdir.join("notebook.ipynb")
+    md_file = tmpdir.join("notebook.md")
+
+    cfg_file.write(
+        """root_level_metadata_filter = "-all"
+"""
+    )
+    nb = new_notebook(
+        cells=[new_code_cell("1 + 1")],
+        metadata={
+            "language_info": {
+                "name": "python",
+                "pygments_lexer": "ipython3",
+            },
+        },
+    )
+    nbformat.write(nb, str(nb_file))
+
+    jupytext_cli([str(nb_file), "--to", "md:myst"])
+    header = next(yaml.safe_load_all(md_file.read()))
+    assert list(header) == [_JUPYTER_METADATA_NAMESPACE]
 
     jupytext_cli([str(md_file), "--to", "notebook", "--update"])
     nb2 = nbformat.read(str(nb_file), as_version=4)

--- a/tests/functional/metadata/test_metadata_filters_from_config.py
+++ b/tests/functional/metadata/test_metadata_filters_from_config.py
@@ -1,4 +1,5 @@
 import nbformat
+import pytest
 import yaml
 from nbformat.v4.nbbase import new_code_cell, new_markdown_cell, new_notebook
 
@@ -49,6 +50,7 @@ cell_metadata_filter = "-all"
     compare_notebooks(nb2, nb)
 
 
+@pytest.mark.requires_myst
 def test_root_level_metadata_filters_from_config(tmpdir):
     cfg_file = tmpdir.join("jupytext.toml")
     nb_file = tmpdir.join("notebook.ipynb")

--- a/tests/functional/round_trip/test_myst_header.py
+++ b/tests/functional/round_trip/test_myst_header.py
@@ -11,10 +11,6 @@ from jupytext.myst import dump_yaml_blocks
 @pytest.mark.requires_myst
 def test_myst_header_is_stable_1247_using_inline_filter(
     md="""---
-mystnb:
-  execution_mode: 'off'
-settings:
-  output_matplotlib_strings: remove
 jupytext:
   formats: md:myst
   notebook_metadata_filter: -jupytext.text_representation.jupytext_version,settings,mystnb
@@ -26,6 +22,10 @@ kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+mystnb:
+  execution_mode: 'off'
+settings:
+  output_matplotlib_strings: remove
 ---
 """,
 ):
@@ -40,10 +40,6 @@ def test_myst_header_is_stable_1247_using_config(
     jupytext_toml_content="""notebook_metadata_filter = "-jupytext.text_representation.jupytext_version,settings,mystnb"
 """,
     md="""---
-mystnb:
-  execution_mode: 'off'
-settings:
-  output_matplotlib_strings: remove
 jupytext:
   formats: md:myst
   text_representation:
@@ -54,6 +50,10 @@ kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+mystnb:
+  execution_mode: 'off'
+settings:
+  output_matplotlib_strings: remove
 ---
 """,
 ):


### PR DESCRIPTION
The "root_level_metadata_filter" I just introduced had a few flaws.

1) The setting of `myst._DEFAULT_ROOT_LEVEL_METADATA` to a list of a three keys is not enough to prevent disruption of existing notebooks; the new setting introduced here is "all" (which is now exactly how the myst format has been working). That "all" makes subsequent separation of metadata and raw cell frontmatter harder, but is solved by storing the frontmatter keys in `jupytext.root_level_metadata_filter`. The "root_level_metadata_filter" key would only be injected if not set by the user and only if there is a raw cell on top (i.e. unlikely to be encountered at all except by folks switching to md:myst from md format).

2) Setting "root_level_metadata_filter" to "-all" in user config was not compatible with the use of `jupytext.default_lexer`, but now is.

3) The implementation of `remove=True` in `subset_metadata` did not work for excluded keys, but now does.

With these changes, I was able to roll back the re-ordering of frontmatter keys introduced in #1315.
