### PR TITLE
avoid quadratic backtracking in help/bash magic regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Jupytext ChangeLog
 **Changed**
 - Harden the github action ([#1569](https://github.com/jupytext/jupytext/pull/1569)). Thanks to [Peyton Murray](https://github.com/peytondmurray) for this PR!
 
+**Fixed**
+- Detecting IPython help/shell commands no longer takes quadratic time on lines made of whitespace ([#1582](https://github.com/jupytext/jupytext/pull/1582))
+
 1.19.4 (2026-06-21)
 -------------------
 

--- a/src/jupytext/magics.py
+++ b/src/jupytext/magics.py
@@ -44,7 +44,10 @@ _MAGIC_FORCE_ESC_RE["csharp"] = re.compile(r"^(// |//)*#![a-zA-Z](.*)//\s*noesca
 _MAGIC_RE["go"] = re.compile(r"^(// |//)*(!|!\*|%|%%|%%%)[a-zA-Z]")
 
 # Commands starting with a question or exclamation mark have to be escaped
-_PYTHON_HELP_OR_BASH_CMD = re.compile(r"^\s*(# |#)*\s*(\?|!)\s*[A-Za-z\.\~\$\\\/\{\}]")
+# The comment prefixes are grouped with the trailing whitespace so that a
+# whitespace-only line does not trigger quadratic backtracking (two \s* runs
+# around a nullable group)
+_PYTHON_HELP_OR_BASH_CMD = re.compile(r"^\s*(?:(?:# |#)+\s*)?(\?|!)\s*[A-Za-z\.\~\$\\\/\{\}]")
 
 # A bash command not followed by an equal sign or a parenthesis is a magic command
 _PYTHON_MAGIC_CMD = re.compile(

--- a/tests/unit/test_escape_magics.py
+++ b/tests/unit/test_escape_magics.py
@@ -215,6 +215,17 @@ def test_question_is_not_magic():
     assert not is_magic("# question: float?", "python", explicitly_code=True)
 
 
+def test_whitespace_line_is_not_magic_and_is_fast():
+    # A whitespace-only line is not a magic, and detecting that must not take
+    # quadratic time (see the _PYTHON_HELP_OR_BASH_CMD regex)
+    import time
+
+    line = " \t" * 100_000
+    start = time.perf_counter()
+    assert not is_magic(line, "python")
+    assert time.perf_counter() - start < 2
+
+
 def test_multiline_python_magic(no_jupytext_version_number):
     nb = new_notebook(
         cells=[


### PR DESCRIPTION
Timing `is_magic()` on a notebook whose only unusual feature is one long whitespace line (a `.py` cell of spaces and tabs):

    whitespace line len    8000   0.37s
    whitespace line len   16000   1.32s
    whitespace line len   32000   5.3s

`_PYTHON_HELP_OR_BASH_CMD` is `^\s*(# |#)*\s*(\?|!)...`: two `\s*` runs around a nullable group, so a whitespace-only line backtracks in O(n^2). It runs per line inside `is_magic`, which `jupytext.reads` and the contents manager call while reading `.py`/`.md` text, so a crafted file turns conversion into quadratic work (a ~160k-char line takes ~130s).

Rewrote it to `^\s*(?:(?:# |#)+\s*)?(\?|!)...`, which accepts exactly the same lines but scans linearly (that 160k line now takes ~0.06s). I checked equivalence by brute-forcing every string up to length 6 over the `# \t?!a` alphabet and 500k random strings over the full character class. Existing magic tests are unchanged and I added a regression test.