### PR TITLE
Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,19 +20,17 @@ updates:
   #         - "*"
 
   - package-ecosystem: "npm" # See documentation for possible values
-    directory: "jupyterlab/packages/jupyterlab-jupytext-extension" # Location of package manifests
+    directories: # Location of package manifests
+      - "jupyterlab/packages/jupyterlab-jupytext-extension"
+      - "jupyterlab/packages/jupyterlab-jupytext-extension/ui-tests"
     schedule:
       interval: "weekly"
     groups:
       jupytext-extension-dependencies:
+        applies-to: "version-updates"
         patterns:
           - "*"
-
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "jupyterlab/packages/jupyterlab-jupytext-extension/ui-tests" # Location of package manifests
-    schedule:
-      interval: "weekly"
-    groups:
-      jupytext-extension-ui-tests-dependencies:
+      jupytext-extension-security-updates:
+        applies-to: "security-updates"
         patterns:
           - "*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Jupytext ChangeLog
 
 **Changed**
 - We have skipped the tests that involve `jupyterfs` on Python 3.12+ as they started failing on the CI with no obvious way to fix them ([#1509](https://github.com/mwouts/jupytext/issues/1509))
+- We have changed the configuration of Dependabot to get grouped dependency updates for our JupyterLab extension.
+
+
+**Fixed**
+- We have fixed the homepage link in `package.json`. Thanks to [Michał Krassowski](https://github.com/krassowski) for making this PR ([#1494](https://github.com/mwouts/jupytext/pull/1494))
 
 
 1.19.1 (2026-01-25)


### PR DESCRIPTION
The point of this PR is to get grouped updates for the JupyterLab extension dependencies