### PR TITLE
Add handling for ROOT-flavored C++ notebooks that use the ".C" extension

### DIFF
--- a/src/jupytext/formats.py
+++ b/src/jupytext/formats.py
@@ -814,6 +814,11 @@ def auto_ext_from_metadata(metadata):
     if auto_ext == ".resource":
         return ".robot"
 
+    # Handle ROOT C++ notebooks
+    # https://tinyurl.com/root-cpp-notebook-doc
+    if auto_ext == ".C":
+        return ".cpp"
+
     return auto_ext
 
 

--- a/tests/data/notebooks/inputs/ipynb_cpp/root_cpp.ipynb
+++ b/tests/data/notebooks/inputs/ipynb_cpp/root_cpp.ipynb
@@ -1,0 +1,60 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f0c19410-7bd1-4b72-9cb3-f042245a06da",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#include <iostream>\n",
+    "#include <string>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "a56bd112-a6f7-439e-be2c-0c8f35f3e3e0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "int k = 4;\n",
+    "std::string foo = \"This string says \\\"foo\\\"\";"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "1b206654-b4d6-4865-b114-f43e32b3071b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "k = 4\n",
+      "This string says \"foo\"\n"
+     ]
+    }
+   ],
+   "source": [
+    "std::cout << \"k = \" << k << '\\n' << foo << '\\n';"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "ROOT C++",
+   "language": "c++",
+   "name": "root"
+  },
+  "language_info": {
+   "codemirror_mode": "text/x-c++src",
+   "file_extension": ".C",
+   "mimetype": " text/x-c++src",
+   "name": "c++"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/functional/others/test_auto_ext.py
+++ b/tests/functional/others/test_auto_ext.py
@@ -32,6 +32,8 @@ def test_auto_from_kernelspecs_works(ipynb_file):
         expected_ext = ".R"
     elif expected_ext == ".fs":
         expected_ext = ".fsx"
+    elif expected_ext == ".C":
+        expected_ext = ".cpp"
     auto_ext = auto_ext_from_metadata(nb.metadata)
     if auto_ext == ".sage":
         pytest.skip(


### PR DESCRIPTION
Recent versions of the [ROOT data analysis framework](https://root.cern.ch/) offer a [C++ kernel](https://github.com/root-project/root/tree/master/bindings/jupyroot#c-rootbook) for Jupyter notebooks. The metadata saved by ROOT into these notebooks lists ".C" as the file extension rather than the more standard ".cpp"

This pull request adds handling of this file extension for the C++ language. An example ROOT C++ notebook is included that passes unit tests after the proposed code changes.