### PR TITLE
Normalize directory separators after expanding globs

### DIFF
--- a/src/jupytext/cli.py
+++ b/src/jupytext/cli.py
@@ -486,7 +486,8 @@ def jupytext(args=None):
     for pattern in args.notebooks:
         if "*" in pattern or "?" in pattern:
             # Exclude the .jupytext.py configuration file
-            notebooks.extend(glob.glob(pattern, recursive=True))
+            # On Windows, wildcards expand with backslash as directory separator.
+            notebooks.extend(path.replace("\\", "/") for path in glob.glob(pattern, recursive=True))
         else:
             notebooks.append(pattern)
 


### PR DESCRIPTION
There are multiple issues related to backslashes in input paths (#629, #1028). Converting backslashes expanded by `glob.glob` seems to be reasonable workaround. If the user uses forward slashes, this should make everything work as expected. Of course, if they mix forward and back slashes, this might not help them.