### PR TITLE
Fix: use comment-tag to update the existing PR comment

### DIFF
--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -29,4 +29,4 @@ jobs:
             HATCH_BUILD_HOOKS_ENABLE=true pip install git+${{ github.event.pull_request.head.repo.clone_url }}@${{ github.event.pull_request.head.ref }}
             ```
             (this requires `nodejs`, see more at [Developing Jupytext](https://jupytext.org/reference/developing/))
-          comment_tag: binder_link
+          comment-tag: binder_link


### PR DESCRIPTION
This should fix the recent bug that we are seeing on the PR comment (the comment is repeated on each update).

According to the action's README at https://github.com/thollander/actions-comment-pull-request, the correct parameter name is `comment-tag`. 

Possibly the parameter name changed between v2 and v3 (we upgraded recently: https://github.com/mwouts/jupytext/commit/bfa81694956ddbe9bcdb1d8c1be619cec3d969a8)