### PR TITLE
Add Jenner language support

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -14,6 +14,7 @@ Jupytext works with notebooks in any of the following languages:
 - Haskell
 - IDL
 - Java
+- Jenner
 - Javascript
 - Julia
 - Logtalk

--- a/src/jupytext/languages.py
+++ b/src/jupytext/languages.py
@@ -92,6 +92,11 @@ _SCRIPT_EXTENSIONS = {
         "comment": "/*",
         "comment_suffix": "*/",
     },
+    ".jenner": {
+        "language": "jenner",
+        "comment": "/*",
+        "comment_suffix": "*/",
+    },
     ".xsh": {"language": "xonsh", "comment": "#"},
     ".lgt": {"language": "logtalk", "comment": "%"},
     ".logtalk": {"language": "logtalk", "comment": "%"},

--- a/tests/data/notebooks/inputs/ipynb_jenner/jenner_test.ipynb
+++ b/tests/data/notebooks/inputs/ipynb_jenner/jenner_test.ipynb
@@ -1,0 +1,58 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Jenner Notebooks with Jupytext"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data test;\n",
+    "    x = 1;\n",
+    "    y = x * 2;\n",
+    "    output;\n",
+    "run;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "proc print data=test;\n",
+    "run;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%let name = Jupytext;\n",
+    "%put &name;"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Jenner",
+   "language": "jenner",
+   "name": "jenner"
+  },
+  "language_info": {
+   "file_extension": ".jenner",
+   "mimetype": "text/x-jenner",
+   "name": "jenner"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/data/notebooks/outputs/ipynb_to_Rmd/jenner_test.Rmd
+++ b/tests/data/notebooks/outputs/ipynb_to_Rmd/jenner_test.Rmd
@@ -1,0 +1,27 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Jenner
+    language: jenner
+    name: jenner
+---
+
+# Jenner Notebooks with Jupytext
+
+```{jenner}
+data test;
+    x = 1;
+    y = x * 2;
+    output;
+run;
+```
+
+```{jenner}
+proc print data=test;
+run;
+```
+
+```{jenner}
+/* %let name = Jupytext;
+/* %put &name;
+```

--- a/tests/data/notebooks/outputs/ipynb_to_hydrogen/jenner_test.jenner
+++ b/tests/data/notebooks/outputs/ipynb_to_hydrogen/jenner_test.jenner
@@ -1,0 +1,25 @@
+/* --- */
+/* jupyter: */
+/*   kernelspec: */
+/*     display_name: Jenner */
+/*     language: jenner */
+/*     name: jenner */
+/* --- */
+
+/* %% [markdown] */
+/* # Jenner Notebooks with Jupytext */
+
+/* %% */
+data test;
+    x = 1;
+    y = x * 2;
+    output;
+run;
+
+/* %% */
+proc print data=test;
+run;
+
+/* %% */
+%let name = Jupytext;
+%put &name;

--- a/tests/data/notebooks/outputs/ipynb_to_md/jenner_test.md
+++ b/tests/data/notebooks/outputs/ipynb_to_md/jenner_test.md
@@ -1,0 +1,27 @@
+---
+jupyter:
+  kernelspec:
+    display_name: Jenner
+    language: jenner
+    name: jenner
+---
+
+# Jenner Notebooks with Jupytext
+
+```jenner
+data test;
+    x = 1;
+    y = x * 2;
+    output;
+run;
+```
+
+```jenner
+proc print data=test;
+run;
+```
+
+```jenner
+%let name = Jupytext;
+%put &name;
+```

--- a/tests/data/notebooks/outputs/ipynb_to_myst/jenner_test.md
+++ b/tests/data/notebooks/outputs/ipynb_to_myst/jenner_test.md
@@ -1,0 +1,26 @@
+---
+kernelspec:
+  display_name: Jenner
+  language: jenner
+  name: jenner
+---
+
+# Jenner Notebooks with Jupytext
+
+```{code-cell}
+data test;
+    x = 1;
+    y = x * 2;
+    output;
+run;
+```
+
+```{code-cell}
+proc print data=test;
+run;
+```
+
+```{code-cell}
+%let name = Jupytext;
+%put &name;
+```

--- a/tests/data/notebooks/outputs/ipynb_to_percent/jenner_test.jenner
+++ b/tests/data/notebooks/outputs/ipynb_to_percent/jenner_test.jenner
@@ -1,0 +1,25 @@
+/* --- */
+/* jupyter: */
+/*   kernelspec: */
+/*     display_name: Jenner */
+/*     language: jenner */
+/*     name: jenner */
+/* --- */
+
+/* %% [markdown] */
+/* # Jenner Notebooks with Jupytext */
+
+/* %% */
+data test;
+    x = 1;
+    y = x * 2;
+    output;
+run;
+
+/* %% */
+proc print data=test;
+run;
+
+/* %% */
+/* %let name = Jupytext;
+/* %put &name;

--- a/tests/data/notebooks/outputs/ipynb_to_script/jenner_test.jenner
+++ b/tests/data/notebooks/outputs/ipynb_to_script/jenner_test.jenner
@@ -1,0 +1,21 @@
+/* --- */
+/* jupyter: */
+/*   kernelspec: */
+/*     display_name: Jenner */
+/*     language: jenner */
+/*     name: jenner */
+/* --- */
+
+/* # Jenner Notebooks with Jupytext */
+
+data test;
+    x = 1;
+    y = x * 2;
+    output;
+run;
+
+proc print data=test;
+run;
+
+/* %let name = Jupytext;
+/* %put &name;


### PR DESCRIPTION
## Summary

[Jenner](https://jenneranalytics.com) is a SAS-compatible statistical programming language with a native Jupyter kernel. It uses the same block comment syntax as SAS (`/* */`).

This PR adds Jenner as a supported language in Jupytext, following the same pattern as the existing SAS entry.

## Changes

- Added `.jenner` extension to `_SCRIPT_EXTENSIONS` in `languages.py` with `/* */` block comments
- Added sample Jenner notebook (`jenner_test.ipynb`) with DATA step, PROC, and macro examples
- Generated mirror test outputs for all formats (light, percent, hydrogen, md, myst, Rmd)
- Added Jenner to the supported languages documentation

## Testing

All 505 mirror tests pass (7 new Jenner tests + 498 existing), with 0 regressions.