### PR TITLE
Update the RTD configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,9 +6,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-24.04"
   tools:
-    python: "mambaforge-4.10"
+    python: "miniconda3-3.12-24.9"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
The documentation build currently fails. This changes updates the RTD configuration using to the [current mamba example](https://docs.readthedocs.com/platform/stable/guides/conda.html#making-builds-faster-with-mamba).