### PR TITLE
change lstat to stat in getting mtime for sync logic, fix #1407

### DIFF
--- a/src/jupytext/cli.py
+++ b/src/jupytext/cli.py
@@ -1103,7 +1103,7 @@ def git_timestamp(path):
 def get_timestamp(path):
     if not os.path.isfile(path):
         return None
-    return os.lstat(path).st_mtime
+    return os.stat(path).st_mtime
 
 
 def load_paired_notebook(notebook, fmt, config, formats, nb_file, log, pre_commit_mode):


### PR DESCRIPTION
Now gets the mtime of the destination of symlinked files by switching to stat from lstat.