### PR TITLE
Fix: a round trip on a simple Python file leaves it unchanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@ of `jupytext --help` ([#433](https://github.com/mwouts/jupytext/issues/433))
 formats for a given notebook ([#1419](https://github.com/mwouts/jupytext/issues/1419))
 
 **Fixed**
+- We have fixed `jupytext --sync`, and the contents manager, to make sure that a simple `.py` file (not in the percent format) will not be treated as a paired file when the Jupytext configuration contains `formats="ipynb,py:percent"` ([#1418](https://github.com/mwouts/jupytext/issues/1418))
 - The test against `jupyter-fs` now installs its `fs` extra dependency ([#1398](https://github.com/mwouts/jupytext/issues/1398))
 - The `jupytext --sync` command now works correctly with symbolic links. Thanks to [mccullerlp](https://github.com/mccullerlp) for reporting ([#1407](https://github.com/mwouts/jupytext/issues/1407)) and addressing ([#1408](https://github.com/mwouts/jupytext/pull/1408)) the problem!
 - Jupytext will look for `quarto.cmd` on Windows. Thanks to [mccullerlp](https://github.com/mccullerlp) for documenting the issue ([#1406](https://github.com/mwouts/jupytext/issues/1406), [#1409](https://github.com/mwouts/jupytext/pull/1409)).
-- We have corrected the `jupytext --paired-paths` command, it will now take the Jupytext configuration file, if any, into account ([#1419](https://github.com/mwouts/jupytext/issues/1419))
+- We have corrected the `jupytext --paired-paths` command: it will now take the Jupytext configuration file, if any, into account ([#1419](https://github.com/mwouts/jupytext/issues/1419))
 
 
 1.17.2 (2025-06-01)

--- a/tests/functional/config/test_config.py
+++ b/tests/functional/config/test_config.py
@@ -5,7 +5,9 @@ import pytest
 from jupytext.config import (
     find_jupytext_configuration_file,
     load_jupytext_configuration_file,
+    notebook_formats,
 )
+from jupytext.jupytext import load_jupytext_config, read
 
 
 def test_find_jupytext_configuration_file(tmpdir):
@@ -200,3 +202,17 @@ def test_deprecated_options_cause_warning(tmpdir, option_name):
     with pytest.warns(FutureWarning, match=f"use '{option_name}'"):
         config.set_default_format_options(fmt)
         assert fmt[option_name] == "value"
+
+
+def test_simple_py_file_is_not_paired(tmp_path):
+    py_file = tmp_path / "simple.py"
+    py_file.write_text('print("Hello, world!")')
+
+    config_file = tmp_path / "jupytext.toml"
+    config_file.write_text('formats = "ipynb,py:percent"')
+
+    notebook = read(str(py_file))
+    config_file = load_jupytext_config(str(config_file))
+
+    formats = notebook_formats(notebook, config_file, str(py_file))
+    assert formats == [{"extension": ".py", "format_name": "light"}], formats


### PR DESCRIPTION
that was not the case in Jupytext v1.17.2 when the configuration has e.g. formats="ipynb,py:percent"

Closes #1418