### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/step_tests-pip.yml
+++ b/.github/workflows/step_tests-pip.yml
@@ -21,13 +21,13 @@ jobs:
       ${{ matrix.no_kernel && '(No kernel)' }}
       ${{ matrix.markdown-it-py && format('(markdown-it-py {0})', matrix.markdown-it-py) }}
       ${{ matrix.no_markdown-it-py && '(No markdown-it-py)'}}
-      ${{ matrix.jupyter_server && '(Jupyter-server {0})'}}
+      ${{ matrix.jupyter_server && format('(Jupyter-server {0})', matrix.jupyter_server) }}
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13"]
         experimental: [false]
         include:
           # Test with jupyter-server=2.10 that does not have the 'require_hash' argument

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Jupytext ChangeLog
 ==================
 
+1.17.2-dev (2025-05-??)
+-------------------
+
+**Changed**
+- We have removed Python 3.8 from the list of supported Python version, and from the CI, as it has reached its EOL
+
+
 1.17.1 (2025-04-26)
 -------------------
 

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: jupytext-dev
 channels:
   - conda-forge
 dependencies:
-  - python>=3.8
+  - python>=3.9
   - jupyterlab>=4.0.0
   - nbformat>=5.1.2
   - pre-commit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "Marc Wouts", email = "marc.wouts@gmail.com" },
 ]
 readme = "build/README_with_absolute_links.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: MIT License",
@@ -24,7 +24,6 @@ classifiers = [
     "Topic :: Text Processing :: Markup",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/src/jupytext/version.py
+++ b/src/jupytext/version.py
@@ -1,3 +1,3 @@
 """Jupytext's version number"""
 
-__version__ = "1.17.1"
+__version__ = "1.17.2-dev"


### PR DESCRIPTION
Python 3.8 has reached its EOL, and `hatch` fails to install in the recent CI runs: https://github.com/mwouts/jupytext/actions/runs/15322535856