### PR TITLE
reject paired paths that escape the notebook directory tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Jupytext ChangeLog
 **Security**
 - `marimo_py_to_notebook` now reuses its secure (0600, `mkstemp`-backed) temporary files instead of closing and reopening them by name, which removed the safe permissions and left a window for a symlink attack on shared machines ([#1568](https://github.com/jupytext/jupytext/pull/1568)). Thanks to [Naveed](https://github.com/nvxbug) for reporting and fixing this!
 
+**Security**
+- Paired paths can no longer be written outside the notebook's directory tree. A `formats` entry read from notebook metadata, e.g. `../../../../etc///py` or an absolute path, is now rejected instead of driving a file write above the working tree ([#1588](https://github.com/jupytext/jupytext/pull/1588)).
+
 1.19.4 (2026-06-21)
 -------------------
 

--- a/src/jupytext/paired_paths.py
+++ b/src/jupytext/paired_paths.py
@@ -66,6 +66,37 @@ def separator(path):
     return "/"
 
 
+def _path_reach(path, sep):
+    """Describe how far a resolved path reaches outside its starting directory.
+
+    Return an ``(anchor, climb)`` pair where ``anchor`` is the leading root the path
+    is tied to (empty for a path relative to the current directory, the separator for
+    an absolute path, or a Windows drive) and ``climb`` is the number of leading '..'
+    segments that survive after resolving '.' and normal segments, i.e. how many
+    levels the path escapes above that anchor.
+    """
+    if path.startswith(sep):
+        anchor = sep
+    elif len(path) >= 2 and path[1] == ":":
+        anchor = path[:2]
+    else:
+        anchor = ""
+
+    climb = 0
+    depth = 0
+    for part in path.split(sep):
+        if part in ("", "."):
+            continue
+        if part == "..":
+            if depth > 0:
+                depth -= 1
+            else:
+                climb += 1
+        else:
+            depth += 1
+    return anchor, climb
+
+
 def get_prefix_root_prefix_dir_prefix_file_name(prefix: str) -> tuple[str, str, str]:
     if "//" in prefix:
         prefix_root, prefix = prefix.rsplit("//", 1)
@@ -328,5 +359,20 @@ def paired_paths(main_path, fmt, formats):
 
     if len(paths) > len(set(paths)):
         raise InconsistentPath("Duplicate paired paths for this notebook. Please fix jupytext.formats.")
+
+    # A paired file must stay within the notebook's own directory tree. Reject any
+    # format whose prefix (e.g. '../../../' or an absolute path) makes a paired path
+    # reach further up, or to a different root, than the notebook itself - otherwise
+    # untrusted 'formats' metadata could drive writes outside the working tree.
+    sep = separator(main_path)
+    main_anchor, main_climb = _path_reach(main_path, sep)
+    for alt_path in paths:
+        anchor, climb = _path_reach(alt_path, sep)
+        if anchor != main_anchor or climb > main_climb:
+            raise InconsistentPath(
+                f"Paired path '{alt_path}' escapes the directory of the notebook '{main_path}'. "
+                "A prefix like '../' or an absolute path in 'formats' must stay within the "
+                "notebook's directory tree."
+            )
 
     return list(zip(paths, formats))

--- a/tests/unit/test_paired_paths.py
+++ b/tests/unit/test_paired_paths.py
@@ -47,6 +47,19 @@ def test_full_path_dotdot():
     assert full_path("scripts/test", fmt=fmt) == "scripts/test.py"
 
 
+@pytest.mark.parametrize(
+    "formats",
+    [
+        "notebooks///ipynb,../../../../../../tmp/escape///py:light",
+        "notebooks///ipynb,/tmp/escape///py:light",
+    ],
+)
+def test_paired_path_cannot_escape_notebook_tree(formats):
+    nb_file = "notebooks/nb.ipynb"
+    with pytest.raises(InconsistentPath, match="escapes the directory"):
+        paired_paths(nb_file, "notebooks///ipynb", formats)
+
+
 def test_base_path_in_tree_from_root():
     fmt = long_form_one_format("scripts///py")
     assert base_path("scripts/subfolder/test.py", fmt=fmt) == "//subfolder/test"


### PR DESCRIPTION
paired_paths builds each paired file target from the formats spec, and that spec is read straight from a notebook's own metadata. full_path expands a prefix like ../../../ or an absolute path with no containment, so running jupytext --sync over a crafted .ipynb writes a paired script outside the working tree (both ../../../../tmp/x/nb.py and /tmp/x/nb.py land on disk). This is easy to reach from a pre-commit hook or CI job that syncs checked-out or downloaded notebooks.

Reject any paired path whose root anchor differs from, or that climbs higher than, the notebook path itself, right where paired_paths already validates the format set. Sibling pairing such as ../scripts//py still works because the .. is consumed by a real parent directory and the result stays in the tree; only paths that genuinely escape are refused.