### PR TITLE
Require zizmor and precommit on ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,28 +36,30 @@ jobs:
     uses: ./.github/workflows/step_pre-commit.yml
 
   static-analysis:
+    needs: [ zizmor, pre-commit ]
     uses: ./.github/workflows/step_static-analysis.yml
     permissions:
       contents: read
       security-events: write
 
   coverage:
+    needs: [ zizmor, pre-commit ]
     uses: ./.github/workflows/step_coverage.yml
 
   test-pip:
-    needs: [ coverage ]
+    needs: [ zizmor, pre-commit, coverage ]
     uses: ./.github/workflows/step_tests-pip.yml
 
   test-conda:
-    needs: [ coverage ]
+    needs: [ zizmor, pre-commit, coverage ]
     uses: ./.github/workflows/step_tests-conda.yml
 
   test-ui:
-    needs: [ coverage ]
+    needs: [ zizmor, pre-commit, coverage ]
     uses: ./.github/workflows/step_tests-ui.yml
 
   build:
-    needs: [ coverage ]
+    needs: [ zizmor, pre-commit, coverage ]
     uses: ./.github/workflows/step_build.yml
     with:
       upload: ${{ inputs.upload-build-artifacts || false }}

--- a/.github/workflows/step_pre-commit.yml
+++ b/.github/workflows/step_pre-commit.yml
@@ -26,29 +26,3 @@ jobs:
           activate-environment: true
 
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
-
-  lint-extension:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          persist-credentials: false
-
-      - name: Base Setup
-        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@95d85449e4f3f352e261221f6529f8ed307f5728 # v1
-        with:
-          python_version: "3.x"
-
-      # Current repo organization will not permit to set up pre-commit config for
-      # TS lint related packages due to absence of package.json in the top level
-      # repo. So we run lint step separately here
-      - name: Lint the extension
-        run: |
-          # Install JupyterLab in an isolated env to get jlpm
-          pip install jupyterlab>=4
-
-          # Install lint deps and lint extension
-          cd jupyterlab/
-          jlpm
-          jlpm run lint:check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,10 @@
 # Run the hooks on all files with
 # 'pre-commit run --all'
 
+# The 'lint-extension' hook below relies on jlpm/node, which are provided
+# by the pixi environment. Run git commit through pixi so they are on PATH,
+# e.g. 'pixi run git commit'
+
 # NB: In this config we exclude the example and tests notebooks
 # from the code hooks (black, flake8, etc) as we want to keep
 # the text representation of the test notebooks unchanged, plus
@@ -50,3 +54,10 @@ repos:
         language: system
         pass_filenames: false
         files: ^(pyproject\.toml|pixi\.toml|pixi\.lock|src/jupytext/version\.py)$
+
+      - id: lint-extension
+        name: Lint the JupyterLab extension (prettier, eslint, stylelint)
+        entry: bash -c 'cd jupyterlab && jlpm && jlpm run lint'
+        language: system
+        pass_filenames: false
+        files: ^jupyterlab/(packages/.*\.(ts|tsx|js|jsx|css)|package\.json|tsconfig.*\.json)$

--- a/jupyterlab/yarn.lock
+++ b/jupyterlab/yarn.lock
@@ -11915,21 +11915,21 @@ __metadata:
 
 "typescript@patch:typescript@>=3 < 6#~builtin<compat/typescript>":
   version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#~builtin<compat/typescript>::version=5.9.3&hash=5786d5"
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#~builtin<compat/typescript>::version=5.9.3&hash=85af82"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: a5a6dc399d3761ded54192031f11d3ad5df8001c7febe3fbbc8098efcb552cdf8f2f402b3618c56dafcd04fef63dee005f4900f608e185404caedc46480539ed
+  checksum: 8bb8d86819ac86a498eada254cad7fb69c5f74778506c700c2a712daeaff21d3a6f51fd0d534fe16903cb010d1b74f89437a3d02d4d0ff5ca2ba9a4660de8497
   languageName: node
   linkType: hard
 
 "typescript@patch:typescript@~6.0.3#~builtin<compat/typescript>":
   version: 6.0.3
-  resolution: "typescript@patch:typescript@npm%3A6.0.3#~builtin<compat/typescript>::version=6.0.3&hash=5786d5"
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#~builtin<compat/typescript>::version=6.0.3&hash=85af82"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 238430fdcadd2ca8ec7179bc644b324dbe4d13d647efae95351f216c7d9645092c0d848a45bd5a27a3d9058e2466eb8d67f9d944e2a78fa32171eee2e2f8d11e
+  checksum: 8ed159a81ab4901a620c19fda539632cee610f8ec34dde57a3acc6b6df72894ad0b50bdd1946b763313d9b73dedb019d2e81c03eff06c0f2c785cde30a537d15
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Plus, move the extension lint step to the pre-commit hook. Closes https://github.com/jupytext/jupytext/issues/1587