### PR TITLE
Skip the `jupyter-fs` tests on Python 3.12+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Jupytext ChangeLog
 ==================
 
+1.19.2.dev0 (unreleased)
+------------------------
+
+**Changed**
+- We have skipped the tests that involve `jupyterfs` on Python 3.12+ as they started failing on the CI with no obvious way to fix them ([#1509](https://github.com/mwouts/jupytext/issues/1509))
+
+
 1.19.1 (2026-01-25)
 -------------------
 

--- a/src/jupytext/version.py
+++ b/src/jupytext/version.py
@@ -1,4 +1,4 @@
 """Jupytext's version number"""
 
 # Must match [N!]N(.N)*[{a|b|rc}N][.postN][.devN], cf. PEP 440
-__version__ = "1.19.1"
+__version__ = "1.19.2.dev0"

--- a/tests/external/jupyter_fs/test_jupyter_fs.py
+++ b/tests/external/jupyter_fs/test_jupyter_fs.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 
 import pytest
 from jupyter_server.utils import ensure_async
@@ -6,6 +7,8 @@ from nbformat.v4.nbbase import new_code_cell, new_markdown_cell, new_notebook
 
 import jupytext
 from jupytext.compare import compare_cells, notebook_model
+
+pytestmark = pytest.mark.skipif(sys.version_info >= (3, 12), reason="https://github.com/mwouts/jupytext/issues/1509")
 
 
 @pytest.fixture(params=["sync", "async"])


### PR DESCRIPTION
For now I don't see how to fix #1509 so I will just skip these tests to restore the CI.