### PR TITLE
fix: preserve trailing whitespace-only line in percent cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Jupytext ChangeLog
 ==================
 
+1.19.6-dev
+----------
+
+**Fixed**
+- Cells in the `percent` format no longer lose a trailing line made of whitespace ([#1599](https://github.com/mwouts/jupytext/issues/1599))
+
 1.19.5 (2026-07-21)
 -------------------
 

--- a/src/jupytext/cell_reader.py
+++ b/src/jupytext/cell_reader.py
@@ -28,6 +28,7 @@ from .pep8 import pep8_lines_between_cells
 from .stringparser import StringParser
 
 _BLANK_LINE = re.compile(r"^\s*$")
+_EMPTY_LINE = re.compile(r"^$")
 _PY_INDENTED = re.compile(r"^\s")
 
 
@@ -809,7 +810,7 @@ class DoublePercentScriptCellReader(LightScriptCellReader):
 
         if last_two_lines_blank(lines[:next_cell]):
             return next_cell - 2, next_cell, False
-        if next_cell > 0 and _BLANK_LINE.match(lines[next_cell - 1]):
+        if next_cell > 0 and _EMPTY_LINE.match(lines[next_cell - 1]):
             return next_cell - 1, next_cell, False
         return next_cell, next_cell, False
 

--- a/tests/functional/simple_notebooks/test_read_simple_percent.py
+++ b/tests/functional/simple_notebooks/test_read_simple_percent.py
@@ -606,3 +606,11 @@ fmt.Printf("Hello World!")
     nb = jupytext.reads(go_percent, fmt="go:percent")
     go = jupytext.writes(nb, fmt="go:percent")
     compare(go, go_percent)
+
+
+def test_trailing_whitespace_only_line_is_preserved():
+    """A trailing line made of spaces belongs to the cell (#1599)"""
+    source = 'print("hello")\n# the following line has 4 white spaces.\n    '
+    nb = jupytext.reads("# %%\n" + source + "\n", fmt="py:percent")
+    assert len(nb.cells) == 1
+    compare(nb.cells[0].source, source)


### PR DESCRIPTION
Closes #1599

`DoublePercentScriptCellReader.find_cell_end` treated any line matching `^\s*$` as the blank separator before the next cell, so a cell whose last line consists only of spaces lost that line when converting `py:percent` back to `.ipynb`. The writer only ever emits a truly empty line as the separator, so this matches `^$` there instead.

Regression test added in `tests/functional/simple_notebooks/test_read_simple_percent.py`; it fails on `main` and passes with the fix. `tests/unit` is baseline-equivalent (14 pre-existing failures before and after, environment-related).
