### PR TITLE
ci: restrict update-playwright-snapshots to repo members only (GHSA-m22c-4q2m-m5wr)

### DIFF
--- a/.github/workflows/update-playwright-snapshots.yml
+++ b/.github/workflows/update-playwright-snapshots.yml
@@ -10,7 +10,10 @@ permissions:
 
 jobs:
   update-snapshots:
-    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, 'update playwright snapshots') }}
+    if: >-
+      ${{ github.event.issue.pull_request &&
+      contains(github.event.comment.body, 'update playwright snapshots') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) }}
     runs-on: ubuntu-latest
 
     steps:
@@ -22,6 +25,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Checkout the branch from the PR that triggered the job
         run: |


### PR DESCRIPTION
## Security Fix — GHSA-m22c-4q2m-m5wr

Fixes the critical vulnerability reported in the security advisory: **Unauthenticated arbitrary code execution via a single PR comment**.

### Root Cause

`update-playwright-snapshots.yml` triggered on `issue_comment` with `contents:write` permissions, but only checked that the comment body contained "update playwright snapshots" — no identity verification. Any unauthenticated user could trigger it from a fork PR, causing attacker-controlled build hooks to execute with access to the `GITHUB_TOKEN`.

### Changes

1. **Author association check** — the workflow now only runs when the commenter is an `OWNER`, `MEMBER`, or `COLLABORATOR`. This is the primary fix.

2. **`persist-credentials: false`** on the initial checkout — prevents the `GITHUB_TOKEN` from being stored in `.git/config` where it could be read by attacker-controlled build hooks. This is defense-in-depth.

The `gh pr checkout` step already correctly passes the token via `env: GITHUB_TOKEN`, so it continues to work without persisted credentials.