### PR TITLE
reuse secure temp files in marimo_py_to_notebook

### DIFF
--- a/src/jupytext/marimo.py
+++ b/src/jupytext/marimo.py
@@ -50,12 +50,15 @@ def marimo_py_to_notebook(text):
     raise_if_marimo_is_not_available()
 
     # On Windows, NamedTemporaryFile cannot be reopened with open,
-    # so we keep the file names and close the files
-    tmp_py_file = tempfile.NamedTemporaryFile(suffix=".py")
+    # so we keep the file names and close the files. We pass delete=False
+    # so the files created with 0600 permissions are reused on reopen,
+    # instead of being deleted and recreated through a name that an
+    # attacker could point at another file in the meantime.
+    tmp_py_file = tempfile.NamedTemporaryFile(suffix=".py", delete=False)
     tmp_py_file_name = tmp_py_file.name
     tmp_py_file.close()
 
-    tmp_ipynb_file = tempfile.NamedTemporaryFile(suffix=".ipynb")
+    tmp_ipynb_file = tempfile.NamedTemporaryFile(suffix=".ipynb", delete=False)
     tmp_ipynb_file_name = tmp_ipynb_file.name
     tmp_ipynb_file.close()
 


### PR DESCRIPTION
`marimo_py_to_notebook` creates its two temp files with the default `delete=True`, closes them (which removes the files), then writes the script back by name with `open(tmp_py_file_name, "w")`. Once the originals are gone the reopen recreates the file under the process umask, so the notebook source lands at 0644 instead of the 0600 `NamedTemporaryFile` gives, and the open follows a symlink left at the freed name. On a shared machine that exposes the source and leaves a window to redirect the write.

Pass `delete=False` so the 0600 file from `mkstemp` is reused on reopen, matching what `notebook_to_marimo_py` already does. The explicit `os.remove` calls at the end still clean both files up.