### PR TITLE
`jupytext --sync` preserves trusted notebooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ Jupytext ChangeLog
 
 
 **Fixed**
+- Trusted notebooks remain trusted after `jupytext --sync` ([#1505](https://github.com/mwouts/jupytext/issues/1505))
 - We have fixed the homepage link in `package.json`. Thanks to [Michał Krassowski](https://github.com/krassowski) for making this PR ([#1494](https://github.com/mwouts/jupytext/pull/1494))
+- Thanks to [Brigitta Sipőcz](https://github.com/bsipocz) for fixing a broken link in our CLI ([#1428](https://github.com/mwouts/jupytext/pull/1428))
 
 
 1.19.1 (2026-01-25)

--- a/src/jupytext/__main__.py
+++ b/src/jupytext/__main__.py
@@ -7,7 +7,9 @@ Call with (e.g.)::
 
 import sys
 
+from nbformat.sign import NotebookNotary
+
 from .cli import jupytext
 
 if __name__ == "__main__":
-    sys.exit(jupytext())
+    sys.exit(jupytext(notary=NotebookNotary()))

--- a/src/jupytext/async_contentsmanager.py
+++ b/src/jupytext/async_contentsmanager.py
@@ -232,12 +232,6 @@ def build_async_jupytext_contents_manager_class(base_contents_manager_class):
                     model["mimetype"] = None
                     try:
                         model["content"] = reads(model["content"], fmt=fmt, config=config)
-                        # mark all code cells from text notebooks as 'trusted'
-                        # as they don't have any outputs, cf. #941
-                        for cell in model["content"].cells:
-                            if cell.cell_type == "code":
-                                cell["metadata"]["trusted"] = True
-
                     except Exception as err:
                         self.log.error("Error while reading file: %s %s", path, err, exc_info=True)
                         raise HTTPError(500, str(err))

--- a/src/jupytext/cli.py
+++ b/src/jupytext/cli.py
@@ -13,6 +13,8 @@ from copy import copy
 from tempfile import NamedTemporaryFile
 from typing import Optional
 
+from nbformat.sign import NotebookNotary
+
 from .combine import combine_inputs_with_outputs
 from .compare import NotebookDifference, compare, test_round_trip_conversion
 from .config import load_jupytext_config, notebook_formats
@@ -339,9 +341,11 @@ def parse_jupytext_args(args=None):
     return parser.parse_args(args)
 
 
-def jupytext(args=None):
+def jupytext(args=None, *, notary=None):
     """Entry point for the jupytext script"""
     args = parse_jupytext_args(args)
+    if notary is None:
+        notary = NotebookNotary()
 
     def log(text):
         if not args.quiet:
@@ -489,17 +493,17 @@ def jupytext(args=None):
     exit_code = 0
     for nb_file in notebooks:
         if not args.warn_only:
-            exit_code += jupytext_single_file(nb_file, args, log)
+            exit_code += jupytext_single_file(nb_file, args, log, notary=notary)
         else:
             try:
-                exit_code += jupytext_single_file(nb_file, args, log)
+                exit_code += jupytext_single_file(nb_file, args, log, notary=notary)
             except Exception as err:
                 sys.stderr.write(f"[jupytext] Error: {str(err)}\n")
 
     return exit_code
 
 
-def jupytext_single_file(nb_file, args, log):
+def jupytext_single_file(nb_file, args, log, notary):
     """Apply the jupytext command, with given arguments, to a single file"""
     if nb_file == "-" and args.sync:
         msg = "Missing notebook path."
@@ -530,6 +534,20 @@ def jupytext_single_file(nb_file, args, log):
 
     config = load_jupytext_config(os.path.abspath(nb_file))
 
+    def _read(path, fmt=None):
+        """Read a notebook; mark cells trusted when the signature is valid."""
+        nb = read(path, fmt=fmt, config=config)
+        if notary.check_signature(nb):
+            notary.mark_cells(nb, True)
+        return nb
+
+    def _writes(nb, fmt):
+        """Serialize a notebook; sign the result when every cell is trusted."""
+        content = writes(nb, fmt=fmt, config=config)
+        if len(nb.cells) and all(cell.get("metadata", {}).get("trusted", False) for cell in nb.cells):
+            notary.sign(reads(content, fmt=fmt, config=config))
+        return content
+
     # Just acting on metadata / pipe => save in place
     save_in_place = not nb_dest and not args.sync
     if save_in_place:
@@ -555,7 +573,8 @@ def jupytext_single_file(nb_file, args, log):
 
     timestamp_checker = TimestampChecker(pre_commit_mode=args.pre_commit_mode)
     timestamp_checker.get_and_check_timestamp(nb_file)
-    notebook = read(nb_file, fmt=fmt, config=config)
+    notebook = _read(nb_file, fmt=fmt)
+
     if "extension" in fmt and "format_name" not in fmt:
         text_representation = notebook.metadata.get("jupytext", {}).get("text_representation", {})
         if text_representation.get("extension") == fmt["extension"]:
@@ -600,6 +619,7 @@ def jupytext_single_file(nb_file, args, log):
 
     # Read paired notebooks
     nb_files = [nb_file, nb_dest]
+    outputs_nb_file = None
     if args.sync:
         # If we are also setting the formats, we take the information
         # from the --set-formats option
@@ -608,9 +628,18 @@ def jupytext_single_file(nb_file, args, log):
         else:
             formats = notebook_formats(notebook, config, nb_file, fallback_on_current_fmt=False)
         set_prefix_and_suffix(fmt, formats, nb_file)
+
         try:
             notebook, inputs_nb_file, outputs_nb_file = load_paired_notebook(
-                notebook, fmt, config, formats, nb_file, log, args.pre_commit_mode, timestamp_checker
+                notebook,
+                fmt,
+                config,
+                formats,
+                nb_file,
+                log,
+                args.pre_commit_mode,
+                timestamp_checker,
+                read_func=_read,
             )
             nb_files = [inputs_nb_file, outputs_nb_file]
         except NotAPairedNotebook as err:
@@ -796,7 +825,7 @@ def jupytext_single_file(nb_file, args, log):
             _, ext = os.path.splitext(path)
             fmt = copy(fmt or {})
             fmt = long_form_one_format(fmt, update={"extension": ext})
-            new_content = writes(notebook, fmt=fmt, config=config)
+            new_content = _writes(notebook, fmt=fmt)
             diff = None
             if not new_content.endswith("\n"):
                 new_content += "\n"
@@ -1158,7 +1187,15 @@ _callback_on_lazy_write = None
 
 
 def load_paired_notebook(
-    notebook, fmt, config, formats, nb_file, log, pre_commit_mode: bool, timestamp_checker: TimestampChecker
+    notebook,
+    fmt,
+    config,
+    formats,
+    nb_file,
+    log,
+    pre_commit_mode: bool,
+    timestamp_checker: TimestampChecker,
+    read_func,
 ):
     """Update the notebook with the inputs and outputs of the most recent paired files"""
     if not formats:
@@ -1174,7 +1211,7 @@ def load_paired_notebook(
 
         log(f"[jupytext] Loading {shlex.quote(path)}")
         timestamp_checker.get_and_check_timestamp(path)
-        return read(path, fmt=fmt, config=config)
+        return read_func(path, fmt=fmt)
 
     if pre_commit_mode and file_in_git_index(nb_file):
         # We raise an error if two representations of this notebook in the git index are inconsistent

--- a/src/jupytext/cli.py
+++ b/src/jupytext/cli.py
@@ -344,8 +344,6 @@ def parse_jupytext_args(args=None):
 def jupytext(args=None, *, notary=None):
     """Entry point for the jupytext script"""
     args = parse_jupytext_args(args)
-    if notary is None:
-        notary = NotebookNotary()
 
     def log(text):
         if not args.quiet:
@@ -370,6 +368,17 @@ def jupytext(args=None, *, notary=None):
         for nb_file in args.notebooks:
             log(nb_file)
 
+    # Only wrap and manage notary lifetime if we create it here
+    if notary is None:
+        notary = NotebookNotary()
+
+        def close_notary_store_if_managed():
+            notary.store.close()
+    else:
+
+        def close_notary_store_if_managed():
+            pass
+
     # Read notebook from stdin
     if not args.notebooks:
         if not args.pre_commit:
@@ -384,6 +393,7 @@ def jupytext(args=None, *, notary=None):
         if len(args.notebooks) != 1:
             raise ValueError("--paired-paths applies to a single notebook")
         print_paired_paths(args.notebooks[0], args.input_format)
+        close_notary_store_if_managed()
         return 1
 
     if args.run_path:
@@ -449,6 +459,7 @@ def jupytext(args=None, *, notary=None):
         )
         sys.stdout.write(diff)
 
+        close_notary_store_if_managed()
         return
 
     if args.output and len(args.notebooks) != 1:
@@ -500,6 +511,7 @@ def jupytext(args=None, *, notary=None):
             except Exception as err:
                 sys.stderr.write(f"[jupytext] Error: {str(err)}\n")
 
+    close_notary_store_if_managed()
     return exit_code
 
 

--- a/src/jupytext/sync_contentsmanager.py
+++ b/src/jupytext/sync_contentsmanager.py
@@ -262,12 +262,6 @@ def build_sync_jupytext_contents_manager_class(base_contents_manager_class):
                         model["content"] = reads(
                             model["content"], fmt=fmt, config=config
                         )
-                        # mark all code cells from text notebooks as 'trusted'
-                        # as they don't have any outputs, cf. #941
-                        for cell in model["content"].cells:
-                            if cell.cell_type == "code":
-                                cell["metadata"]["trusted"] = True
-
                     except Exception as err:
                         self.log.error(
                             "Error while reading file: %s %s", path, err, exc_info=True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,10 +52,13 @@ def force_validate_nbformat(monkeypatch):
 
 @pytest.fixture
 def fresh_notary(tmp_path):
-    return NotebookNotary(
+    notary = NotebookNotary(
         db_file=":memory:",
         secret=b"test-secret",
     )
+    yield notary
+    # Close the SQLite database connection to avoid ResourceWarnings on Python 3.13+
+    notary.store.close()
 
 
 @pytest.fixture(params=["sync", "async"])
@@ -70,7 +73,11 @@ def cm(request, fresh_notary):
     # notebooks is not shared between tests
     cm.notary = fresh_notary
 
-    return cm
+    yield cm
+    # Clean up any resources in the contents manager
+    with contextlib.suppress(Exception):
+        if hasattr(cm, "close"):
+            cm.close()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,8 @@ from nbformat.v4.nbbase import (
     new_notebook,
     new_output,
 )
+from nbformat.sign import NotebookNotary
+
 
 import jupytext
 from jupytext.cell_reader import rst2md
@@ -48,12 +50,27 @@ def force_validate_nbformat(monkeypatch):
     monkeypatch.setattr(nbformat, "reads", nbformat_reads)
 
 
+@pytest.fixture
+def fresh_notary(tmp_path):
+    return NotebookNotary(
+        db_file=":memory:",
+        secret=b"test-secret",
+    )
+
+
 @pytest.fixture(params=["sync", "async"])
-def cm(request):
+def cm(request, fresh_notary):
     if request.param == "sync":
-        return jupytext.TextFileContentsManager()
+        cm = jupytext.TextFileContentsManager()
     else:
-        return jupytext.AsyncTextFileContentsManager()
+        cm = jupytext.AsyncTextFileContentsManager()
+
+    # We use a fresh notary for each test,
+    # to make sure that the trust status of
+    # notebooks is not shared between tests
+    cm.notary = fresh_notary
+
+    return cm
 
 
 @pytest.fixture

--- a/tests/functional/others/test_trust_notebook.py
+++ b/tests/functional/others/test_trust_notebook.py
@@ -1,16 +1,22 @@
+"""
+A notebook is trusted when all its outputs are trusted. Hence, a trusted notebook that is
+updated using Jupytext should remain trusted, as no new outputs are added.
+"""
+
 import os
 import shutil
 
 import pytest
 from jupyter_server.utils import ensure_async
-from nbformat.v4.nbbase import new_code_cell, new_output
-
+from nbformat.v4.nbbase import new_code_cell, new_notebook, new_output
+from jupytext.cli import jupytext as jupytext_cli
 from jupytext.compare import compare_notebooks
 
 pytestmark = pytest.mark.asyncio
 
 
 async def test_py_notebooks_are_trusted(python_file, cm):
+    """Text notebooks don't have outputs, so they are trusted"""
     root, file = os.path.split(python_file)
     cm.root_dir = root
     nb = await ensure_async(cm.get(file))
@@ -19,6 +25,7 @@ async def test_py_notebooks_are_trusted(python_file, cm):
 
 
 async def test_rmd_notebooks_are_trusted(rmd_file, cm):
+    """Text notebooks don't have outputs, so they are trusted"""
     root, file = os.path.split(rmd_file)
     cm.root_dir = root
     nb = await ensure_async(cm.get(file))
@@ -26,7 +33,22 @@ async def test_rmd_notebooks_are_trusted(rmd_file, cm):
         assert cell.metadata.get("trusted", True)
 
 
-@pytest.mark.skip(reason="Fails intermittently on CI, see #1346")
+def cell_just_has_safe_outputs(cell):
+    if cell.cell_type != "code":
+        return True
+    for output in cell.get("outputs", []):
+        if output.output_type == "stream":
+            continue
+        if output.output_type == "error":
+            continue
+        if output.output_type == "display_data":
+            return False
+        if output.output_type == "execute_result":
+            return False
+        return False
+    return True
+
+
 async def test_ipynb_notebooks_can_be_trusted(ipynb_py_file, tmpdir, no_jupytext_version_number, cm):
     if "hash sign" in ipynb_py_file:
         pytest.skip()
@@ -41,16 +63,12 @@ async def test_ipynb_notebooks_can_be_trusted(ipynb_py_file, tmpdir, no_jupytext
     model = await ensure_async(cm.get(file))
     await ensure_async(cm.save(model, py_file))
 
-    # Unsign and test notebook
-    nb = model["content"]
-    for cell in nb.cells:
-        cell.metadata.pop("trusted", True)
-
-    cm.notary.unsign(nb)
-
+    # Make sure notebook is NOT trusted to start with
     model = await ensure_async(cm.get(file))
     for cell in model["content"].cells:
-        assert "trusted" not in cell.metadata or not cell.metadata["trusted"] or not cell.outputs
+        if cell_just_has_safe_outputs(cell):
+            continue
+        assert "trusted" not in cell.metadata or not cell.metadata["trusted"]
 
     # Trust and reload
     await ensure_async(cm.trust_notebook(py_file))
@@ -71,7 +89,6 @@ async def test_ipynb_notebooks_can_be_trusted(ipynb_py_file, tmpdir, no_jupytext
     await ensure_async(cm.trust_notebook(file))
 
 
-@pytest.mark.skip(reason="Fails intermittently on CI, see #1346")
 async def test_ipynb_notebooks_can_be_trusted_even_with_metadata_filter(ipynb_py_file, tmpdir, no_jupytext_version_number, cm):
     if "hash sign" in ipynb_py_file:
         pytest.skip()
@@ -88,12 +105,12 @@ async def test_ipynb_notebooks_can_be_trusted_even_with_metadata_filter(ipynb_py
     model = await ensure_async(cm.get(file))
     await ensure_async(cm.save(model, py_file))
 
-    # Unsign notebook
-    nb = model["content"]
-    for cell in nb.cells:
-        cell.metadata.pop("trusted", True)
-
-    cm.notary.unsign(nb)
+    # Make sure notebook is NOT trusted to start with
+    model = await ensure_async(cm.get(file))
+    for cell in model["content"].cells:
+        if cell_just_has_safe_outputs(cell):
+            continue
+        assert "trusted" not in cell.metadata or not cell.metadata["trusted"]
 
     # Trust and reload
     await ensure_async(cm.trust_notebook(py_file))
@@ -136,9 +153,6 @@ async def test_text_notebooks_can_be_trusted(percent_file, tmpdir, no_jupytext_v
         assert cell.metadata.get("trusted", True)
 
 
-# This test started failing on Windows on 2025-04-26
-# https://github.com/mwouts/jupytext/actions/runs/14683344298/job/41208822220?pr=1380
-@pytest.mark.skip_on_windows
 async def test_simple_notebook_is_trusted(tmpdir, python_notebook, cm):
     cm.root_dir = str(tmpdir)
 
@@ -194,6 +208,87 @@ init_notebook_mode(all_interactive=True)
 
     # All cells are trusted in this notebook
     assert cm.notary.check_cells(nb)
+
+
+@pytest.mark.parametrize("nb_was_originally_trusted", [True, False])
+async def test_notebook_remains_trusted_after_jupytext_sync(tmp_path, cm, nb_was_originally_trusted):
+    """
+    A trusted notebook should remain trusted after a jupytext --sync edit,
+    e.g. through the jupytext-sync extension in VS Code (#1505)
+    """
+    # Write a jupytext.toml that pairs every ipynb to py:percent (global config, no per-notebook metadata needed)
+    (tmp_path / "jupytext.toml").write_text('formats = "ipynb,py:percent"\n')
+
+    cm.root_dir = str(tmp_path)
+
+    # Build an ipynb with a code cell that has a rich output that is not
+    # automatically considered safe by Jupyter's trust model.
+    nb = new_notebook(
+        cells=[
+            new_code_cell(
+                source="HTML('<b>hello</b>')",
+                outputs=[
+                    new_output(
+                        output_type="display_data",
+                        data={"text/html": "<b>hello</b>"},
+                        metadata={},
+                    )
+                ],
+            )
+        ],
+        metadata={
+            "kernelspec": {
+                "display_name": "Python 3",
+                "language": "python",
+                "name": "python3",
+            }
+        },
+    )
+
+    # Sign the notebook
+    nb.cells[0].metadata["trusted"] = nb_was_originally_trusted
+
+    # Save via the CM – this also creates the paired .py file
+    await ensure_async(cm.save(dict(type="notebook", content=nb), "test.ipynb"))
+
+    # Check that the notebook is indeed trusted at this stage
+    nb = (await ensure_async(cm.get("test.ipynb")))["content"]
+    for cell in nb.cells:
+        assert cell.metadata.get("trusted", True) is nb_was_originally_trusted, (
+            f"Cell should have trusted={nb_was_originally_trusted} after initial save"
+        )
+
+    # Simulate an LLM editing the paired .py file directly on disk
+    py_file = tmp_path / "test.py"
+    original_text = py_file.read_text()
+    modified_text = original_text.replace("HTML('<b>hello</b>')", "HTML('<b>hello, world!</b>')")
+    py_file.write_text(modified_text)
+
+    # Reload the ipynb: the py file is now newer, so its content is used.
+    # The .ipynb still holds the original trusted outputs, so the combined
+    # notebook should remain trusted.
+    nb = (await ensure_async(cm.get("test.ipynb")))["content"]
+    assert nb.cells[0].metadata["trusted"] is nb_was_originally_trusted, (
+        f"Cell should keep trusted={nb_was_originally_trusted} after paired .py file is edited"
+    )
+
+    # We save the notebook with the CM
+    await ensure_async(cm.save(dict(type="notebook", content=nb), "test.ipynb"))
+
+    # We modify the notebook again
+    modified_text = original_text.replace("HTML('<b>hello</b>')", "HTML('<b>hello again, world!</b>')")
+    py_file.write_text(modified_text)
+
+    # And this time we run 'jupytext --sync test.ipynb' to update the .ipynb
+    ipynb_file = tmp_path / "test.ipynb"
+    jupytext_cli(["--sync", str(ipynb_file)], notary=cm.notary)
+
+    # And check that the updated notebook is still trusted
+    nb = (await ensure_async(cm.get("test.ipynb")))["content"]
+    print(nb)
+    assert nb.cells[0].metadata["trusted"] is nb_was_originally_trusted, (
+        f"Cell should keep trusted={nb_was_originally_trusted} after jupytext sync"
+    )
 
 
 @pytest.mark.requires_myst


### PR DESCRIPTION
In this PR we make sure the contents manager used in tests has a fresh notary (=database for signed notebooks).

Also, `jupytext --sync` will now use the notary and sign notebooks when they have safe outputs.

Closes #1505 