### PR TITLE
Harden the github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,8 @@ updates:
         applies-to: "security-updates"
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions" # See documentation for possible values
     directory: "/" # Workflow files stored in the default location of `.github/workflows`
@@ -33,3 +35,5 @@ updates:
       actions-dependencies:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     needs: [ pre-commit, static-analysis, test-pip, coverage, test-conda, test-ui, build ]
     runs-on: ubuntu-latest
     steps:
-      - uses: re-actors/alls-green@release/v1
+      - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
           allowed-skips: coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  zizmor:
+    uses: ./.github/workflows/step_zizmor.yml
+
   pre-commit:
     uses: ./.github/workflows/step_pre-commit.yml
 
@@ -58,7 +61,7 @@ jobs:
 
   pass:
     name: Pass
-    needs: [ pre-commit, static-analysis, test-pip, coverage, test-conda, test-ui, build ]
+    needs: [ zizmor, pre-commit, static-analysis, test-pip, coverage, test-conda, test-ui, build ]
     runs-on: ubuntu-latest
     steps:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2

--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -1,5 +1,10 @@
 name: Comment PR
 
+#####
+# This workflow is triggered by pull_request_target event.
+# Never checkout the PR and run ANY local code on it.
+#####
+
 on:
   pull_request_target:
 
@@ -11,13 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Comment PR
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
       - name: Comment PR
-        uses: thollander/actions-comment-pull-request@v3
+        uses: thollander/actions-comment-pull-request@65f9e5c9a1f2cd378bd74b2e057c9736982a8e74 # v3
         with:
           message: |
             Thank you for making this pull request.

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,16 +1,11 @@
 name: Deploy website to GitHub Pages
-
+permissions: {}
 on:
   push:
     branches: [main]
     paths:
       - "website/**"
   workflow_dispatch:
-
-permissions:
-  contents: read
-  pages: write
-  id-token: write
 
 # Allow one concurrent deployment; don't cancel an in-progress one.
 concurrency:
@@ -22,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - name: Build with Astro
-        uses: withastro/action@v6
+        uses: withastro/action@b7d53628f8b666036b0238aadb0b984a2a489f26 # v6
         with:
           path: website
           node-version: 22
@@ -36,6 +31,9 @@ jobs:
 
   deploy:
     needs: build
+    permissions:
+      pages: write
+      id-token: write
     runs-on: ubuntu-latest
     environment:
       name: github-pages
@@ -43,4 +41,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,12 +25,12 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
       - name: Install pixi
-        uses: prefix-dev/setup-pixi@v0.9.6
+        uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           pixi-version: v0.68.0
           cache: true
@@ -40,4 +40,4 @@ jobs:
         run: HATCH_BUILD_HOOKS_ENABLE=true hatch build
 
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1

--- a/.github/workflows/step_build.yml
+++ b/.github/workflows/step_build.yml
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
       - name: Install pixi
-        uses: prefix-dev/setup-pixi@v0.9.6
+        uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           pixi-version: v0.68.0
           cache: true
@@ -40,7 +40,7 @@ jobs:
         run: HATCH_BUILD_HOOKS_ENABLE=true hatch build
 
       - name: Archive build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dist
           path: dist

--- a/.github/workflows/step_coverage.yml
+++ b/.github/workflows/step_coverage.yml
@@ -20,12 +20,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
       - name: Base Setup
-        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@95d85449e4f3f352e261221f6529f8ed307f5728 # v1
         with:
           python_version: 3.x
 
@@ -39,7 +39,7 @@ jobs:
         run: pytest tests/${{ matrix.coverage }} -n logical --cov --cov-report=xml
 
       - name: Upload the coverage
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           flags: ${{ matrix.coverage }}
           fail_ci_if_error: true

--- a/.github/workflows/step_pre-commit.yml
+++ b/.github/workflows/step_pre-commit.yml
@@ -4,24 +4,7 @@ run-name: Run pre-commit tests
 on:
   workflow_call:
 
-permissions:
-  contents: read
-
 jobs:
-  zizmor:
-    runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      with:
-        persist-credentials: false
-
-    - name: Run zizmor 🌈
-      uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
-
   pre-commit:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/step_pre-commit.yml
+++ b/.github/workflows/step_pre-commit.yml
@@ -8,38 +8,52 @@ permissions:
   contents: read
 
 jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
+
+    - name: Run zizmor 🌈
+      uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+
   pre-commit:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.x"
 
       - name: Install pixi
-        uses: prefix-dev/setup-pixi@v0.9.6
+        uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           pixi-version: v0.68.0
           cache: true
           activate-environment: true
 
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
   lint-extension:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
       - name: Base Setup
-        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@95d85449e4f3f352e261221f6529f8ed307f5728 # v1
         with:
           python_version: "3.x"
 

--- a/.github/workflows/step_static-analysis.yml
+++ b/.github/workflows/step_static-analysis.yml
@@ -14,14 +14,14 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           languages: python, javascript
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4

--- a/.github/workflows/step_tests-conda.yml
+++ b/.github/workflows/step_tests-conda.yml
@@ -30,12 +30,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
       - name: Install pixi
-        uses: prefix-dev/setup-pixi@v0.9.6
+        uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           pixi-version: v0.68.0
           cache: true
@@ -77,7 +77,7 @@ jobs:
           python -m jupyterlab.browser_check
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           fail_ci_if_error: true
           verbose: true

--- a/.github/workflows/step_tests-pip.yml
+++ b/.github/workflows/step_tests-pip.yml
@@ -45,12 +45,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
       - name: Base Setup
-        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@95d85449e4f3f352e261221f6529f8ed307f5728 # v1
         with:
           python_version: ${{ matrix.python-version }}
           dependency_type: ${{ matrix.dependency_type }}
@@ -108,7 +108,7 @@ jobs:
           python -m jupyterlab.browser_check
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           fail_ci_if_error: true
           verbose: true

--- a/.github/workflows/step_tests-ui.yml
+++ b/.github/workflows/step_tests-ui.yml
@@ -14,12 +14,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
       - name: Install pixi
-        uses: prefix-dev/setup-pixi@v0.9.6
+        uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           pixi-version: v0.68.0
           cache: true
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload UI Test artifacts
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ui-test-output
           path: |

--- a/.github/workflows/step_zizmor.yml
+++ b/.github/workflows/step_zizmor.yml
@@ -1,0 +1,20 @@
+name: zizmor
+run-name: Run zizmor
+
+on:
+  workflow_call:
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
+
+    - name: Run zizmor 🌈
+      uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6

--- a/.github/workflows/update-playwright-snapshots.yml
+++ b/.github/workflows/update-playwright-snapshots.yml
@@ -24,7 +24,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
@@ -43,7 +43,7 @@ jobs:
           pip uninstall jupyter-fs -y
 
       - name: Update snapshots
-        uses: jupyterlab/maintainer-tools/.github/actions/update-snapshots@v1
+        uses: jupyterlab/maintainer-tools/.github/actions/update-snapshots@95d85449e4f3f352e261221f6529f8ed307f5728 # v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Test folder within your repository

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,6 @@
+rules:
+  dangerous-triggers:
+    ignore:
+      # Needed to comment on PRs from forks. Known risk, but no external code is executed here that
+      # isn't pinned.
+      - comment-pr.yml:8


### PR DESCRIPTION
Hi all,

I've been working on hardening github actions for a number of the jupyter projects. This PR continues that effort with changes that

- Set the default permissions as conservatively as possible
- Pin all the currently-used github actions to commit hashes
- Add a new job to the "step_pre-commit" workflow that runs the zizmor action (so that these types of vulnerabilities can't get into the code base in the future)

Additionally, while the docs for https://github.com/thollander/actions-comment-pull-request suggest that you need to call `actions/checkout` before calling `thollander/actions-comment-pull-request`, I don't see any reason why that would be necessary, and generally we want to avoid checking out code on anything triggered by `pull_request_target`. So I've removed it from the `comment-pr` workflow here, but I'm going to test out whether this works on my own fork before marking this as ready for review.

I also added a comment block that I pulled from https://github.com/jupyterlab/jupyterlab/blob/main/.github/workflows/labeler.yml#L4 to warn other contributors about the dangers of `pull_request_target`.