### PR TITLE
Add back file icons, denote notebook-only types with orange border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Jupytext ChangeLog
 -------------------------
 
 **Changed**
+- Jupytext does not change the file icons anymore! Thanks to [Michał Krassowski](https://github.com/krassowski) for finally solving this long standing issue! ([#398](https://github.com/mwouts/jupytext/issues/398))
 - We have bumped lodash from 4.17.21 to 4.17.23 in JupyterLab extension ([#1483](https://github.com/mwouts/jupytext/pull/1483))
 - We require `marimo<=0.19.4` in tests following a change in the location of the `marimo` import ([#1485](https://github.com/mwouts/jupytext/issues/1485))
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -20,14 +20,14 @@ Jupytext comes with a series of tools and plugin, which we will now briefly desc
 
 ## Jupytext's contents manager
 
-Jupytext provides a contents manager that let Jupyter open and save notebooks as text files. When Jupytext's content manager is active in Jupyter, scripts and Markdown documents have a notebook icon.
+Jupytext provides a contents manager that let Jupyter open and save notebooks as text files.
 
 Jupytext's contents manager is activated automatically by Jupytext's server extension. When you start either `jupyter lab` or `jupyter notebook`, you should see a line that looks like:
 ```bash
 [I 10:28:31.646 LabApp] [Jupytext Server Extension] Changing NotebookApp.contents_manager_class from LargeFileManager to jupytext.TextFileContentsManager
 ```
 
-If you don't have the notebook icon on text documents after a fresh restart of your Jupyter server, please enable our server extension explicitly with
+If you don't see the message above after a fresh restart of your Jupyter server, please enable our server extension explicitly with
 ```
 jupyter serverextension enable jupytext
 ```

--- a/docs/text-notebooks.md
+++ b/docs/text-notebooks.md
@@ -12,8 +12,7 @@ The outputs of the notebook are not stored on disk, unless you decide to
 
 ## How to open a text notebook in JupyterLab
 
-Once you have [installed](install.md) Jupytext, `.py` and `.md` files get a
-notebook icon in Jupyter. And you can really open and run these files as
+Once you have [installed](install.md) Jupytext, you can open and run `.py` and `.md` files as
 notebooks.
 
 ### With a right click

--- a/jupyterlab/packages/jupyterlab-jupytext-extension/src/index.ts
+++ b/jupyterlab/packages/jupyterlab-jupytext-extension/src/index.ts
@@ -371,15 +371,19 @@ const extension: JupyterFrontEndPlugin<void> = {
     const createTextNotebookCommands =
       await getAvailableCreateTextNotebookCommands(
         includeFormats,
-        availableKernelLanguages
+        availableKernelLanguages,
       );
 
     // Register Jupytext text notebooks file types
-    registerFileTypes(availableKernelLanguages,
-        [
-          ...[...JUPYTEXT_PAIR_COMMANDS_FILETYPE_DATA.values()].flat(),
-          ...[...AUTO_LANGUAGE_FILETYPE_DATA.values()].flat()
-        ], docRegistry, trans);
+    registerFileTypes(
+      availableKernelLanguages,
+      [
+        ...[...JUPYTEXT_PAIR_COMMANDS_FILETYPE_DATA.values()].flat(),
+        ...[...AUTO_LANGUAGE_FILETYPE_DATA.values()].flat(),
+      ],
+      docRegistry,
+      trans,
+    );
 
     // Get all kernel file types to add to Jupytext factory
     const kernelLanguageNames: string[] = [];

--- a/jupyterlab/packages/jupyterlab-jupytext-extension/src/index.ts
+++ b/jupyterlab/packages/jupyterlab-jupytext-extension/src/index.ts
@@ -54,6 +54,7 @@ import {
   CommandIDs,
   IFileTypeData,
   JupytextIcon,
+  AUTO_LANGUAGE_FILETYPE_DATA,
 } from './tokens';
 
 import {
@@ -362,6 +363,7 @@ const extension: JupyterFrontEndPlugin<void> = {
     // Get a map of available kernel languages in current widget
     const availableKernelLanguages = await getAvailableKernelLanguages(
       languages,
+      docRegistry,
       serviceManager,
     );
 
@@ -369,11 +371,15 @@ const extension: JupyterFrontEndPlugin<void> = {
     const createTextNotebookCommands =
       await getAvailableCreateTextNotebookCommands(
         includeFormats,
-        availableKernelLanguages,
+        availableKernelLanguages
       );
 
     // Register Jupytext text notebooks file types
-    registerFileTypes(availableKernelLanguages, docRegistry, trans);
+    registerFileTypes(availableKernelLanguages,
+        [
+          ...[...JUPYTEXT_PAIR_COMMANDS_FILETYPE_DATA.values()].flat(),
+          ...[...AUTO_LANGUAGE_FILETYPE_DATA.values()].flat()
+        ], docRegistry, trans);
 
     // Get all kernel file types to add to Jupytext factory
     const kernelLanguageNames: string[] = [];

--- a/jupyterlab/packages/jupyterlab-jupytext-extension/src/registry.ts
+++ b/jupyterlab/packages/jupyterlab-jupytext-extension/src/registry.ts
@@ -13,25 +13,25 @@ export function registerFileTypes(
   trans: TranslationBundle,
 ) {
   const mystExtensions = ['myst', 'mystnb', 'mnb'];
-  const rmdExtensions = ['Rmd']
-  const quartoExtensions = ['qmd']
+  const rmdExtensions = ['Rmd'];
+  const quartoExtensions = ['qmd'];
 
   const extensionsWithFactory = [
     ...mystExtensions,
     ...rmdExtensions,
-    ...quartoExtensions
-  ]
+    ...quartoExtensions,
+  ];
 
   // Add a catch-all file type to overrride icon which by default is derive from model type.
   // Because jupytext changes the type of all files it can handle to Notebook, we need to
   // override it. We exclude file types which have dedicated icons (handled later).
   const excludedExtensions = [
     'ipynb',
-    ...jupytextFormatsWithFileTypeData.map(f => f.fileExt),
-    ...extensionsWithFactory
+    ...jupytextFormatsWithFileTypeData.map((f) => f.fileExt),
+    ...extensionsWithFactory,
   ].join('|');
   docRegistry.addFileType({
-    name: `jupytext-notebook-file`,
+    name: 'jupytext-notebook-file',
     contentType: 'notebook',
     pattern: `^(?!.*\\.(${excludedExtensions})$).*$`,
     icon: fileIcon,
@@ -46,7 +46,9 @@ export function registerFileTypes(
         // `pattern` field gives it precedence over other file type information when resolving the icon
         pattern: `\\.${format.fileExt}$`,
         extensions: [`.${format.fileExt}`],
-        icon: format.iconName ? LabIcon.resolve({ icon: format.iconName }) : format.kernelIcon,
+        icon: format.iconName
+          ? LabIcon.resolve({ icon: format.iconName })
+          : format.kernelIcon,
       });
     }
   }
@@ -63,7 +65,9 @@ export function registerFileTypes(
             kernelFileType.paletteLabel.split('New')[1].trim(),
           ),
           extensions: [`.${kernelFileType.fileExt}`],
-          icon: kernelFileType.iconName ? LabIcon.resolve({ icon: kernelFileType.iconName }) : kernelFileType.kernelIcon,
+          icon: kernelFileType.iconName
+            ? LabIcon.resolve({ icon: kernelFileType.iconName })
+            : kernelFileType.kernelIcon,
         });
       });
     },
@@ -81,7 +85,7 @@ export function registerFileTypes(
       name: 'myst',
       contentType: 'notebook',
       displayName: trans.__('MyST Markdown Notebook'),
-      extensions: mystExtensions.map(ext => '.' + ext),
+      extensions: mystExtensions.map((ext) => '.' + ext),
       icon: markdownNotebookIcon,
     },
     ['Notebook'],
@@ -93,7 +97,7 @@ export function registerFileTypes(
       contentType: 'notebook',
       displayName: trans.__('R Markdown Notebook'),
       // Extension file are transformed to lower case...
-      extensions: rmdExtensions.map(ext => '.' + ext),
+      extensions: rmdExtensions.map((ext) => '.' + ext),
       icon: markdownNotebookIcon,
     },
     ['Notebook'],
@@ -104,8 +108,8 @@ export function registerFileTypes(
       name: 'quarto',
       contentType: 'notebook',
       displayName: trans.__('Quarto Notebook'),
-      extensions: quartoExtensions.map(ext => '.' + ext),
-      pattern: `\\.qmd$`,
+      extensions: quartoExtensions.map((ext) => '.' + ext),
+      pattern: '\\.qmd$',
       icon: markdownNotebookIcon,
     },
     ['Notebook'],

--- a/jupyterlab/packages/jupyterlab-jupytext-extension/src/registry.ts
+++ b/jupyterlab/packages/jupyterlab-jupytext-extension/src/registry.ts
@@ -2,43 +2,87 @@ import { DocumentRegistry } from '@jupyterlab/docregistry';
 
 import { TranslationBundle } from '@jupyterlab/translation';
 
-import { markdownIcon, kernelIcon } from '@jupyterlab/ui-components';
+import { markdownIcon, LabIcon, fileIcon } from '@jupyterlab/ui-components';
 
 import { IFileTypeData } from './tokens';
 
 export function registerFileTypes(
   availableKernelLanguages: Map<string, IFileTypeData[]>,
+  jupytextFormatsWithFileTypeData: IFileTypeData[],
   docRegistry: DocumentRegistry,
   trans: TranslationBundle,
 ) {
+  const mystExtensions = ['myst', 'mystnb', 'mnb'];
+  const rmdExtensions = ['Rmd']
+  const quartoExtensions = ['qmd']
+
+  const extensionsWithFactory = [
+    ...mystExtensions,
+    ...rmdExtensions,
+    ...quartoExtensions
+  ]
+
+  // Add a catch-all file type to overrride icon which by default is derive from model type.
+  // Because jupytext changes the type of all files it can handle to Notebook, we need to
+  // override it. We exclude file types which have dedicated icons (handled later).
+  const excludedExtensions = [
+    'ipynb',
+    ...jupytextFormatsWithFileTypeData.map(f => f.fileExt),
+    ...extensionsWithFactory
+  ].join('|');
+  docRegistry.addFileType({
+    name: `jupytext-notebook-file`,
+    contentType: 'notebook',
+    pattern: `^(?!.*\\.(${excludedExtensions})$).*$`,
+    icon: fileIcon,
+  });
+
+  // Handle file types with dedicated icons
+  for (const format of jupytextFormatsWithFileTypeData) {
+    if (!extensionsWithFactory.includes(format.fileExt)) {
+      docRegistry.addFileType({
+        name: `${format.fileExt}-jupytext-notebook`,
+        contentType: 'notebook',
+        // `pattern` field gives it precedence over other file type information when resolving the icon
+        pattern: `\\.${format.fileExt}$`,
+        extensions: [`.${format.fileExt}`],
+        icon: format.iconName ? LabIcon.resolve({ icon: format.iconName }) : format.kernelIcon,
+      });
+    }
+  }
+
   // Add kernel file types to registry
   availableKernelLanguages.forEach(
     (kernelFileTypes: IFileTypeData[], kernelLanguage: string) => {
-      // Do not add python as it will be already there by default
-      if (kernelLanguage !== 'python') {
-        kernelFileTypes.map((kernelFileType) => {
-          docRegistry.addFileType({
-            name: kernelLanguage,
-            contentType: 'file',
-            displayName: trans.__(
-              kernelFileType.paletteLabel.split('New')[1].trim(),
-            ),
-            extensions: [`.${kernelFileType.fileExt}`],
-            icon: kernelFileType.kernelIcon || kernelIcon,
-          });
+      kernelFileTypes.map((kernelFileType) => {
+        docRegistry.addFileType({
+          name: kernelLanguage,
+          contentType: 'notebook',
+          pattern: `\\.${kernelFileType.fileExt}$`,
+          displayName: trans.__(
+            kernelFileType.paletteLabel.split('New')[1].trim(),
+          ),
+          extensions: [`.${kernelFileType.fileExt}`],
+          icon: kernelFileType.iconName ? LabIcon.resolve({ icon: kernelFileType.iconName }) : kernelFileType.kernelIcon,
         });
-      }
+      });
     },
   );
 
-  // Add markdown file types to registry
+  const markdownNotebookIcon = markdownIcon.bindprops({
+    boxSizing: 'border-box',
+    border: '2px solid var(--jp-notebook-icon-color)',
+    borderRadius: '2px',
+  });
+
+  // Add markdown file types to registry - these will be open with Notebook by default
   docRegistry.addFileType(
     {
       name: 'myst',
       contentType: 'notebook',
       displayName: trans.__('MyST Markdown Notebook'),
-      extensions: ['.myst', '.mystnb', '.mnb'],
-      icon: markdownIcon,
+      extensions: mystExtensions.map(ext => '.' + ext),
+      icon: markdownNotebookIcon,
     },
     ['Notebook'],
   );
@@ -49,8 +93,8 @@ export function registerFileTypes(
       contentType: 'notebook',
       displayName: trans.__('R Markdown Notebook'),
       // Extension file are transformed to lower case...
-      extensions: ['.Rmd'],
-      icon: markdownIcon,
+      extensions: rmdExtensions.map(ext => '.' + ext),
+      icon: markdownNotebookIcon,
     },
     ['Notebook'],
   );
@@ -60,8 +104,9 @@ export function registerFileTypes(
       name: 'quarto',
       contentType: 'notebook',
       displayName: trans.__('Quarto Notebook'),
-      extensions: ['.qmd'],
-      icon: markdownIcon,
+      extensions: quartoExtensions.map(ext => '.' + ext),
+      pattern: `\\.qmd$`,
+      icon: markdownNotebookIcon,
     },
     ['Notebook'],
   );

--- a/jupyterlab/packages/jupyterlab-jupytext-extension/src/utils.ts
+++ b/jupyterlab/packages/jupyterlab-jupytext-extension/src/utils.ts
@@ -59,7 +59,7 @@ function base64ToSvgStr(width: number, imageBase64: string): string {
  */
 async function getKernelIcon(
   specModel: KernelSpec.ISpecModel,
-  fileType: DocumentRegistry.IFileType | undefined
+  fileType: DocumentRegistry.IFileType | undefined,
 ): Promise<LabIcon> {
   // First check for logo-svg
   if (specModel.resources['logo-svg']) {

--- a/jupyterlab/packages/jupyterlab-jupytext-extension/src/utils.ts
+++ b/jupyterlab/packages/jupyterlab-jupytext-extension/src/utils.ts
@@ -10,7 +10,7 @@ import { LabIcon } from '@jupyterlab/ui-components';
 
 import { URLExt } from '@jupyterlab/coreutils';
 
-import { IDocumentWidget } from '@jupyterlab/docregistry';
+import { DocumentRegistry, IDocumentWidget } from '@jupyterlab/docregistry';
 
 import { CommandRegistry } from '@lumino/commands';
 
@@ -59,6 +59,7 @@ function base64ToSvgStr(width: number, imageBase64: string): string {
  */
 async function getKernelIcon(
   specModel: KernelSpec.ISpecModel,
+  fileType: DocumentRegistry.IFileType | undefined
 ): Promise<LabIcon> {
   // First check for logo-svg
   if (specModel.resources['logo-svg']) {
@@ -90,6 +91,9 @@ async function getKernelIcon(
       svgstr: base64ToSvgStr(32, iconBase64String),
     });
   }
+  if (fileType && fileType.icon) {
+    return fileType.icon;
+  }
   // If not found, make a generic kernel icon
   return LabIcon.resolve({
     icon: 'ui-components:kernel',
@@ -102,6 +106,7 @@ async function getKernelIcon(
  */
 export async function getAvailableKernelLanguages(
   languages: IEditorLanguageRegistry,
+  docRegistry: DocumentRegistry,
   serviceManager: ServiceManager.IManager,
 ): Promise<Map<string, IFileTypeData[]>> {
   const specsManager = serviceManager.kernelspecs;
@@ -120,18 +125,21 @@ export async function getAvailableKernelLanguages(
         // If we managed to find the language, construct the FileTypeData
         // Here we make an assumption that first extension in
         // languageInfo.extensions is the most common one.
+        const fileExt = languageInfo.extensions[0];
+        const fileType = docRegistry.getFileTypesForPath(`test.${fileExt}`)[0];
         if (languageInfo) {
           // We attempt to get kernelIcon here for specModel.resources
           // If none provided, we return generic kernel icon
-          const kernelIcon = await getKernelIcon(specModel);
+          const kernelIcon = await getKernelIcon(specModel, fileType);
           const displayName =
             languageInfo.displayName || specModel.display_name;
           const exts: IFileTypeData[] = [
             {
-              fileExt: languageInfo.extensions[0],
+              fileExt,
               paletteLabel: `New ${displayName} Text Notebook`,
               caption: `Create a new ${displayName} Text Notebook`,
               kernelIcon: kernelIcon,
+              iconName: fileType.iconClass,
               launcherLabel: displayName,
               kernelName: spec,
             },

--- a/jupyterlab/packages/jupyterlab-jupytext-extension/src/utils.ts
+++ b/jupyterlab/packages/jupyterlab-jupytext-extension/src/utils.ts
@@ -139,7 +139,6 @@ export async function getAvailableKernelLanguages(
               paletteLabel: `New ${displayName} Text Notebook`,
               caption: `Create a new ${displayName} Text Notebook`,
               kernelIcon: kernelIcon,
-              iconName: fileType.iconClass,
               launcherLabel: displayName,
               kernelName: spec,
             },


### PR DESCRIPTION
This fixes #398 by using higher precedence `pattern` matching to restore original icons for files which are now declared by the server's content manager as notebooks.

The file types which default to a notebook factory (`.Rmd`, `.qmd`, `.mnb` and other myst extensions) have now an orange border box indicator which makes them look more like the notebook icon. I think this is a nice idea but happy to drop it (I initially added that for debugging purposes).

| Before | After this PR |
|--|--|
| <img width="521" height="1572" alt="image" src="https://github.com/user-attachments/assets/970cca3d-1a06-4bd2-b218-c8060ceffdf3" /> | <img width="521" height="1572" alt="image" src="https://github.com/user-attachments/assets/f78a8697-725c-42a8-b92c-d3cab90641be" /> |

<details>

| After this PR | Without jupytext |
|--|--|
| <img width="521" height="1572" alt="image" src="https://github.com/user-attachments/assets/f78a8697-725c-42a8-b92c-d3cab90641be" /> | <img width="521" height="1572" alt="image" src="https://github.com/user-attachments/assets/862352da-14de-44a4-b197-f917f129a3fd" /> |

</details>