### PR TITLE
Run all the tests and build steps once the coverage tests have passed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,35 +30,33 @@ jobs:
     uses: ./.github/workflows/step_pre-commit.yml
 
   static-analysis:
-    needs: [ pre-commit ]
     uses: ./.github/workflows/step_static-analysis.yml
     permissions:
       contents: read
       security-events: write
 
+  coverage:
+    uses: ./.github/workflows/step_coverage.yml
+    if: github.event_name != 'schedule'
+
   test-pip:
-    needs: [ pre-commit ]
+    needs: [ coverage ]
     uses: ./.github/workflows/step_tests-pip.yml
     with:
       coverage: ${{ github.event_name != 'schedule' }}
 
-  coverage:
-    needs: [ test-pip ]
-    uses: ./.github/workflows/step_coverage.yml
-    if: github.event_name != 'schedule'
-
   test-conda:
-    needs: [ pre-commit ]
+    needs: [ coverage ]
     uses: ./.github/workflows/step_tests-conda.yml
     with:
       coverage: ${{ github.event_name != 'schedule' }}
 
   test-ui:
-    needs: [ test-pip ]
+    needs: [ coverage ]
     uses: ./.github/workflows/step_tests-ui.yml
 
   build:
-    needs: [ test-pip, test-conda, test-ui ]
+    needs: [ coverage ]
     uses: ./.github/workflows/step_build.yml
     with:
       upload: ${{ inputs.upload-build-artifacts || false }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Jupytext ChangeLog
 **Changed**
 - We have skipped the tests that involve `jupyterfs` on Python 3.12+ as they started failing on the CI with no obvious way to fix them ([#1509](https://github.com/mwouts/jupytext/issues/1509))
 - We have changed the configuration of Dependabot to get grouped dependency updates for our JupyterLab extension.
+- The CI workflow has been restructured to maximize parallelization. All test suites (pip, conda, UI) and the build step now run concurrently after pre-commit checks, instead of sequentially, reducing CI times ([#1527](https://github.com/mwouts/jupytext/pull/1527))
 
 
 **Fixed**


### PR DESCRIPTION
The coverage tests are pretty fast (two minutes), so I'd like to launch the full suite as soon as these have passed.