### PR TITLE
chore: Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,9 @@
 version: 2
 updates:
   - package-ecosystem: "npm" # See documentation for possible values
-    directory: "jupyterlab" # Location of package manifests
+    directories: # Location of package manifests
+      - "jupyterlab"
+      - "jupyterlab/packages/jupyterlab-jupytext-extension"
     schedule:
       interval: "weekly"
     # Ignore devDependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,26 +5,13 @@
 
 version: 2
 updates:
-  # Let's not bother about bumping top level dependencies as they are mostly
-  # developmental packages like linters. We can bump them manually
-  # when we make changes to extension packages to be consistent with JupyterLab.
-  # Importantly, these packages will not and should not effect the working of the
-  # extension, so lets try to keep maintenance low by ignoring this.
-  # - package-ecosystem: "npm" # See documentation for possible values
-  #   directory: "jupyterlab" # Location of package manifests
-  #   schedule:
-  #     interval: "weekly"
-  #   groups:
-  #     top-level-dependencies:
-  #       patterns:
-  #         - "*"
-
   - package-ecosystem: "npm" # See documentation for possible values
-    directories: # Location of package manifests
-      - "jupyterlab/packages/jupyterlab-jupytext-extension"
-      - "jupyterlab/packages/jupyterlab-jupytext-extension/ui-tests"
+    directory: "jupyterlab" # Location of package manifests
     schedule:
       interval: "weekly"
+    # Ignore devDependencies
+    allow:
+      - dependency-type: "production"
     groups:
       jupytext-extension-dependencies:
         applies-to: "version-updates"


### PR DESCRIPTION
This PR updates the dependabot config so that extension packages are bumped correctly. We ignored the top level dependencies to avoid opening PRs on dev dependencies (which are less critical). However, we have one global `yarn.lock` file in `/jupyterlab` folder and where all packages are listed. By ignoring this folder, we are effectively turned off the version bumping of all packages in the extension.

The new config enable the top level directory in dependabot and attempts to allow only production updates and ignore dev dependencies.
