### PR TITLE
DOC: remove nonexistent link from help page

### DIFF
--- a/src/jupytext/cli.py
+++ b/src/jupytext/cli.py
@@ -119,6 +119,8 @@ def parse_jupytext_args(args=None):
             "The main formats (MyST Markdown, Markdown, percent, light) preserve "
             "notebooks and text documents in a roundtrip. Use the "
             "--test and and --test-strict commands to test the roundtrip on your files. "
+            "Read more about the available formats at "
+            "https://jupytext.readthedocs.io/en/latest/formats-scripts.html "
             "NB: in addition to the extensions listed above, you can also use these: '{}'".format(
                 "', '".join(
                     sorted(

--- a/src/jupytext/cli.py
+++ b/src/jupytext/cli.py
@@ -119,8 +119,6 @@ def parse_jupytext_args(args=None):
             "The main formats (MyST Markdown, Markdown, percent, light) preserve "
             "notebooks and text documents in a roundtrip. Use the "
             "--test and and --test-strict commands to test the roundtrip on your files. "
-            "Read more about the available formats at "
-            "https://jupytext.readthedocs.io/en/latest/formats.html. "
             "NB: in addition to the extensions listed above, you can also use these: '{}'".format(
                 "', '".join(
                     sorted(


### PR DESCRIPTION
The unified formats.html docs page have been removed years ago. The current help feels detailed enough that I just simply removed the link rather than adding back multiple new ones that replaced that single link.