### PR TITLE
Version 1.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 Jupytext ChangeLog
 ==================
 
-1.19.1.dev0 (development)
--------------------------
+1.19.1 (2026-01-25)
+-------------------
 
 **Changed**
 - Jupytext does not change the file icons anymore! Thanks to [Michał Krassowski](https://github.com/krassowski) for finally solving this long standing issue! ([#398](https://github.com/mwouts/jupytext/issues/398))

--- a/src/jupytext/version.py
+++ b/src/jupytext/version.py
@@ -1,4 +1,4 @@
 """Jupytext's version number"""
 
 # Must match [N!]N(.N)*[{a|b|rc}N][.postN][.devN], cf. PEP 440
-__version__ = "1.19.1.dev0"
+__version__ = "1.19.1"


### PR DESCRIPTION
**Changed**
- Jupytext does not change the file icons anymore! Thanks to [Michał Krassowski](https://github.com/krassowski) for finally solving this long standing issue! ([#398](https://github.com/mwouts/jupytext/issues/398))
- We have bumped lodash from 4.17.21 to 4.17.23 in JupyterLab extension ([#1483](https://github.com/mwouts/jupytext/pull/1483))
- We require `marimo<=0.19.4` in tests following a change in the location of the `marimo` import ([#1485](https://github.com/mwouts/jupytext/issues/1485))