### PR TITLE
Fix homepage link in `package.json`

### DIFF
--- a/jupyterlab/packages/jupyterlab-jupytext-extension/package.json
+++ b/jupyterlab/packages/jupyterlab-jupytext-extension/package.json
@@ -8,7 +8,7 @@
     "jupyterlab",
     "jupyterlab-extension"
   ],
-  "homepage": "https://github.com/mwouts/jupytext/tree/main/jupyterlab/packages/jupyterlab-jupytext",
+  "homepage": "https://github.com/mwouts/jupytext/tree/main/jupyterlab/packages/jupyterlab-jupytext-extension",
   "bugs": {
     "url": "https://github.com/mwouts/jupytext/issues"
   },


### PR DESCRIPTION
Fixes 404:

<img width="1562" height="393" alt="image" src="https://github.com/user-attachments/assets/95d0625b-c89b-4b1a-8efb-2793514e5bc5" />

Coming from https://github.com/jupyterlab/plugin-playground/pull/112