### PR TITLE
Version 1.19.0 (bis)

### DIFF
--- a/src/jupytext/version.py
+++ b/src/jupytext/version.py
@@ -1,4 +1,4 @@
 """Jupytext's version number"""
 
 # Must match [N!]N(.N)*[{a|b|rc}N][.postN][.devN], cf. PEP 440
-__version__ = "1.20.0"
+__version__ = "1.19.0"

--- a/tests/functional/docs/test_changelog.py
+++ b/tests/functional/docs/test_changelog.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from jupytext.version import __version__
 
 
 def replace_issue_number_with_links(text):
@@ -41,3 +42,28 @@ def test_update_changelog():
     new_text = replace_issue_number_with_links(cur_text)
     if cur_text != new_text:
         changelog_file.write_text(new_text)  # pragma: no cover
+
+
+def test_version_matches_changelog():
+    root_path = Path(__file__).parent.parent.parent.parent
+    changelog_file = root_path / "CHANGELOG.md"
+
+    # Read version from version.py
+    current_version = __version__
+
+    # Read first version from CHANGELOG.md
+    changelog_text = changelog_file.read_text()
+    prev_line = ""
+    for line in changelog_text.splitlines():
+        if not line.startswith("--------"):
+            prev_line = line
+            continue
+
+        changelog_version = prev_line.split("(")[0].strip()
+        assert current_version == changelog_version, (
+            f"Version mismatch: version.py has {current_version}, but CHANGELOG.md has {changelog_version}"
+        )
+
+        return
+
+    raise ValueError("No version found in CHANGELOG.md")


### PR DESCRIPTION
1.19.0 (2026-01-18)
-------------------

**Changes**
- The environment used to develop Jupytext is now maintained using Pixi ([#1459](https://github.com/mwouts/jupytext/pull/1459))

**Fixed**
- We have restored the support for `.qmd` documents in Jupyter ([#1435](https://github.com/mwouts/jupytext/issues/1435))
- We have fixed warnings about the cell ids like either `Cell is missing an id field` or `Additional properties are not allowed ('id' was unexpected)` when converting to some formats, including Pandoc ([#1464](https://github.com/mwouts/jupytext/pull/1464))
- We have updated the dependencies of the Jupytext extension for JupyterLab. Many thanks to [Mahendra Paipuri](https://github.com/mahendrapaipuri) for his PR ([#1477](https://github.com/mwouts/jupytext/pull/1477))!

**Added**
- We have added a new `py:marimo` format, which uses the `marimo` command line interface to convert notebooks to and from the Marimo format ([#1431](https://github.com/mwouts/jupytext/pull/1431))