### PR TITLE
Fix unguarded access to `languageInfo.extensions` array

### DIFF
--- a/jupyterlab/packages/jupyterlab-jupytext-extension/src/utils.ts
+++ b/jupyterlab/packages/jupyterlab-jupytext-extension/src/utils.ts
@@ -127,7 +127,9 @@ export async function getAvailableKernelLanguages(
         // languageInfo.extensions is the most common one.
         if (languageInfo) {
           const fileExt = languageInfo.extensions[0];
-          const fileType = docRegistry.getFileTypesForPath(`test.${fileExt}`)[0];
+          const fileType = docRegistry.getFileTypesForPath(
+            `test.${fileExt}`,
+          )[0];
           // We attempt to get kernelIcon here for specModel.resources
           // If none provided, we return generic kernel icon
           const kernelIcon = await getKernelIcon(specModel, fileType);

--- a/jupyterlab/packages/jupyterlab-jupytext-extension/src/utils.ts
+++ b/jupyterlab/packages/jupyterlab-jupytext-extension/src/utils.ts
@@ -125,9 +125,9 @@ export async function getAvailableKernelLanguages(
         // If we managed to find the language, construct the FileTypeData
         // Here we make an assumption that first extension in
         // languageInfo.extensions is the most common one.
-        const fileExt = languageInfo.extensions[0];
-        const fileType = docRegistry.getFileTypesForPath(`test.${fileExt}`)[0];
         if (languageInfo) {
+          const fileExt = languageInfo.extensions[0];
+          const fileType = docRegistry.getFileTypesForPath(`test.${fileExt}`)[0];
           // We attempt to get kernelIcon here for specModel.resources
           // If none provided, we return generic kernel icon
           const kernelIcon = await getKernelIcon(specModel, fileType);

--- a/jupyterlab/packages/jupyterlab-jupytext-extension/src/utils.ts
+++ b/jupyterlab/packages/jupyterlab-jupytext-extension/src/utils.ts
@@ -125,7 +125,7 @@ export async function getAvailableKernelLanguages(
         // If we managed to find the language, construct the FileTypeData
         // Here we make an assumption that first extension in
         // languageInfo.extensions is the most common one.
-        if (languageInfo) {
+        if (languageInfo && languageInfo.extensions) {
           const fileExt = languageInfo.extensions[0];
           const fileType = docRegistry.getFileTypesForPath(
             `test.${fileExt}`,


### PR DESCRIPTION
- Fixes #1583 
- Follow-up to https://github.com/jupytext/jupytext/pull/1482

| Before | After |
|--|--|
| <img width="621" height="489" alt="image" src="https://github.com/user-attachments/assets/1a1fdebb-38b0-4fb6-9563-8b14a18f7aac" /> | <img width="621" height="489" alt="image" src="https://github.com/user-attachments/assets/c20f047b-8c49-49a0-b1aa-1f478f853869" /> |
