### PR TITLE
Document all the extensions supported by `jupytext --to`

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -9,7 +9,7 @@ coverage:
       source:
         paths:
           - "src/jupytext/"
-        target: 97%
+        target: 96.5%
         threshold: 0.2%
       tests:
         paths:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Jupytext ChangeLog
 1.17.3-dev (???)
 -------------------
 
+**Added**
+- All the extensions supported by Jupytext now appear in the `--to` paragraph
+of `jupytext --help` ([#433](https://github.com/mwouts/jupytext/issues/433))
+
+**Fixed**
+- The text against `jupyter-fs` now install its `fs` extra dependency ([#1398](https://github.com/mwouts/jupytext/issues/1398))
+
 
 1.17.2 (2025-06-01)
 -------------------

--- a/src/jupytext/cli.py
+++ b/src/jupytext/cli.py
@@ -19,6 +19,7 @@ from .formats import (
     _BINARY_FORMAT_OPTIONS,
     _VALID_FORMAT_OPTIONS,
     JUPYTEXT_FORMATS,
+    NOTEBOOK_EXTENSIONS,
     check_auto_ext,
     check_file_version,
     long_form_multiple_formats,
@@ -94,20 +95,23 @@ def parse_jupytext_args(args=None):
         "file extension and content when missing.",
     )
     # Destination format & act on metadata
+
+    selected_file_extensions = ["md", "Rmd", "jl", "py", "R"]
     parser.add_argument(
         "--to",
         dest="output_format",
         help=(
             "The destination format: 'ipynb', 'markdown' or 'script', or a file extension: "
-            "'md', 'Rmd', 'jl', 'py', 'R', ..., 'auto' (script extension matching the notebook language), "
+            "'{}', ... or 'auto' (script extension matching the notebook language), "
             "or a combination of an extension and a format name, e.g. {} ".format(
+                "', '".join(selected_file_extensions),
                 ", ".join(
                     {
                         f"md:{fmt.format_name}"
                         for fmt in JUPYTEXT_FORMATS
                         if fmt.extension == ".md"
                     }
-                )
+                ),
             )
             + " or {}. ".format(
                 ", ".join(
@@ -125,7 +129,15 @@ def parse_jupytext_args(args=None):
             "notebooks and text documents in a roundtrip. Use the "
             "--test and and --test-strict commands to test the roundtrip on your files. "
             "Read more about the available formats at "
-            "https://jupytext.readthedocs.io/en/latest/formats.html"
+            "https://jupytext.readthedocs.io/en/latest/formats.html. "
+            "NB: in addition to the extensions listed above, you can also use these: '{}'".format(
+                "', '".join(
+                    sorted(
+                        set(ext.removeprefix(".") for ext in NOTEBOOK_EXTENSIONS)
+                        - set(selected_file_extensions + ["auto", "ipynb"])
+                    )
+                )
+            )
         ),
     )
 


### PR DESCRIPTION
This PR changes the output of `jupytext --help` in the following way:

```
(jupytext-dev) jupytext $ jupytext --help > v1.17.3
(jupytext-dev) jupytext $ jupytext --help > v1.17.2
(jupytext-dev) jupytext $ diff v1.17.2 v1.17.3
25,40c25,46
<                         'py', 'R', ..., 'auto' (script extension matching the
<                         notebook language), or a combination of an extension
<                         and a format name, e.g. md:myst, md:markdown,
<                         md:pandoc or py:light, py:percent, py:sphinx,
<                         py:hydrogen, py:nomarker. The default format for
<                         scripts is the 'percent' format, which uses '# %%' as
<                         cell markers and is compatible with VS Code and
<                         PyCharm. Alternatively, you can also use the 'light'
<                         format, which uses fewer cell markers. The main
<                         formats (MyST Markdown, Markdown, percent, light)
<                         preserve notebooks and text documents in a roundtrip.
<                         Use the --test and and --test-strict commands to test
<                         the roundtrip on your files. Read more about the
<                         available formats at
<                         https://jupytext.readthedocs.io/en/latest/formats.html
<                         (default: None)
---
>                         'py', 'R', ... or 'auto' (script extension matching
>                         the notebook language), or a combination of an
>                         extension and a format name, e.g. md:myst, md:pandoc,
>                         md:markdown or py:percent, py:hydrogen, py:nomarker,
>                         py:sphinx, py:light. The default format for scripts is
>                         the 'percent' format, which uses '# %%' as cell
>                         markers and is compatible with VS Code and PyCharm.
>                         Alternatively, you can also use the 'light' format,
>                         which uses fewer cell markers. The main formats (MyST
>                         Markdown, Markdown, percent, light) preserve notebooks
>                         and text documents in a roundtrip. Use the --test and
>                         and --test-strict commands to test the roundtrip on
>                         your files. Read more about the available formats at h
>                         ttps://jupytext.readthedocs.io/en/latest/formats.html.
>                         NB: in addition to the extensions listed above, you
>                         can also use these: 'clj', 'coco', 'cpp', 'cs', 'do',
>                         'fs', 'fsx', 'go', 'gp', 'groovy', 'hs', 'java', 'js',
>                         'lgt', 'logtalk', 'lua', 'm', 'mac', 'markdown', 'ml',
>                         'mnb', 'myst', 'mystnb', 'pro', 'ps1', 'q', 'qmd',
>                         'r', 'resource', 'robot', 'rs', 'sage', 'sas',
>                         'scala', 'scm', 'sh', 'sos', 'ss', 'tcl', 'ts',
>                         'wolfram', 'xsh' (default: None)
```

Closes #433