### PR TITLE
fix: Support unicode characters while dumping YAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Jupytext ChangeLog
 1.19.4.dev0 (wip)
 -----------------
 
+**Fixed**
+- fix: Support unicode characters while dumping YAML ([#1542](https://github.com/mwouts/jupytext/pull/1542))
+
 **Changed**
 - Jupytext's documentation is now at https://jupytext.org! ([#1538](https://github.com/mwouts/jupytext/pull/1538))
 

--- a/src/jupytext/myst.py
+++ b/src/jupytext/myst.py
@@ -43,7 +43,7 @@ def raise_if_myst_is_not_available():
 
 def myst_version():
     """The version of myst."""
-    return 0.13
+    return "0.13"
 
 
 def myst_extensions(no_md=False):
@@ -158,7 +158,8 @@ def dump_yaml_blocks(data, compact=True):
         tags: [hide-output, show-input]
         ---
     """
-    string = yaml.dump(data, Dumper=CompactDumper, sort_keys=False)
+    # Allow unicode characters for taking accents into account
+    string = yaml.dump(data, Dumper=CompactDumper, sort_keys=False, allow_unicode=True)
     lines = string.splitlines()
     if compact and all(line and line[0].isalpha() for line in lines):
         return "\n".join([f":{line}" for line in lines]) + "\n\n"

--- a/src/jupytext/myst.py
+++ b/src/jupytext/myst.py
@@ -43,7 +43,7 @@ def raise_if_myst_is_not_available():
 
 def myst_version():
     """The version of myst."""
-    return "0.13"
+    return 0.13
 
 
 def myst_extensions(no_md=False):

--- a/tests/functional/round_trip/test_myst_header.py
+++ b/tests/functional/round_trip/test_myst_header.py
@@ -17,7 +17,7 @@ jupytext:
   text_representation:
     extension: .md
     format_name: myst
-    format_version: 0.13
+    format_version: '0.13'
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
@@ -45,7 +45,7 @@ jupytext:
   text_representation:
     extension: .md
     format_name: myst
-    format_version: 0.13
+    format_version: '0.13'
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python

--- a/tests/functional/round_trip/test_myst_header.py
+++ b/tests/functional/round_trip/test_myst_header.py
@@ -124,7 +124,7 @@ jupytext:
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
-  name: àèìòùÀÈÌÒÙáéíóúýÁÉÍÓÚÝâêîôûÂÊÎÔÛãñõÃÑÕäëïöüÿÄËÏÖÜŸçÇßØøÅåÆæœ
+  name: àèìòùÀÈÌÒÙáéíóúýÁÉÍÓÚÝâêîôûÂÊÎÔÛãñõÃÑÕäëïöüÿÄËÏÖÜŸőűŐŰçÇßØøÅåÆæœ
 mystnb:
   execution_mode: 'off'
 settings:

--- a/tests/functional/round_trip/test_myst_header.py
+++ b/tests/functional/round_trip/test_myst_header.py
@@ -17,7 +17,7 @@ jupytext:
   text_representation:
     extension: .md
     format_name: myst
-    format_version: '0.13'
+    format_version: 0.13
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
@@ -45,7 +45,7 @@ jupytext:
   text_representation:
     extension: .md
     format_name: myst
-    format_version: '0.13'
+    format_version: 0.13
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
@@ -109,3 +109,30 @@ def test_myst_frontmatter_metadata_combo(no_jupytext_version_number):
     actual_md = writes(actual_nb, fmt="md:myst", config=config)
     expected_md = md
     compare(actual_md, expected_md)
+
+
+@pytest.mark.requires_myst
+def test_myst_metadata_support_unicode_characters(
+    md="""---
+jupytext:
+  formats: md:myst
+  notebook_metadata_filter: -jupytext.text_representation.jupytext_version,settings,mystnb
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: àèìòùÀÈÌÒÙáéíóúýÁÉÍÓÚÝâêîôûÂÊÎÔÛãñõÃÑÕäëïöüÿÄËÏÖÜŸçÇßØøÅåÆæœ
+mystnb:
+  execution_mode: 'off'
+settings:
+  output_matplotlib_strings: remove
+---
+""",
+):
+    nb = reads(md, fmt="md")
+    md2 = writes(nb, fmt="md")
+
+    compare(md2, md)

--- a/tests/integration/contents_manager/test_contentsmanager.py
+++ b/tests/integration/contents_manager/test_contentsmanager.py
@@ -1914,7 +1914,7 @@ jupytext:
   text_representation:
     extension: .md
     format_name: myst
-    format_version: '0.13'
+    format_version: 0.13
 kernelspec:
   display_name: itables
   language: python
@@ -1951,7 +1951,7 @@ jupytext:
   text_representation:
     extension: .md
     format_name: myst
-    format_version: '0.13'
+    format_version: 0.13
 kernelspec:
   display_name: itables
   language: python

--- a/tests/integration/contents_manager/test_contentsmanager.py
+++ b/tests/integration/contents_manager/test_contentsmanager.py
@@ -1914,7 +1914,7 @@ jupytext:
   text_representation:
     extension: .md
     format_name: myst
-    format_version: 0.13
+    format_version: '0.13'
 kernelspec:
   display_name: itables
   language: python
@@ -1951,7 +1951,7 @@ jupytext:
   text_representation:
     extension: .md
     format_name: myst
-    format_version: 0.13
+    format_version: '0.13'
 kernelspec:
   display_name: itables
   language: python


### PR DESCRIPTION
* Return myst version as string to be consistent with other versions

#myst-education-2026